### PR TITLE
fix: sed コマンドを ubuntu-latest 環境に対応（issue #41）

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -38,20 +38,20 @@ jobs:
 
       - name: Update package.json
         run: |
-          sed -i '' "s/\"version\": \".*\"/\"version\": \"${{ env.VERSION }}\"/" package.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"${{ env.VERSION }}\"/" package.json
 
       - name: Update Cargo.toml
         run: |
-          sed -i '' "s/^version = .*/version = \"${{ env.VERSION }}\"/" src-tauri/Cargo.toml
+          sed -i "s/^version = .*/version = \"${{ env.VERSION }}\"/" src-tauri/Cargo.toml
 
       - name: Update tauri.conf.json
         run: |
-          sed -i '' "s/\"version\": \".*\"/\"version\": \"${{ env.VERSION }}\"/" src-tauri/tauri.conf.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"${{ env.VERSION }}\"/" src-tauri/tauri.conf.json
 
       - name: Update README.md
         run: |
-          sed -i '' -E 's/prototype-[0-9]+\.[0-9]+\.[0-9]+/prototype-${{ env.VERSION }}/g' README.md
-          sed -i '' -E 's/RightCheat_[0-9]+\.[0-9]+\.[0-9]+/RightCheat_${{ env.VERSION }}/g' README.md
+          sed -i -E 's/prototype-[0-9]+\.[0-9]+\.[0-9]+/prototype-${{ env.VERSION }}/g' README.md
+          sed -i -E 's/RightCheat_[0-9]+\.[0-9]+\.[0-9]+/RightCheat_${{ env.VERSION }}/g' README.md
 
       - name: Create feature branch
         run: |


### PR DESCRIPTION
## Summary
GitHub Actions の update-version ワークフローが ubuntu-latest 環境で実行できるように sed コマンドを修正しました。

## Changes
macOS の sed 形式 (`sed -i ''`) を Linux の sed 形式 (`sed -i`) に変更しました。

### Modified Commands
- **Update package.json**: `sed -i '' "..."` → `sed -i "..."`
- **Update Cargo.toml**: `sed -i '' "..."` → `sed -i "..."`
- **Update tauri.conf.json**: `sed -i '' "..."` → `sed -i "..."`
- **Update README.md**: `sed -i '' -E '...'` → `sed -i -E '...'`

## Impact
これにより、update-version ワークフローが ubuntu-latest で正常に実行され、すべてのバージョンファイルが正しく更新されるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>