### PR TITLE
package.jsonのname項目のアプリ名もRightCheatに修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "right-cheat",
+  "name": "RightCheat",
   "version": "1.1.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
アクセシビリティ画面で表示されるアプリケーション名の修正のためpackage.jsonでの名前設定も変更する。