### PR TITLE
チートシート選択コンボボックスでフォーカスがない状態でエンターキー時に最初の項目を選択する (#90)

### DIFF
--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -31,6 +31,7 @@ export const CheatSheet = () => {
   const [cheatSheetData, setCheatSheetData] = useState<CheatSheetData>()
 
   const [reloading, setReloading] = useState<boolean>(false)
+  const [autocompleteOpen, setAutocompleteOpen] = useState<boolean>(false)
 
   const theme = useTheme()
   const { getCheatSheetFilePath } = usePreferencesStore()
@@ -90,6 +91,36 @@ export const CheatSheet = () => {
 
   const handleChange = (_event: unknown, value: string | null) => {
     setCheatSheet(value ?? '')
+  }
+
+  const handleAutocompleteKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    // リストが開いている状態でエンターキーが押された場合、最初の項目を選択
+    if (event.key === 'Enter' && autocompleteOpen) {
+      // Material-UIのAutocompleteはリストボックスをポップアップで描画するため、
+      // document全体から探索する
+      const listboxElement = document.querySelector('[role="listbox"]')
+
+      // リストボックスが存在し、その中にフォーカスがない場合、最初の項目を選択
+      if (listboxElement) {
+        const activeElement = document.activeElement
+        const isInListbox = listboxElement.contains(activeElement as Node)
+
+        if (!isInListbox) {
+          // 表示されている最初のリスト項目を取得してクリック
+          const firstOption = listboxElement.querySelector(
+            'li',
+          ) as HTMLLIElement
+          if (firstOption) {
+            event.preventDefault()
+            // リスト項目をクリックして選択
+            firstOption.click()
+            setAutocompleteOpen(false)
+          }
+        }
+      }
+    }
   }
 
   // Keyboard shortcuts handler
@@ -166,11 +197,15 @@ export const CheatSheet = () => {
             options={cheatSheetTitles?.title || []}
             value={selectCheatSheet || undefined}
             onChange={handleChange}
+            open={autocompleteOpen}
+            onOpen={() => setAutocompleteOpen(true)}
+            onClose={() => setAutocompleteOpen(false)}
             renderInput={(params) => (
               <TextField
                 {...params}
                 label='CheatSheet'
                 size='small'
+                onKeyDown={handleAutocompleteKeyDown}
                 sx={{
                   '& .MuiOutlinedInput-root': {
                     '&.Mui-focused .MuiOutlinedInput-notchedOutline': {


### PR DESCRIPTION
## 概要

チートシート選択コンボボックスの UX 改善です。リストが開いている状態で、リスト内の項目にフォーカスが当たっていない場合にエンターキーを押すと、表示されている最初の項目が自動的に選択されるようになりました。

## 変更内容

### 実装内容
- Autocomplete コンポーネントに `open`/`onOpen`/`onClose` パラメータを追加してオープン状態を管理
- `onKeyDown` ハンドラーを実装し、リスト内のフォーカスがない状態でエンターキーが押された場合の処理を追加
- DOM から実際に表示されている最初のリスト項目を取得し、クリックして選択状態にすることで、検索結果に対応した動作を実現

### 動作
1. コンボボックスを開く
2. 検索で特定のチートシートをフィルタリング
3. フィルタリング結果に表示されている最初の項目にフォーカスが当たらない状態でエンターキーを押す
4. フィルタリング結果の最初の項目が選択される

## 関連 Issue

Closes #90

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)