### PR TITLE
feat: ショートカットのグループ表示機能を追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "WebFetch(domain:docs.rs)",
       "mcp__inkdrop__search-notes",
       "mcp__inkdrop__read-note",
-      "Bash(yarn fix:prettier:*)"
+      "Bash(yarn fix:prettier:*)",
+      "Bash(git checkout *)"
     ],
     "deny": [],
     "ask": []

--- a/README.md
+++ b/README.md
@@ -134,6 +134,44 @@ RightCheatを完全に削除するには、以下の手順を行います：
 | `shortcut`                | ショートカットキーの一覧表示（グリッド表示、コピー非対応）        |
 | `application`             | クリックまたはEnterキーでコマンドを実行してアプリケーションを起動 |
 
+### ショートカットのグループ表示
+
+`shortcut` タイプのチートシートでは、`commandlist` 内に `group` オブジェクトを追加することで、関連するショートカットをグループ化して表示できます。グループと通常ショートカットは混在可能です。
+
+```json
+[
+  {
+    "title": "vim",
+    "type": "shortcut",
+    "commandlist": [
+      {
+        "description": "保存",
+        "command": ":w"
+      },
+      {
+        "group": "移動",
+        "commandlist": [
+          { "description": "上へ移動", "command": "k" },
+          { "description": "下へ移動", "command": "j" },
+          { "description": "左へ移動", "command": "h" },
+          { "description": "右へ移動", "command": "l" }
+        ]
+      },
+      {
+        "group": "編集",
+        "commandlist": [
+          { "description": "コピー（行）", "command": "yy" },
+          { "description": "ペースト", "command": "p" },
+          { "description": "削除（行）", "command": "dd" }
+        ]
+      }
+    ]
+  }
+]
+```
+
+グループは角丸のボーダーボックスで囲まれ、グループ名がボーダー上部に表示されます。グループのネストはサポートしていません。
+
 ### コマンドの表示レイアウト
 
 `command` / `application` タイプのチートシートでは、`layout` フィールドでコマンドの表示レイアウトを変更できます。

--- a/src-tauri/src/api/cheatsheet.rs
+++ b/src-tauri/src/api/cheatsheet.rs
@@ -70,6 +70,8 @@ impl fmt::Display for CheatSheet {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CommandItem {
+    // Group を Single より先に定義する: untagged enum は上から順にマッチを試みるため、
+    // Single が先だと `group` フィールドを持つオブジェクトが Command としてパースされ失敗する
     Group(CommandGroup),
     Single(Command),
 }

--- a/src-tauri/src/api/cheatsheet.rs
+++ b/src-tauri/src/api/cheatsheet.rs
@@ -53,18 +53,39 @@ pub struct CheatSheet {
     window_size: Option<WindowSize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     layout: Option<String>,
-    commandlist: Vec<Command>,
+    commandlist: Vec<CommandItem>,
 }
 impl fmt::Display for CheatSheet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "title = {}, commandlist = ", self.title)?;
