### PR TITLE
ワークフロー: ビルド後のdmgファイルに対してxattr -crを実行するようにする

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -126,6 +126,10 @@ jobs:
           echo "Copying $DMG_SOURCE to $DMG_DEST"
           cp "$DMG_SOURCE" "$DMG_DEST"
 
+          # Remove extended attributes from dmg file
+          echo "Removing extended attributes from dmg file..."
+          xattr -cr "$DMG_DEST"
+
           # Remove old version dmg files (keep only current version)
           echo "Removing old version dmg files..."
           find dist -name "RightCheat_*.dmg" -type f ! -name "RightCheat_${VERSION}_*.dmg" -delete


### PR DESCRIPTION
## 概要

GitHub Actions のワークフロー（update-version.yml）を修正し、ビルド後の dmg ファイルに対して README に記載されている `xattr -cr` コマンドを自動実行するようにしました。

## 変更内容

### 修正対象
- `.github/workflows/update-version.yml` の "Manage dist directory" ステップ

### 修正内容
- dmg ファイルを dist ディレクトリにコピー後、`xattr -cr RightCheat_*.dmg` を自動実行
- これにより、セキュリティ警告なしにマウント可能な dmg ファイルがコミットされるようになります

## 効果

- ユーザーが dmg ファイルを使用する際に、macOS のセキュリティ警告が表示されなくなります
- README に記載されているコマンドを手動実行する必要がなくなります

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)