### PR TITLE
JSONパース失敗時に詳細なエラーメッセージを表示する

### DIFF
--- a/src-tauri/src/api/cheatsheet.rs
+++ b/src-tauri/src/api/cheatsheet.rs
@@ -15,6 +15,12 @@ lazy_static! {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    success: bool,
+    error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CheatSheet {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
@@ -56,7 +62,20 @@ pub fn get_cheat_titles(input_path: &str) -> String {
     // キャッシュが空ならファイルから読み込む
     if cache.is_none() {
         log::debug!("Cache is empty, reading from file: {}", input_path);
-        *cache = read_json_from_file(PathBuf::from(input_path)).ok();
+        match read_json_from_file(PathBuf::from(input_path)) {
+            Ok(data) => *cache = Some(data),
+            Err(e) => {
+                let error_msg = format_json_error(e.as_ref());
+                log::error!("Failed to read JSON file: {}", error_msg);
+                let error_response = ErrorResponse {
+                    success: false,
+                    error: error_msg,
+                };
+                return serde_json::to_string(&error_response).unwrap_or_else(|_| {
+                    r#"{"success":false,"error":"JSONレスポンス生成エラー"}"#.to_string()
+                });
+            }
+        }
     }
 
     let titlelist = cache
@@ -77,7 +96,20 @@ pub fn get_cheat_sheet(input_path: &str, title: &str) -> String {
     // キャッシュが空ならファイルから読み込む
     if cache.is_none() {
         log::debug!("Cache is empty, reading from file: {}", input_path);
-        *cache = read_json_from_file(PathBuf::from(input_path)).ok();
+        match read_json_from_file(PathBuf::from(input_path)) {
+            Ok(data) => *cache = Some(data),
+            Err(e) => {
+                let error_msg = format_json_error(e.as_ref());
+                log::error!("Failed to read JSON file: {}", error_msg);
+                let error_response = ErrorResponse {
+                    success: false,
+                    error: error_msg,
+                };
+                return serde_json::to_string(&error_response).unwrap_or_else(|_| {
+                    r#"{"success":false,"error":"JSONレスポンス生成エラー"}"#.to_string()
+                });
+            }
+        }
     }
 
     let binding = vec![];
@@ -112,4 +144,28 @@ fn read_json_from_file(file_path: PathBuf) -> Result<Vec<CheatSheet>, Box<dyn Er
     let reader = BufReader::new(file);
     let cheatsheet: Vec<CheatSheet> = serde_json::from_reader(reader)?;
     Ok(cheatsheet)
+}
+
+fn format_json_error(error: &dyn std::error::Error) -> String {
+    let error_msg = error.to_string();
+
+    // serde_json エラーはメッセージに行とカラムの情報を含む
+    // 例: "expected value at line 5 column 10"
+    // このメッセージをそのままユーザーに返す
+    if error_msg.contains("line") && error_msg.contains("column") {
+        format!(
+            "JSONファイルのパースに失敗しました。\nエラー: {}",
+            error_msg
+        )
+    } else if error_msg.contains("No such file") || error_msg.contains("not found") {
+        format!(
+            "指定されたJSONファイルが見つかりません。\nエラー: {}",
+            error_msg
+        )
+    } else {
+        format!(
+            "JSONファイルの読み込みに失敗しました。\nエラー: {}",
+            error_msg
+        )
+    }
 }

--- a/src-tauri/tests/api/cheatsheet.rs
+++ b/src-tauri/tests/api/cheatsheet.rs
@@ -9,7 +9,13 @@ mod get_cheat_titles {
         let app = mock_app();
         let _ = reload_cheat_sheet(app.handle().clone());
 
-        assert_eq!(get_cheat_titles("notfound.json"), "{\"title\": []}");
+        let result = get_cheat_titles("notfound.json");
+
+        // エラーレスポンスであることを確認
+        assert!(result.contains("\"success\":false"));
+        assert!(result.contains("\"error\""));
+        // ファイルが見つからないエラーメッセージを確認
+        assert!(result.contains("見つかりません") || result.contains("No such file"));
     }
 
     #[test]
@@ -17,10 +23,16 @@ mod get_cheat_titles {
         let app = mock_app();
         let _ = reload_cheat_sheet(app.handle().clone());
 
-        assert_eq!(
-            get_cheat_titles("./tests/api/invalid.json"),
-            "{\"title\": []}"
-        );
+        let result = get_cheat_titles("./tests/api/invalid.json");
+
+        // エラーレスポンスであることを確認
+        assert!(result.contains("\"success\":false"));
+        assert!(result.contains("\"error\""));
+        // JSONパースエラーメッセージを確認
+        assert!(result.contains("パースに失敗"));
+        // 行番号とカラム情報が含まれることを確認
+        assert!(result.contains("line"));
+        assert!(result.contains("column"));
     }
 
     #[test]
@@ -69,7 +81,13 @@ mod get_cheat_sheet {
         let app = mock_app();
         let _ = reload_cheat_sheet(app.handle().clone());
 
-        assert_eq!(get_cheat_sheet("notfound.json", "dummy"), "{}");
+        let result = get_cheat_sheet("notfound.json", "dummy");
+
+        // エラーレスポンスであることを確認
+        assert!(result.contains("\"success\":false"));
+        assert!(result.contains("\"error\""));
+        // ファイルが見つからないエラーメッセージを確認
+        assert!(result.contains("見つかりません") || result.contains("No such file"));
     }
 
     #[test]
@@ -77,7 +95,16 @@ mod get_cheat_sheet {
         let app = mock_app();
         let _ = reload_cheat_sheet(app.handle().clone());
 
-        assert_eq!(get_cheat_sheet("./tests/api/invalid.json", "invalid"), "{}");
+        let result = get_cheat_sheet("./tests/api/invalid.json", "invalid");
+
+        // エラーレスポンスであることを確認
+        assert!(result.contains("\"success\":false"));
+        assert!(result.contains("\"error\""));
+        // JSONパースエラーメッセージを確認
+        assert!(result.contains("パースに失敗"));
+        // 行番号とカラム情報が含まれることを確認
+        assert!(result.contains("line"));
+        assert!(result.contains("column"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

JSONファイルのパース失敗時に詳細なエラーメッセージを表示する機能を実装しました。ユーザーはエラーの詳細（行番号、カラム情報など）を確認でき、JSON ファイルの問題を素早く特定・修正できます。

## 変更内容

### バックエンド (Rust)
- `ErrorResponse` 構造体を定義してエラーレスポンスを統一
- `get_cheat_titles` と `get_cheat_sheet` で JSON パースエラーをキャッチ
- `format_json_error` 関数を実装してエラー詳細を抽出（行番号・カラム情報）

### フロントエンド (React/TypeScript)
- エラーレスポンスを検出する処理を追加
- `errorMessage` 状態でエラー詳細を管理
- エラーメッセージを改行保持で表示（ユーザーフレンドリー）

### テスト
- JSON パースエラーのテストケースを追加
- ファイル不在エラーのテストケースを追加
- 全 30 テスト成功（`--test-threads=1`）

## 問題解決

**修正前:**
```
正しい内容の入力ファイルが指定されていないようです。
（汎用メッセージのみ。ユーザーが何が問題か分からない）
```

**修正後:**
```
JSONファイルのパースに失敗しました。
エラー: expected value at line 5 column 10
```

ユーザーが JSON エラーの正確な位置を特定でき、迅速に修正できます。

## CI・テスト結果

✅ Frontend Test: SUCCESS
✅ Backend Test: SUCCESS
✅ 全テスト: 30/30 成功

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)