### PR TITLE
feat: GitHub Actions ワークフロー update-version を実装（issue #41）

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -76,8 +76,8 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: Update version to ${{ env.VERSION }}"
-          title: "chore: Update version to ${{ env.VERSION }}"
+          commit-message: 'chore: Update version to ${{ env.VERSION }}'
+          title: 'chore: Update version to ${{ env.VERSION }}'
           body: |
             ## Summary
             バージョン番号を ${{ env.VERSION }} に更新します。
@@ -89,7 +89,7 @@ jobs:
             - README.md
 
             このPRは自動生成されました。
-          branch: "feature/bump-version-${{ env.VERSION }}"
+          branch: 'feature/bump-version-${{ env.VERSION }}'
           base: develop
           labels: |
             chore


### PR DESCRIPTION
## Summary
バージョン番号を手動で更新するワークフロー設定を実装しました。

## Changes
- `.github/workflows/update-version.yml` を新規作成
- トリガー: `workflow_dispatch` (手動実行)
- 入力パラメータ: `version` (X.Y.Z形式)

## Processing Steps

### 1. リポジトリチェックアウト
- `develop` ブランチをチェックアウト
- Git設定（user.name, user.email）を設定

### 2. バージョンファイルの更新
- `package.json` の version フィールドを更新
- `src-tauri/Cargo.toml` の version フィールドを更新
- `src-tauri/tauri.conf.json` の version フィールドを更新
- `README.md` のダウンロードリンクを更新（prototype-X.X.X、RightCheat_X.X.X）

### 3. Git操作
- フィーチャーブランチ作成：`feature/bump-version-<VERSION>`
- ファイル追加 & コミット：`chore: Update version to <VERSION>`
- ブランチをプッシュ

### 4. プルリクエスト作成
- `develop` ブランチへのマージを対象
- ラベル: `chore`, `release` を付与
- 自動生成されたPRテンプレート使用

## Validation
- バージョン番号形式の妥当性チェック（X.Y.Z形式）
- すべてのファイルが正しく更新される確認
- Git操作が成功する確認

## Test Cases
正常なバージョン：1.0.0, 2.1.3, 0.9.0-beta1
無効なバージョン：1.0, v1.0.0, 1.0.0. など

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>