### PR TITLE
数字キー(1-9, 0)によるコマンドコピー・チートシート選択機能の実装 (#20)

### DIFF
--- a/src/components/molecules/CommandField.tsx
+++ b/src/components/molecules/CommandField.tsx
@@ -2,88 +2,108 @@
 import { useClipboard } from '@/hooks/useClipboard'
 import { Box, Stack, StackProps, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
+import { forwardRef } from 'react'
 
 export type CommandFieldProps = StackProps & {
   description: string
   command: string
+  numberHint?: string
 }
 
-export const CommandField = (props: CommandFieldProps) => {
-  const { description, command, tabIndex, ...remainProps } = props
+export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
+  (props, ref) => {
+    const { description, command, numberHint, tabIndex, ...remainProps } = props
 
-  const theme = useTheme()
+    const theme = useTheme()
 
-  const { copy, hasCopied, error } = useClipboard(command)
+    const { copy, hasCopied, error } = useClipboard(command)
 
-  const colorScheme = () => {
-    const defaultScheme = {
-      color: theme.palette.text.primary,
-      backgroundColor: theme.palette.primary.main,
-      border: 2,
-      borderColor: 'base.pale',
-      '&:hover': {
-        borderColor: 'alert.main',
-      },
-      '&:focus-visible': {
-        outlineStyle: 'outset',
-        outlineColor: 'alert.main',
-        outlineWidth: 2,
-      },
-    }
-    if (error) {
-      return {
-        ...defaultScheme,
-        backgroundColor: theme.palette.alert.main,
+    const colorScheme = () => {
+      const defaultScheme = {
+        color: theme.palette.text.primary,
+        backgroundColor: theme.palette.primary.main,
+        border: 2,
+        borderColor: 'base.pale',
+        '&:hover': {
+          borderColor: 'alert.main',
+        },
+        '&:focus-visible': {
+          outlineStyle: 'outset',
+          outlineColor: 'alert.main',
+          outlineWidth: 2,
+        },
       }
-    } else if (hasCopied) {
-      return {
-        ...defaultScheme,
-        backgroundColor: theme.palette.background.default,
+      if (error) {
+        return {
+          ...defaultScheme,
+          backgroundColor: theme.palette.alert.main,
+        }
+      } else if (hasCopied) {
+        return {
+          ...defaultScheme,
+          backgroundColor: theme.palette.background.default,
+        }
+      } else {
+        return defaultScheme
       }
-    } else {
-      return defaultScheme
     }
-  }
 
-  return (
-    <Stack direction='row' spacing={1} alignItems='baseline' {...remainProps}>
-      <Box
-        maxWidth='100%'
-        width='fit-content'
-        tabIndex={tabIndex ?? 0}
-        padding={0.5}
-        sx={colorScheme()}
-        onClick={copy}
-        onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-          if (event.key === 'Enter') {
-            copy()
-          }
-        }}
-      >
+    return (
+      <Stack direction='row' spacing={1} alignItems='baseline' {...remainProps}>
+        {numberHint && (
+          <Typography
+            variant='caption'
+            color='text.secondary'
+            sx={{
+              minWidth: '16px',
+              textAlign: 'center',
+              fontWeight: 'bold',
+            }}
+          >
+            {numberHint}
+          </Typography>
+        )}
+        <Box
+          ref={ref}
+          maxWidth='100%'
+          width='fit-content'
+          tabIndex={tabIndex ?? 0}
+          padding={0.5}
+          sx={colorScheme()}
+          onClick={copy}
+          onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter') {
+              copy()
+            }
+          }}
+        >
+          <Typography
+            variant='body1'
+            noWrap={true}
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {command}
+          </Typography>
+        </Box>
         <Typography
-          variant='body1'
+          variant='h3'
           noWrap={true}
+          color='text.secondary'
           sx={{
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
           }}
         >
-          {command}
+          {description}
         </Typography>
-      </Box>
-      <Typography
-        variant='h3'
-        noWrap={true}
-        color='text.secondary'
-        sx={{
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {description}
-      </Typography>
-    </Stack>
-  )
-}
+      </Stack>
+    )
+  },
+)
+
+CommandField.displayName = 'CommandField'

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import {
   FormControl,
@@ -17,6 +17,7 @@ import { debug } from '@tauri-apps/plugin-log'
 
 import { Event } from '@/common'
 import { CommandField } from '@/components/molecules/CommandField'
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
 import {
   CheatSheetAPI,
@@ -39,6 +40,10 @@ export const CheatSheet = () => {
 
   const theme = useTheme()
   const { getCheatSheetFilePath } = usePreferencesStore()
+
+  // Refs for keyboard shortcuts
+  const commandFieldRefs = useRef<Array<HTMLDivElement | null>>([])
+  const selectRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     ;(async () => {
@@ -93,6 +98,39 @@ export const CheatSheet = () => {
     setCheatSheet(event.target.value as string)
   }
 
+  // Keyboard shortcuts handler
+  useKeyboardShortcuts({
+    onNumberKey: (index) => {
+      // Trigger click on the corresponding command field (1-9)
+      if (
+        cheatSheetData?.commandlist &&
+        index < cheatSheetData.commandlist.length
+      ) {
+        const targetElement = commandFieldRefs.current[index]
+        if (targetElement) {
+          // Trigger the Enter key event to copy the command
+          const enterEvent = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            bubbles: true,
+            cancelable: true,
+          })
+          targetElement.dispatchEvent(enterEvent)
+        }
+      }
+    },
+    onZeroKey: () => {
+      // Open the select dropdown
+      if (selectRef.current) {
+        const selectElement = selectRef.current.querySelector(
+          'div[role="combobox"]',
+        )
+        if (selectElement) {
+          ;(selectElement as HTMLElement).click()
+        }
+      }
+    },
+  })
+
   return (
     <Stack padding={1}>
       {jsonInputPath == undefined ? (
@@ -109,7 +147,7 @@ export const CheatSheet = () => {
         </Typography>
       ) : (
         <>
-          <FormControl fullWidth>
+          <FormControl fullWidth ref={selectRef}>
             <InputLabel
               id='demo-simple-select-label'
               sx={{
@@ -144,8 +182,12 @@ export const CheatSheet = () => {
             {cheatSheetData?.commandlist.map((item: CommandData, index) => (
               <CommandField
                 key={index}
+                ref={(el) => {
+                  commandFieldRefs.current[index] = el
+                }}
                 description={item.description}
                 command={item.command}
+                numberHint={index < 9 ? (index + 1).toString() : undefined}
               />
             ))}
           </Stack>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,67 @@
+import { RefObject, useEffect } from 'react'
+
+export type KeyboardShortcutHandlers = {
+  onNumberKey?: (index: number) => void
+  onZeroKey?: () => void
+}
+
+export type UseKeyboardShortcutsOptions = {
+  enabled?: boolean
+  targetRef?: RefObject<HTMLElement>
+}
+
+export const useKeyboardShortcuts = (
+  handlers: KeyboardShortcutHandlers,
+  options?: UseKeyboardShortcutsOptions,
+) => {
+  const { enabled = true, targetRef } = options || {}
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // 入力フィールドやテキストエリアではショートカットを無効化
+      const target = event.target as HTMLElement
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return
+      }
+
+      // 修飾キー（Ctrl, Cmd, Alt, Shift）が押されている場合は無効化
+      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+        return
+      }
+
+      const key = event.key
+
+      // 0キーの処理
+      if (key === '0' && handlers.onZeroKey) {
+        event.preventDefault()
+        handlers.onZeroKey()
+        return
+      }
+
+      // 1-9キーの処理
+      const numberKey = parseInt(key, 10)
+      if (
+        numberKey >= 1 &&
+        numberKey <= 9 &&
+        !isNaN(numberKey) &&
+        handlers.onNumberKey
+      ) {
+        event.preventDefault()
+        handlers.onNumberKey(numberKey - 1) // 0-indexed
+      }
+    }
+
+    const element = targetRef?.current || window
+    element.addEventListener('keydown', handleKeyDown as EventListener)
+
+    return () => {
+      element.removeEventListener('keydown', handleKeyDown as EventListener)
+    }
+  }, [enabled, handlers, targetRef])
+}


### PR DESCRIPTION
## 概要
Issue #20 の実装: キーボードの数字キー(1-9, 0)を使用して、より効率的な操作を可能にする機能を追加しました。

## 実装内容

### 新規追加ファイル
- `src/hooks/useKeyboardShortcuts.ts`: キーボードショートカット処理用カスタムフック

### 変更ファイル
- `src/components/organisms/CheatSheet.tsx`: キーボードショートカットの統合
- `src/components/molecules/CommandField.tsx`: 数字キーヒント表示とref対応

## 機能

### 1-9キー: コマンドコピー
- 画面に表示されている最初の9個までのコマンドに対応
- `1`キー → 1番目のコマンドをクリップボードにコピー
- `2`キー → 2番目のコマンドをクリップボードにコピー
- ... (9番目まで)
- 各コマンドの左側に数字ヒント(1-9)を表示

### 0キー: チートシート選択
- `0`キー → チートシート選択リストボックスを開く

## 実装の特徴

### セーフティ機能
- 入力フィールドやテキストエリアにフォーカスがある場合は無効化
- 修飾キー(Ctrl, Cmd, Alt, Shift)が押されている場合は無効化
- 表示されているコマンド数に応じて動的に有効化

### UI/UX
- 数字キーヒント(1-9)を各コマンドの左側に表示
- 既存のキーボードナビゲーション(矢印キー、Enterなど)と競合しない設計

## テスト
- ✅ yarn lint 成功
- ✅ コード品質チェック成功

## 関連Issue
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)