### PR TITLE
Preferences画面のglobal shortcutエラーメッセージ表示位置を改善（issue #46）

### DIFF
--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -12,13 +12,18 @@ import { GlobalShortcutAPI, ShortcutDef } from '@/types/api/GlobalShortcut'
 import { WindowAPI } from '@/types/api/Window'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import { Box, Divider, Stack, Tooltip, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
 import { debug, error } from '@tauri-apps/plugin-log'
 import { relaunch } from '@tauri-apps/plugin-process'
 import { Command } from '@tauri-apps/plugin-shell'
 
 export default function Page() {
+  const theme = useTheme()
+
   const [settedInputFilePath, setSettedInputFilePath] = useState<string>()
+  const [shortcutValidationError, setShortcutValidationError] =
+    useState<boolean>(false)
 
   const { getCheatSheetFilePath, setCheatSheetFilePath } = usePreferencesStore()
   const {
@@ -171,14 +176,21 @@ export default function Page() {
         <FileEditButton onClick={openFileByEditor} size='small' />
       </Stack>
       <Divider />
-      <Stack direction='row' spacing={1}>
-        <Typography variant='body1'>Global Shortcut</Typography>
-        <Tooltip
-          title='Restart the application to reflect the settings.'
-          placement='right'
-        >
-          <ErrorOutlineIcon fontSize='small' sx={{ color: grey[300] }} />
-        </Tooltip>
+      <Stack direction='row' spacing={1} alignItems='center'>
+        <Stack direction='row' spacing={1}>
+          <Typography variant='body1'>Global Shortcut</Typography>
+          <Tooltip
+            title='Restart the application to reflect the settings.'
+            placement='right'
+          >
+            <ErrorOutlineIcon fontSize='small' sx={{ color: grey[300] }} />
+          </Tooltip>
+        </Stack>
+        {shortcutValidationError && (
+          <Typography variant='caption' color={theme.palette.alert.main}>
+            ^ ⌥ ⌘ のいずれか1つはチェックしてください。
+          </Typography>
+        )}
       </Stack>
       <Stack padding={1}>
         {toggleVisibleShortcut && (
@@ -186,6 +198,7 @@ export default function Page() {
             shortcutName='Toggle Visible'
             shortcut={toggleVisibleShortcut}
             callback={shortcutEditCallback}
+            onValidationChange={setShortcutValidationError}
           />
         )}
       </Stack>

--- a/src/components/molecules/ShortcutEditField.tsx
+++ b/src/components/molecules/ShortcutEditField.tsx
@@ -13,7 +13,6 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
 import { useEffect, useState } from 'react'
 
 export type ShortcutEditFieldProps = {
@@ -25,18 +24,22 @@ export type ShortcutEditFieldProps = {
     commandKey: boolean,
     hotKey: string,
   ) => void
+  onValidationChange: (isValid: boolean) => void
 }
 
 export const ShortcutEditField = (props: ShortcutEditFieldProps) => {
-  const { shortcutName, shortcut, callback, ...remainProps } = props
-
-  const theme = useTheme()
+  const {
+    shortcutName,
+    shortcut,
+    callback,
+    onValidationChange,
+    ...remainProps
+  } = props
 
   const [ctrlKey, setCtrlKey] = useState<boolean>(shortcut.ctrl)
   const [optionKey, setOptionKey] = useState<boolean>(shortcut.option)
   const [commandKey, setCommandKey] = useState<boolean>(shortcut.command)
   const [hotKey, setHotKey] = useState<string>(shortcut.hotkey)
-  const [valid, setValid] = useState<boolean>(true)
 
   const [editMode, setEditMode] = useState<boolean>(false)
 
@@ -53,11 +56,11 @@ export const ShortcutEditField = (props: ShortcutEditFieldProps) => {
 
   const onEditClick = () => {
     if (ctrlKey || optionKey || commandKey) {
-      setValid(true)
+      onValidationChange(false)
       callback(ctrlKey, optionKey, commandKey, hotKey)
       setEditMode(false)
     } else {
-      setValid(false)
+      onValidationChange(true)
     }
   }
 
@@ -96,84 +99,77 @@ export const ShortcutEditField = (props: ShortcutEditFieldProps) => {
   }
 
   return (
-    <Stack>
-      <Stack direction='row' alignItems='center' {...remainProps}>
-        <Typography variant='h3'>{shortcutName} : </Typography>
-        <Stack
-          direction='row'
-          height='40px'
-          padding={1}
-          spacing={1}
-          alignItems='center'
-        >
-          {editMode === false ? (
-            <>
-              <Box
-                p={1}
-                sx={{
-                  border: '1px solid',
-                  borderRadius: '8px',
-                  borderColor: grey[300],
-                }}
-              >
-                <Typography variant='body1'>{getShortcutStr()}</Typography>
-              </Box>
-              <SettingsButton onClick={onSettingsClick} size='small' />
-            </>
-          ) : (
-            <>
-              <FormGroup row={true}>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={ctrlKey}
-                      onChange={handleCtrlKeyChange}
-                      sx={{ '&.Mui-checked': { color: 'info.main' } }}
-                    />
-                  }
-                  label='^'
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={optionKey}
-                      onChange={handleOptionKeyChange}
-                      sx={{ '&.Mui-checked': { color: 'info.main' } }}
-                    />
-                  }
-                  label='⌥'
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={commandKey}
-                      onChange={handleCommandKeyChange}
-                      sx={{ '&.Mui-checked': { color: 'info.main' } }}
-                    />
-                  }
-                  label='⌘'
-                />
-              </FormGroup>
-              <Box width='60px'>
-                <TextField
-                  size='small'
-                  color='info'
-                  variant='outlined'
-                  label='hotkey'
-                  value={hotKey}
-                  onKeyDown={handleHotKeyDown}
-                />
-              </Box>
-              <EditButton onClick={onEditClick} size='small' />
-            </>
-          )}
-        </Stack>
+    <Stack direction='row' alignItems='center' {...remainProps}>
+      <Typography variant='h3'>{shortcutName} : </Typography>
+      <Stack
+        direction='row'
+        height='40px'
+        padding={1}
+        spacing={1}
+        alignItems='center'
+      >
+        {editMode === false ? (
+          <>
+            <Box
+              p={1}
+              sx={{
+                border: '1px solid',
+                borderRadius: '8px',
+                borderColor: grey[300],
+              }}
+            >
+              <Typography variant='body1'>{getShortcutStr()}</Typography>
+            </Box>
+            <SettingsButton onClick={onSettingsClick} size='small' />
+          </>
+        ) : (
+          <>
+            <FormGroup row={true}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={ctrlKey}
+                    onChange={handleCtrlKeyChange}
+                    sx={{ '&.Mui-checked': { color: 'info.main' } }}
+                  />
+                }
+                label='^'
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={optionKey}
+                    onChange={handleOptionKeyChange}
+                    sx={{ '&.Mui-checked': { color: 'info.main' } }}
+                  />
+                }
+                label='⌥'
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={commandKey}
+                    onChange={handleCommandKeyChange}
+                    sx={{ '&.Mui-checked': { color: 'info.main' } }}
+                  />
+                }
+                label='⌘'
+              />
+            </FormGroup>
+            <Box width='60px'>
+              <TextField
+                size='small'
+                color='info'
+                variant='outlined'
+                label='hotkey'
+                value={hotKey}
+                onKeyDown={handleHotKeyDown}
+              />
+            </Box>
+            <EditButton onClick={onEditClick} size='small' />
+          </>
+        )}
       </Stack>
-      {editMode == true && valid == false && (
-        <Typography variant='body1' color={theme.palette.alert.main}>
-          ^ ⌥ ⌘ のいずれか1つはチェックしてください。
-        </Typography>
-      )}
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary
- Preferences画面のglobal shortcut変更時に表示されるエラーメッセージを、「Global Shortcut」セクションヘッダーの右側に表示するように改善しました
- これにより、エラーメッセージ表示時にウィンドウの高さが不足してスクロールバーが表示される問題を解決

## Changes
1. **ShortcutEditField.tsx**
   - エラーメッセージ表示機能を削除
   - `onValidationChange` コールバックを追加して、エラー状態を親コンポーネントに通知

2. **src/app/preferences/page.tsx**
   - `shortcutValidationError` 状態を管理
   - Global Shortcutセクションヘッダーの右側にエラーメッセージを条件付き表示
   - `useTheme` を追加してエラーメッセージの色設定に対応

## Benefits
- ウィンドウの高さ不足によるスクロールバー表示の問題を解決
- より効率的なレイアウトで、空いているスペースを活用
- ユーザーエクスペリエンスの向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #46 