### PR TITLE
fix: Command+Tab直後にキーボードショートカットが機能しない問題を修正

### DIFF
--- a/src-tauri/src/common.rs
+++ b/src-tauri/src/common.rs
@@ -8,4 +8,5 @@ pub mod event {
     pub const RELOAD_CHEAT_SHEET: &str = "reload_cheat_sheet";
     pub const THEME_CHANGED: &str = "theme_changed";
     pub const FONT_SIZE_CHANGED: &str = "font_size_changed";
+    pub const WINDOW_FOCUSED: &str = "window_focused";
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use settings_store::{SettingsStore, TauriSettingsStore};
 use tauri::image::Image;
 use tauri::menu::{AboutMetadataBuilder, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::Emitter;
+use tauri::Manager;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tauri_plugin_opener::OpenerExt;
 
@@ -59,6 +60,22 @@ pub fn run() {
             }
             global_shortcut_configuration(app)?;
             api::visible_on_all_workspaces::init_visible_on_all_workspaces_settings(app.handle())?;
+
+            // Command+Tab でアプリがアクティブになった際、WKWebView が
+            // キーボードの first responder を取得できない場合がある。
+            // WindowEvent::Focused(true) を検知してフロントエンドへ通知する。
+            if let Some(main_window) = app.get_webview_window("main") {
+                let main_window_clone = main_window.clone();
+                main_window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::Focused(true) = event {
+                        log::debug!("[lib] Window focused: emitting window_focused event");
+                        main_window_clone
+                            .emit(common::event::WINDOW_FOCUSED, ())
+                            .ok();
+                    }
+                });
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/tests/common.rs
+++ b/src-tauri/tests/common.rs
@@ -1,0 +1,221 @@
+// common.rs のテスト
+//
+// テスト対象: app_lib::common
+//   - config モジュールの定数
+//   - event モジュールの定数
+//
+// ブラックボックス テスト設計:
+//   [同値分割]
+//     有効クラス①: 定数が期待する文字列値と等しい（各定数1ケース）
+//     有効クラス②: 定数同士が互いに異なる（一意性の確認）
+//   [境界値分析]
+//     各定数は固定文字列リテラルであるため入力境界はない。
+//     ただし、以下の観点を検証する:
+//       - 空文字列でないこと（最短境界: len >= 1）
+//       - 値に意図しない余分な空白が含まれていないこと
+//
+// ホワイトボックス テスト設計:
+//   - config モジュールの全定数（SETTING_FILENAME, TOGGLE_VISIBLE_SHORTCUT）を参照するパス
+//   - event モジュールの全定数（WINDOW_VISIABLE_TOGGLE, RELOAD_CHEAT_SHEET,
+//     THEME_CHANGED, FONT_SIZE_CHANGED, WINDOW_FOCUSED）を参照するパス
+//   定数は分岐を持たないため、参照するだけでカバレッジが達成される
+
+#[cfg(test)]
+mod config_constants {
+    use app_lib::common::config;
+
+    // ブラックボックス: 同値分割 - 有効クラス① (SETTING_FILENAME が期待値と等しい)
+    // ホワイトボックス: config::SETTING_FILENAME を参照するパス
+    #[test]
+    fn setting_filename_has_expected_value() {
+        // Arrange: 期待する設定ファイル名
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(config::SETTING_FILENAME, "rightcheat-settings.json");
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス① (TOGGLE_VISIBLE_SHORTCUT が期待値と等しい)
+    // ホワイトボックス: config::TOGGLE_VISIBLE_SHORTCUT を参照するパス
+    #[test]
+    fn toggle_visible_shortcut_has_expected_value() {
+        // Arrange: 期待するショートカット設定キー名
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(
+            config::TOGGLE_VISIBLE_SHORTCUT,
+            "toggle_visibe_shortcut_settings"
+        );
+    }
+
+    // ブラックボックス: 境界値分析 - 各定数が空文字列でないこと（最短境界）
+    // ホワイトボックス: config モジュール全定数を参照するパス
+    #[test]
+    fn config_constants_are_not_empty() {
+        // Assert: いずれの定数も空文字列でないこと
+        assert!(
+            !config::SETTING_FILENAME.is_empty(),
+            "SETTING_FILENAME は空文字列であってはならない"
+        );
+        assert!(
+            !config::TOGGLE_VISIBLE_SHORTCUT.is_empty(),
+            "TOGGLE_VISIBLE_SHORTCUT は空文字列であってはならない"
+        );
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス② (config 定数同士が異なる)
+    #[test]
+    fn config_constants_are_unique() {
+        // Assert: config 内の定数が互いに異なること（誤ったコピペによる重複がないこと）
+        assert_ne!(
+            config::SETTING_FILENAME,
+            config::TOGGLE_VISIBLE_SHORTCUT,
+            "config 定数はそれぞれ一意の値を持つこと"
+        );
+    }
+
+    // ブラックボックス: 境界値分析 - 定数値に余分な空白が含まれていないこと
+    #[test]
+    fn config_constants_have_no_surrounding_whitespace() {
+        // Assert: 各定数が trim() しても変化しないこと（前後に空白がないこと）
+        assert_eq!(
+            config::SETTING_FILENAME,
+            config::SETTING_FILENAME.trim(),
+            "SETTING_FILENAME に前後の空白が含まれていないこと"
+        );
+        assert_eq!(
+            config::TOGGLE_VISIBLE_SHORTCUT,
+            config::TOGGLE_VISIBLE_SHORTCUT.trim(),
+            "TOGGLE_VISIBLE_SHORTCUT に前後の空白が含まれていないこと"
+        );
+    }
+}
+
+#[cfg(test)]
+mod event_constants {
+    use app_lib::common::event;
+
+    // ブラックボックス: 同値分割 - 有効クラス① (WINDOW_VISIABLE_TOGGLE が期待値と等しい)
+    // ホワイトボックス: event::WINDOW_VISIABLE_TOGGLE を参照するパス
+    #[test]
+    fn window_visiable_toggle_has_expected_value() {
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(event::WINDOW_VISIABLE_TOGGLE, "window_visible_toggle");
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス① (RELOAD_CHEAT_SHEET が期待値と等しい)
+    // ホワイトボックス: event::RELOAD_CHEAT_SHEET を参照するパス
+    #[test]
+    fn reload_cheat_sheet_has_expected_value() {
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(event::RELOAD_CHEAT_SHEET, "reload_cheat_sheet");
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス① (THEME_CHANGED が期待値と等しい)
+    // ホワイトボックス: event::THEME_CHANGED を参照するパス
+    #[test]
+    fn theme_changed_has_expected_value() {
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(event::THEME_CHANGED, "theme_changed");
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス① (FONT_SIZE_CHANGED が期待値と等しい)
+    // ホワイトボックス: event::FONT_SIZE_CHANGED を参照するパス
+    #[test]
+    fn font_size_changed_has_expected_value() {
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(event::FONT_SIZE_CHANGED, "font_size_changed");
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス① (WINDOW_FOCUSED が期待値と等しい)
+    // ホワイトボックス: event::WINDOW_FOCUSED を参照するパス
+    // ※ 今回追加された新定数のテスト
+    #[test]
+    fn window_focused_has_expected_value() {
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(event::WINDOW_FOCUSED, "window_focused");
+    }
+
+    // ブラックボックス: 境界値分析 - 各定数が空文字列でないこと（最短境界）
+    // ホワイトボックス: event モジュール全定数を参照するパス
+    #[test]
+    fn event_constants_are_not_empty() {
+        // Assert: いずれの定数も空文字列でないこと
+        assert!(
+            !event::WINDOW_VISIABLE_TOGGLE.is_empty(),
+            "WINDOW_VISIABLE_TOGGLE は空文字列であってはならない"
+        );
+        assert!(
+            !event::RELOAD_CHEAT_SHEET.is_empty(),
+            "RELOAD_CHEAT_SHEET は空文字列であってはならない"
+        );
+        assert!(
+            !event::THEME_CHANGED.is_empty(),
+            "THEME_CHANGED は空文字列であってはならない"
+        );
+        assert!(
+            !event::FONT_SIZE_CHANGED.is_empty(),
+            "FONT_SIZE_CHANGED は空文字列であってはならない"
+        );
+        assert!(
+            !event::WINDOW_FOCUSED.is_empty(),
+            "WINDOW_FOCUSED は空文字列であってはならない"
+        );
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス② (event 定数同士が互いに異なる)
+    // フロントエンドとバックエンドが同じ文字列でイベントを識別するため、
+    // 各定数が一意であることは重大な要件である。
+    #[test]
+    fn event_constants_are_all_unique() {
+        // Arrange: 全定数を配列に集める
+        let constants = [
+            event::WINDOW_VISIABLE_TOGGLE,
+            event::RELOAD_CHEAT_SHEET,
+            event::THEME_CHANGED,
+            event::FONT_SIZE_CHANGED,
+            event::WINDOW_FOCUSED,
+        ];
+
+        // Act: 重複チェック（O(n^2) だが定数数が少ないため許容）
+        for i in 0..constants.len() {
+            for j in (i + 1)..constants.len() {
+                assert_ne!(
+                    constants[i], constants[j],
+                    "event 定数はすべて一意の値を持つこと: index {} と {} が同じ値 \"{}\"",
+                    i, j, constants[i]
+                );
+            }
+        }
+    }
+
+    // ブラックボックス: 境界値分析 - 定数値に余分な空白が含まれていないこと
+    // イベント名に空白が混入していると Tauri のイベントシステムで
+    // リスナーとエミッターが一致しなくなるため検証が必要。
+    #[test]
+    fn event_constants_have_no_surrounding_whitespace() {
+        // Assert: 各定数が trim() しても変化しないこと（前後に空白がないこと）
+        assert_eq!(
+            event::WINDOW_VISIABLE_TOGGLE,
+            event::WINDOW_VISIABLE_TOGGLE.trim(),
+            "WINDOW_VISIABLE_TOGGLE に前後の空白が含まれていないこと"
+        );
+        assert_eq!(
+            event::RELOAD_CHEAT_SHEET,
+            event::RELOAD_CHEAT_SHEET.trim(),
+            "RELOAD_CHEAT_SHEET に前後の空白が含まれていないこと"
+        );
+        assert_eq!(
+            event::THEME_CHANGED,
+            event::THEME_CHANGED.trim(),
+            "THEME_CHANGED に前後の空白が含まれていないこと"
+        );
+        assert_eq!(
+            event::FONT_SIZE_CHANGED,
+            event::FONT_SIZE_CHANGED.trim(),
+            "FONT_SIZE_CHANGED に前後の空白が含まれていないこと"
+        );
+        assert_eq!(
+            event::WINDOW_FOCUSED,
+            event::WINDOW_FOCUSED.trim(),
+            "WINDOW_FOCUSED に前後の空白が含まれていないこと"
+        );
+    }
+}

--- a/src-tauri/tests/lib.rs
+++ b/src-tauri/tests/lib.rs
@@ -1,1 +1,2 @@
 mod api;
+mod common;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,6 +53,9 @@ export default function Home() {
       // イベントを受け取り、WKWebView のフォーカスを復元する。
       unlistenFocused = await listen<{}>(Event.WINDOW_FOCUSED, async () => {
         const focused = document.activeElement as HTMLElement | null
+        // Rust の WindowEvent::Focused(true) 検知後に emit されるため、
+        // native イベントの後処理は完了済み。useWindowSize.ts の
+        // restoreFocusAfterWindowOp() と異なり待機は不要。
         await getCurrentWindow().setFocus()
         if (
           focused &&

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,8 @@ export default function Home() {
   const { showError } = useNotificationContext() ?? {}
 
   useEffect(() => {
-    let unlisten: (() => void) | null = null
+    let unlistenToggle: (() => void) | null = null
+    let unlistenFocused: (() => void) | null = null
 
     const setupListener = async () => {
       // アプリケーション初期化時に設定ファイルから取得した値を使用
@@ -40,18 +41,38 @@ export default function Home() {
         showError?.('全ワークスペース表示設定の初期化に失敗しました')
       }
 
-      unlisten = await listen<{}>(Event.WINDOW_VISIABLE_TOGGLE, () => {
+      unlistenToggle = await listen<{}>(Event.WINDOW_VISIABLE_TOGGLE, () => {
         ;(async () => {
           await changeWindowVisible()
         })()
+      })
+
+      // Command+Tab などでアプリがアクティブになった際、WKWebView が
+      // キーボードの first responder を取得できない場合がある。
+      // Rust 側の WindowEvent::Focused(true) を検知して emit された
+      // イベントを受け取り、WKWebView のフォーカスを復元する。
+      unlistenFocused = await listen<{}>(Event.WINDOW_FOCUSED, async () => {
+        const focused = document.activeElement as HTMLElement | null
+        await getCurrentWindow().setFocus()
+        if (
+          focused &&
+          focused !== document.body &&
+          document.body.contains(focused)
+        ) {
+          focused.blur()
+          focused.focus()
+        }
       })
     }
 
     setupListener()
 
     return () => {
-      if (unlisten) {
-        unlisten()
+      if (unlistenToggle) {
+        unlistenToggle()
+      }
+      if (unlistenFocused) {
+        unlistenFocused()
       }
     }
   }, [getVisibleOnAllWorkspacesSettings, showError])

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,5 @@
 export class Event {
   static readonly WINDOW_VISIABLE_TOGGLE = 'window_visible_toggle'
   static readonly RELOAD_CHEAT_SHEET = 'reload_cheat_sheet'
+  static readonly WINDOW_FOCUSED = 'window_focused'
 }


### PR DESCRIPTION
## Summary

- Rust側で `WindowEvent::Focused(true)` を検知し、フロントエンドへ `window_focused` イベントを emit するハンドラを追加
- フロントエンドで `window_focused` イベントをリッスンし、`setFocus()` + `blur()/focus()` で WKWebView の first responder を復元
- `common.rs` / `common.ts` に `WINDOW_FOCUSED` イベント定数を追加

## Test plan

- [x] `yarn tauri dev` で起動後、Command+Tab でアプリをアクティブにして数字キー・`p`・`0` が動作することを確認
- [x] グローバルショートカット（Ctrl+Cmd+R 等）でウィンドウを表示した後も同様に動作することを確認
- [x] マウスクリック後のキーボード操作が引き続き正常に動作することを確認

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)