-        for command in self.commandlist.iter() {
+        for item in self.commandlist.iter() {
             write!(f, "(")?;
-            command.fmt(f)?;
+            item.fmt(f)?;
             write!(f, "),")?;
         }
         write!(f, "")
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CommandItem {
+    Group(CommandGroup),
+    Single(Command),
+}
+impl fmt::Display for CommandItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CommandItem::Group(g) => write!(f, "group = {}", g.group),
+            CommandItem::Single(c) => c.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CommandGroup {
+    pub group: String,
+    pub commandlist: Vec<Command>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/tests/api/cheatsheet.rs
+++ b/src-tauri/tests/api/cheatsheet.rs
@@ -68,6 +68,25 @@ mod get_cheat_titles {
             "{\"title\": [\"MultilineCommands\"]}"
         );
     }
+
+    // ブラックボックス：同値分割 - グループを含むチートシートのタイトル一覧取得（有効クラス）
+    // ホワイトボックス：CommandItem::Group と CommandItem::Single が混在する commandlist を持つ
+    //                   CheatSheet が正常にデシリアライズされ、タイトル一覧が返るパス
+    #[test]
+    fn json_with_group_returns_titles() {
+        let app = mock_app();
+        let _ = reload_cheat_sheet(app.handle().clone());
+
+        // Arrange: グループを含むチートシートと含まないチートシートが混在するファイルを指定
+        // Act
+        let result = get_cheat_titles("./tests/api/test-data-with-group.json");
+
+        // Assert: 2つのタイトルが返ること
+        assert_eq!(
+            result,
+            "{\"title\": [\"ShortcutWithGroup\",\"ShortcutWithoutGroup\"]}"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -890,6 +909,187 @@ mod get_cheat_sheet {
         assert_eq!(
             result,
             "{\"title\":\"SheetWithoutLayout\",\"commandlist\":[{\"command\":\"command3\"},{\"description\":\"コマンド4\",\"command\":\"command4\"}]}"
+        );
+    }
+
+    // ブラックボックス：同値分割 - グループを含むチートシートの取得（有効クラス①）
+    // ホワイトボックス：CommandItem::Group と CommandItem::Single が混在する commandlist が
+    //                   #[serde(untagged)] により正しくデシリアライズ・シリアライズされるパス
+    #[test]
+    fn json_with_group_contains_group_names() {
+        let app = mock_app();
+        let _ = reload_cheat_sheet(app.handle().clone());
+
+        // Arrange: Single 1つ + Group 2つが混在するチートシートを指定
+        // Act
+        let result = get_cheat_sheet("./tests/api/test-data-with-group.json", "ShortcutWithGroup");
+
+        // Assert: シリアライズされた JSON に "group":"移動" と "group":"編集" が含まれること
+        assert!(
+            result.contains("\"group\":\"移動\""),
+            "グループ名「移動」がシリアライズ結果に含まれること: {}",
+            result
+        );
+        assert!(
+            result.contains("\"group\":\"編集\""),
+            "グループ名「編集」がシリアライズ結果に含まれること: {}",
+            result
+        );
+    }
+
+    // ブラックボックス：同値分割 - グループを含むチートシートの構造検証（有効クラス①詳細）
+    // ホワイトボックス：#[serde(untagged)] による CommandItem::Group/Single の分岐、
+    //                   各グループ内の Vec<Command> が正しくシリアライズされるパス
+    #[test]
+    fn json_with_group_structure_is_correct() {
+        let app = mock_app();
+        let _ = reload_cheat_sheet(app.handle().clone());
+
+        // Arrange: Single 1つ + Group 2つが混在するチートシートを指定
+        // Act
+        let result = get_cheat_sheet("./tests/api/test-data-with-group.json", "ShortcutWithGroup");
+
+        // Assert: serde_json::Value でパースして構造を検証
+        let parsed: serde_json::Value = serde_json::from_str(&result).expect("JSON パースに失敗");
+
+        let commandlist = parsed["commandlist"]
+            .as_array()
+            .expect("commandlist が配列であること");
+
+        // commandlist の要素数が3であること（Single 1つ + Group 2つ）
+        assert_eq!(
+            commandlist.len(),
+            3,
+            "commandlist の要素数が3であること（Single 1つ + Group 2つ）: {:?}",
+            commandlist
+        );
+
+        // 0番目の要素は command: "x" の Single コマンドであること
+        // ブラックボックス：境界値分析 - 最初の要素（Single）
+        let item0 = &commandlist[0];
+        assert_eq!(
+            item0["command"], "x",
+            "0番目の要素は command: \"x\" の Single コマンドであること: {:?}",
+            item0
+        );
+        assert!(
+            item0.get("group").is_none(),
+            "0番目の要素は Group ではなく Single であること（group フィールドなし）: {:?}",
+            item0
+        );
+
+        // 1番目の要素は group: "移動" で commandlist に "k" と "j" を持つ Group であること
+        // ブラックボックス：同値分割 - Group 要素（2コマンド含む）
+        let item1 = &commandlist[1];
+        assert_eq!(
+            item1["group"], "移動",
+            "1番目の要素の group が「移動」であること: {:?}",
+            item1
+        );
+        let group1_commands = item1["commandlist"]
+            .as_array()
+            .expect("1番目の要素の commandlist が配列であること");
+        assert_eq!(
+            group1_commands.len(),
+            2,
+            "「移動」グループのコマンド数が2であること: {:?}",
+            group1_commands
+        );
+        assert!(
+            group1_commands.iter().any(|c| c["command"] == "k"),
+            "「移動」グループに command: \"k\" が含まれること: {:?}",
+            group1_commands
+        );
+        assert!(
+            group1_commands.iter().any(|c| c["command"] == "j"),
+            "「移動」グループに command: \"j\" が含まれること: {:?}",
+            group1_commands
+        );
+
+        // 2番目の要素は group: "編集" で commandlist に "y", "p", "d" を持つ Group であること
+        // ブラックボックス：同値分割 - Group 要素（3コマンド含む）
+        let item2 = &commandlist[2];
+        assert_eq!(
+            item2["group"], "編集",
+            "2番目の要素の group が「編集」であること: {:?}",
+            item2
+        );
+        let group2_commands = item2["commandlist"]
+            .as_array()
+            .expect("2番目の要素の commandlist が配列であること");
+        assert_eq!(
+            group2_commands.len(),
+            3,
+            "「編集」グループのコマンド数が3であること: {:?}",
+            group2_commands
+        );
+        assert!(
+            group2_commands.iter().any(|c| c["command"] == "y"),
+            "「編集」グループに command: \"y\" が含まれること: {:?}",
+            group2_commands
+        );
+        assert!(
+            group2_commands.iter().any(|c| c["command"] == "p"),
+            "「編集」グループに command: \"p\" が含まれること: {:?}",
+            group2_commands
+        );
+        assert!(
+            group2_commands.iter().any(|c| c["command"] == "d"),
+            "「編集」グループに command: \"d\" が含まれること: {:?}",
+            group2_commands
+        );
+    }
+
+    // ブラックボックス：同値分割 - グループなしのチートシートの取得（後方互換性）（有効クラス②）
+    // ホワイトボックス：commandlist の全要素が CommandItem::Single にデシリアライズされるパス
+    //                   （CommandItem::Group のブランチを通らず、全て Single として処理されること）
+    #[test]
+    fn json_without_group_is_parsed_correctly() {
+        let app = mock_app();
+        let _ = reload_cheat_sheet(app.handle().clone());
+
+        // Arrange: グループを含まない（全て Single コマンド）チートシートを指定
+        // Act
+        let result = get_cheat_sheet(
+            "./tests/api/test-data-with-group.json",
+            "ShortcutWithoutGroup",
+        );
+
+        // Assert: serde_json::Value でパースして構造を検証
+        let parsed: serde_json::Value = serde_json::from_str(&result).expect("JSON パースに失敗");
+
+        // commandlist の要素数が2であること
+        let commandlist = parsed["commandlist"]
+            .as_array()
+            .expect("commandlist が配列であること");
+        assert_eq!(
+            commandlist.len(),
+            2,
+            "グループなしの commandlist の要素数が2であること: {:?}",
+            commandlist
+        );
+
+        // 全要素が Group ではなく Single であること（group フィールドが存在しない）
+        for (i, item) in commandlist.iter().enumerate() {
+            assert!(
+                item.get("group").is_none(),
+                "{}番目の要素は Group ではなく Single であること（group フィールドなし）: {:?}",
+                i,
+                item
+            );
+        }
+
+        // 各コマンドの値が正しいこと
+        // ブラックボックス：境界値分析 - 境界要素（先頭・末尾）の確認
+        assert!(
+            commandlist.iter().any(|c| c["command"] == ":w"),
+            "command: \":w\" が含まれること: {:?}",
+            commandlist
+        );
+        assert!(
+            commandlist.iter().any(|c| c["command"] == ":q"),
+            "command: \":q\" が含まれること: {:?}",
+            commandlist
         );
     }
 }

--- a/src-tauri/tests/api/test-data-with-group.json
+++ b/src-tauri/tests/api/test-data-with-group.json
@@ -1,0 +1,35 @@
+[
+  {
+    "type": "shortcut",
+    "title": "ShortcutWithGroup",
+    "commandlist": [
+      {
+        "description": "通常ショートカット",
+        "command": "x"
+      },
+      {
+        "group": "移動",
+        "commandlist": [
+          { "description": "上へ移動", "command": "k" },
+          { "description": "下へ移動", "command": "j" }
+        ]
+      },
+      {
+        "group": "編集",
+        "commandlist": [
+          { "description": "コピー", "command": "y" },
+          { "description": "ペースト", "command": "p" },
+          { "description": "削除", "command": "d" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "shortcut",
+    "title": "ShortcutWithoutGroup",
+    "commandlist": [
+      { "description": "保存", "command": ":w" },
+      { "description": "終了", "command": ":q" }
+    ]
+  }
+]

--- a/src/components/molecules/ShortcutGroup.tsx
+++ b/src/components/molecules/ShortcutGroup.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { Box, Grid, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { ShortcutField } from '@/components/molecules/ShortcutField'
+import { CommandData } from '@/types/api/CheatSheet'
+
+type ShortcutGroupProps = {
+  group: string
+  commandlist: CommandData[]
+}
+
+export const ShortcutGroup = ({ group, commandlist }: ShortcutGroupProps) => {
+  const theme = useTheme()
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        border: 1,
+        borderColor: theme.palette.divider,
+        borderRadius: 1,
+        pt: 2,
+        pb: 1,
+        px: 1,
+        mt: 1,
+      }}
+    >
+      <Typography
+        variant='caption'
+        sx={{
+          position: 'absolute',
+          top: -10,
+          left: 8,
+          px: 0.5,
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.secondary,
+          lineHeight: 1,
+        }}
+      >
+        {group}
+      </Typography>
+      <Grid container spacing={1}>
+        {commandlist.map((item, index) => (
+          <Grid key={index} size={{ xs: 6, sm: 4, md: 3, lg: 2 }}>
+            <ShortcutField
+              m={0.5}
+              description={item.description ?? ''}
+              command={item.command}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  )
+}

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -29,7 +29,6 @@ import {
   CheatSheetAPI,
   CheatSheetData,
   CheatSheetTitleData,
-  CommandData,
   CommandListItem,
   isCommandGroupData,
 } from '@/types/api/CheatSheet'
@@ -311,21 +310,30 @@ export const CheatSheet = () => {
             </Grid>
           ) : (
             <Stack paddingY={1} spacing={1} width='100%'>
-              {cheatSheetData?.commandlist.map((item: CommandData, index) => (
-                <CommandField
-                  key={index}
-                  ref={(el) => {
-                    commandFieldRefs.current[index] = el
-                  }}
-                  description={item.description}
-                  command={item.command}
-                  numberHint={index < 9 ? (index + 1).toString() : undefined}
-                  mode={
-                    cheatSheetData.type === 'application' ? 'execute' : 'copy'
-                  }
-                  layout={item.layout ?? cheatSheetData.layout ?? 'inline'}
-                />
-              ))}
+              {cheatSheetData?.commandlist.map(
+                (item: CommandListItem, index) => {
+                  if (isCommandGroupData(item)) return null
+                  return (
+                    <CommandField
+                      key={index}
+                      ref={(el) => {
+                        commandFieldRefs.current[index] = el
+                      }}
+                      description={item.description}
+                      command={item.command}
+                      numberHint={
+                        index < 9 ? (index + 1).toString() : undefined
+                      }
+                      mode={
+                        cheatSheetData.type === 'application'
+                          ? 'execute'
+                          : 'copy'
+                      }
+                      layout={item.layout ?? cheatSheetData.layout ?? 'inline'}
+                    />
+                  )
+                },
+              )}
             </Stack>
           )}
         </>

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -20,6 +20,7 @@ import { debug } from '@tauri-apps/plugin-log'
 import { Event } from '@/common'
 import { CommandField } from '@/components/molecules/CommandField'
 import { ShortcutField } from '@/components/molecules/ShortcutField'
+import { ShortcutGroup } from '@/components/molecules/ShortcutGroup'
 import { useCheatSheetLoader } from '@/hooks/useCheatSheetLoader'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
@@ -28,7 +29,8 @@ import {
   CheatSheetAPI,
   CheatSheetData,
   CheatSheetTitleData,
-  CommandData,
+  CommandListItem,
+  isCommandGroupData,
 } from '@/types/api/CheatSheet'
 
 export const CheatSheet = () => {
@@ -282,15 +284,29 @@ export const CheatSheet = () => {
           />
           {cheatSheetData?.type === 'shortcut' ? (
             <Grid container spacing={1} p={1} width='100%'>
-              {cheatSheetData?.commandlist.map((item: CommandData, index) => (
-                <Grid key={index} size={{ xs: 6, sm: 4, md: 3, lg: 2 }}>
-                  <ShortcutField
-                    m={0.5}
-                    description={item.description ?? ''}
-                    command={item.command}
-                  />
-                </Grid>
-              ))}
+              {cheatSheetData?.commandlist.map(
+                (item: CommandListItem, index) => {
+                  if (isCommandGroupData(item)) {
+                    return (
+                      <Grid key={index} size={{ xs: 12 }}>
+                        <ShortcutGroup
+                          group={item.group}
+                          commandlist={item.commandlist}
+                        />
+                      </Grid>
+                    )
+                  }
+                  return (
+                    <Grid key={index} size={{ xs: 6, sm: 4, md: 3, lg: 2 }}>
+                      <ShortcutField
+                        m={0.5}
+                        description={item.description ?? ''}
+                        command={item.command}
+                      />
+                    </Grid>
+                  )
+                },
+              )}
             </Grid>
           ) : (
             <Stack paddingY={1} spacing={1} width='100%'>

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -29,6 +29,7 @@ import {
   CheatSheetAPI,
   CheatSheetData,
   CheatSheetTitleData,
+  CommandData,
   CommandListItem,
   isCommandGroupData,
 } from '@/types/api/CheatSheet'

--- a/src/types/api/CheatSheet.ts
+++ b/src/types/api/CheatSheet.ts
@@ -11,15 +11,26 @@ export type CheatSheetTitleData = {
 
 export type CommandLayout = 'inline' | 'stacked' | 'command_only'
 
-export type CheatSheetData = {
-  type?: 'command' | 'shortcut' | 'application'
-  title: string
-  layout?: CommandLayout
-  commandlist: CommandData[]
-}
-
 export type CommandData = {
   description?: string
   command: string
   layout?: CommandLayout
+}
+
+export type CommandGroupData = {
+  group: string
+  commandlist: CommandData[]
+}
+
+export type CommandListItem = CommandData | CommandGroupData
+
+export const isCommandGroupData = (
+  item: CommandListItem,
+): item is CommandGroupData => 'group' in item
+
+export type CheatSheetData = {
+  type?: 'command' | 'shortcut' | 'application'
+  title: string
+  layout?: CommandLayout
+  commandlist: CommandListItem[]
 }


### PR DESCRIPTION
## Summary

- `commandlist` 内に `group` オブジェクトを定義できるようにし、関連するショートカットをグループ化して表示できる機能を追加
- グループは角丸ボーダーのボックスで囲まれ、グループ名は上ボーダーライン上に表示される
- グループとグループ外のショートカットの混在が可能

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src-tauri/src/api/cheatsheet.rs` | `CommandItem` enum・`CommandGroup` 構造体を追加、`CheatSheet.commandlist` の型変更 |
| `src/types/api/CheatSheet.ts` | `CommandGroupData` 型・`isCommandGroupData` 型ガード追加、`CommandListItem` 型追加 |
| `src/components/molecules/ShortcutGroup.tsx` | 新規作成（グループ表示コンポーネント） |
| `src/components/organisms/CheatSheet.tsx` | ショートカット描画ロジックをグループ対応に更新 |
| `src-tauri/tests/api/test-data-with-group.json` | 新規作成（テストデータ） |
| `src-tauri/tests/api/cheatsheet.rs` | グループ対応テスト追加（4件） |

## Test plan

- [x] `cargo test --verbose -- --test-threads=1` 全テストパス（92件）
- [x] `yarn lint` エラーなし
- [x] グループを含むJSONでショートカット表示を確認
- [x] グループなしのショートカットも引き続き正常に表示されること

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)