### PR TITLE
fix: Update sed commands to be macOS (BSD sed) compatible

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -42,26 +42,26 @@ jobs:
       - name: Update package.json
         run: |
           echo "Before: $(grep '"version"' package.json)"
-          sed -i 's|"version": ".*"|"version": "${{ env.VERSION }}"|' package.json
+          sed -i '' 's|"version": ".*"|"version": "${{ env.VERSION }}"|' package.json
           echo "After: $(grep '"version"' package.json)"
 
       - name: Update Cargo.toml
         run: |
           echo "Before: $(grep '^version' src-tauri/Cargo.toml)"
-          sed -i 's|^version = .*|version = "${{ env.VERSION }}"|' src-tauri/Cargo.toml
+          sed -i '' 's|^version = .*|version = "${{ env.VERSION }}"|' src-tauri/Cargo.toml
           echo "After: $(grep '^version' src-tauri/Cargo.toml)"
 
       - name: Update tauri.conf.json
         run: |
           echo "Before: $(grep 'version' src-tauri/tauri.conf.json)"
-          sed -i 's|"version": ".*"|"version": "${{ env.VERSION }}"|' src-tauri/tauri.conf.json
+          sed -i '' 's|"version": ".*"|"version": "${{ env.VERSION }}"|' src-tauri/tauri.conf.json
           echo "After: $(grep 'version' src-tauri/tauri.conf.json)"
 
       - name: Update README.md
         run: |
           echo "Before: $(grep -E '/[0-9]+\.[0-9]+\.[0-9]+/|RightCheat_[0-9]+\.[0-9]+\.[0-9]+' README.md || true)"
-          sed -i -E 's|/[0-9]+\.[0-9]+\.[0-9]+/|/${{ env.VERSION }}/|g' README.md
-          sed -i -E 's|RightCheat_[0-9]+\.[0-9]+\.[0-9]+|RightCheat_${{ env.VERSION }}|g' README.md
+          sed -i '' -E 's|/[0-9]+\.[0-9]+\.[0-9]+/|/${{ env.VERSION }}/|g' README.md
+          sed -i '' -E 's|RightCheat_[0-9]+\.[0-9]+\.[0-9]+|RightCheat_${{ env.VERSION }}|g' README.md
           echo "After: $(grep -E '/[0-9]+\.[0-9]+\.[0-9]+/|RightCheat_[0-9]+\.[0-9]+\.[0-9]+' README.md || echo 'No matches found')"
 
       - name: Create feature branch


### PR DESCRIPTION
## Problem
GitHub Actions workflow fails on `macos-latest` runner with:
```
Error: Process completed with exit code 1.
sedi: 1: package.json: extra characters at the end of p command
```

## Root Cause
macOS uses BSD sed instead of GNU sed. The syntax differs:
- **Linux (GNU sed)**: `sed -i 's|...|...|'` - backups disabled by default
- **macOS (BSD sed)**: `sed -i ''` - must specify empty string to disable backup

## Solution
Updated all `sed -i` commands to `sed -i ''` format for macOS compatibility.

### Modified Commands
1. **Update package.json** (line 45)
   - `sed -i ''` instead of `sed -i`

2. **Update Cargo.toml** (line 51)
   - `sed -i ''` instead of `sed -i`

3. **Update tauri.conf.json** (line 57)
   - `sed -i ''` instead of `sed -i`

4. **Update README.md** (lines 63-64)
   - `sed -i '' -E` instead of `sed -i -E` (both commands)

## Testing
This fix ensures the workflow will properly execute sed commands on macOS runners without errors.

## Related
- #59: バージョン更新ワークフローの修正
- #60: PR that merged the macOS workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)