### PR TITLE
feat: command/applicationタイプのグループ表示対応とlisten修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,13 @@ RightCheatを完全に削除するには、以下の手順を行います：
 | `shortcut`                | ショートカットキーの一覧表示（グリッド表示、コピー非対応）        |
 | `application`             | クリックまたはEnterキーでコマンドを実行してアプリケーションを起動 |
 
-### ショートカットのグループ表示
+### グループ表示
 
-`shortcut` タイプのチートシートでは、`commandlist` 内に `group` オブジェクトを追加することで、関連するショートカットをグループ化して表示できます。グループと通常ショートカットは混在可能です。
+すべてのタイプ（`command` / `shortcut` / `application`）のチートシートで、`commandlist` 内に `group` オブジェクトを追加することで、関連するコマンドやショートカットをグループ化して表示できます。グループと通常コマンドは混在可能です。
+
+グループは角丸のボーダーボックスで囲まれ、グループ名がボーダー上部に表示されます。グループのネストはサポートしていません。
+
+**`shortcut` タイプの例：**
 
 ```json
 [
@@ -156,21 +160,44 @@ RightCheatを完全に削除するには、以下の手順を行います：
           { "description": "左へ移動", "command": "h" },
           { "description": "右へ移動", "command": "l" }
         ]
-      },
-      {
-        "group": "編集",
-        "commandlist": [
-          { "description": "コピー（行）", "command": "yy" },
-          { "description": "ペースト", "command": "p" },
-          { "description": "削除（行）", "command": "dd" }
-        ]
       }
     ]
   }
 ]
 ```
 
-グループは角丸のボーダーボックスで囲まれ、グループ名がボーダー上部に表示されます。グループのネストはサポートしていません。
+**`command` タイプの例：**
+
+グループ内のコマンドにも数字キー（1〜9）が連続して割り当てられます。
+
+```json
+[
+  {
+    "title": "git",
+    "type": "command",
+    "commandlist": [
+      {
+        "description": "状態確認",
+        "command": "git status"
+      },
+      {
+        "group": "コミット",
+        "commandlist": [
+          { "description": "ステージング", "command": "git add ." },
+          { "description": "コミット", "command": "git commit -m 'message'" }
+        ]
+      },
+      {
+        "group": "リモート",
+        "commandlist": [
+          { "description": "プッシュ", "command": "git push" },
+          { "description": "プル", "command": "git pull" }
+        ]
+      }
+    ]
+  }
+]
+```
 
 ### コマンドの表示レイアウト
 

--- a/src/components/molecules/CommandFieldGroup.tsx
+++ b/src/components/molecules/CommandFieldGroup.tsx
@@ -43,7 +43,7 @@ export const CommandFieldGroup = ({
         variant='caption'
         sx={{
           position: 'absolute',
-          top: -10,
+          top: -6,
           left: 8,
           px: 0.5,
           backgroundColor: theme.palette.background.paper,

--- a/src/components/molecules/CommandFieldGroup.tsx
+++ b/src/components/molecules/CommandFieldGroup.tsx
@@ -1,0 +1,78 @@
+'use client'
+import React from 'react'
+
+import { Box, Stack, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { CommandField } from '@/components/molecules/CommandField'
+import { CommandData, CommandLayout } from '@/types/api/CheatSheet'
+
+type CommandFieldGroupProps = {
+  group: string
+  commandlist: CommandData[]
+  startIndex: number
+  mode: 'copy' | 'execute'
+  cheatSheetLayout?: CommandLayout
+  commandFieldRefs: React.MutableRefObject<Array<HTMLDivElement | null>>
+}
+
+export const CommandFieldGroup = ({
+  group,
+  commandlist,
+  startIndex,
+  mode,
+  cheatSheetLayout,
+  commandFieldRefs,
+}: CommandFieldGroupProps) => {
+  const theme = useTheme()
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        border: 1,
+        borderColor: theme.palette.divider,
+        borderRadius: 1,
+        pt: 2,
+        pb: 1,
+        px: 1,
+        mt: 1,
+      }}
+    >
+      <Typography
+        variant='caption'
+        sx={{
+          position: 'absolute',
+          top: -10,
+          left: 8,
+          px: 0.5,
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.secondary,
+          lineHeight: 1,
+        }}
+      >
+        {group}
+      </Typography>
+      <Stack spacing={1}>
+        {commandlist.map((item, i) => {
+          const flatIndex = startIndex + i
+          return (
+            <CommandField
+              key={i}
+              ref={(el) => {
+                commandFieldRefs.current[flatIndex] = el
+              }}
+              description={item.description}
+              command={item.command}
+              numberHint={
+                flatIndex < 9 ? (flatIndex + 1).toString() : undefined
+              }
+              mode={mode}
+              layout={item.layout ?? cheatSheetLayout ?? 'inline'}
+            />
+          )
+        })}
+      </Stack>
+    </Box>
+  )
+}

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import PushPin from '@mui/icons-material/PushPin'
 import PushPinOutlined from '@mui/icons-material/PushPinOutlined'
@@ -19,6 +19,7 @@ import { debug } from '@tauri-apps/plugin-log'
 
 import { Event } from '@/common'
 import { CommandField } from '@/components/molecules/CommandField'
+import { CommandFieldGroup } from '@/components/molecules/CommandFieldGroup'
 import { ShortcutField } from '@/components/molecules/ShortcutField'
 import { ShortcutGroup } from '@/components/molecules/ShortcutGroup'
 import { useCheatSheetLoader } from '@/hooks/useCheatSheetLoader'
@@ -154,6 +155,27 @@ export const CheatSheet = () => {
   // shortcut タイプ以外（command / application / 未指定）で数字キーショートカットを有効化
   const isKeyboardShortcutEnabled = cheatSheetData?.type !== 'shortcut'
 
+  // グループを展開したフラットなコマンド一覧（数字キーの件数チェックに使用）
+  const flatCommandCount = useMemo(() => {
+    if (!cheatSheetData || cheatSheetData.type === 'shortcut') return 0
+    return cheatSheetData.commandlist.reduce(
+      (acc, item) =>
+        acc + (isCommandGroupData(item) ? item.commandlist.length : 1),
+      0,
+    )
+  }, [cheatSheetData])
+
+  // commandlist の各アイテムに対するフラットインデックスの開始位置
+  const flatStartIndices = useMemo(() => {
+    if (!cheatSheetData) return []
+    let acc = 0
+    return cheatSheetData.commandlist.map((item) => {
+      const start = acc
+      acc += isCommandGroupData(item) ? item.commandlist.length : 1
+      return start
+    })
+  }, [cheatSheetData])
+
   useKeyboardShortcuts({
     onPKey: async () => {
       if (selectCheatSheet) {
@@ -164,11 +186,7 @@ export const CheatSheet = () => {
     onNumberKey: (index) => {
       // 対応するコマンドフィールドをクリック (1-9)
       // shortcut タイプ以外のチートシートで有効
-      if (
-        isKeyboardShortcutEnabled &&
-        cheatSheetData?.commandlist &&
-        index < cheatSheetData.commandlist.length
-      ) {
+      if (isKeyboardShortcutEnabled && index < flatCommandCount) {
         const targetElement = commandFieldRefs.current[index]
         if (targetElement) {
           // Enterキーイベントをトリガーしてコマンドをコピー
@@ -312,23 +330,34 @@ export const CheatSheet = () => {
             <Stack paddingY={1} spacing={1} width='100%'>
               {cheatSheetData?.commandlist.map(
                 (item: CommandListItem, index) => {
-                  if (isCommandGroupData(item)) return null
+                  const flatIndex = flatStartIndices[index]
+                  const mode =
+                    cheatSheetData.type === 'application' ? 'execute' : 'copy'
+                  if (isCommandGroupData(item)) {
+                    return (
+                      <CommandFieldGroup
+                        key={index}
+                        group={item.group}
+                        commandlist={item.commandlist}
+                        startIndex={flatIndex}
+                        mode={mode}
+                        cheatSheetLayout={cheatSheetData.layout}
+                        commandFieldRefs={commandFieldRefs}
+                      />
+                    )
+                  }
                   return (
                     <CommandField
                       key={index}
                       ref={(el) => {
-                        commandFieldRefs.current[index] = el
+                        commandFieldRefs.current[flatIndex] = el
                       }}
                       description={item.description}
                       command={item.command}
                       numberHint={
-                        index < 9 ? (index + 1).toString() : undefined
+                        flatIndex < 9 ? (flatIndex + 1).toString() : undefined
                       }
-                      mode={
-                        cheatSheetData.type === 'application'
-                          ? 'execute'
-                          : 'copy'
-                      }
+                      mode={mode}
                       layout={item.layout ?? cheatSheetData.layout ?? 'inline'}
                     />
                   )

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -340,15 +340,17 @@ export const CheatSheet = () => {
                     cheatSheetData.type === 'application' ? 'execute' : 'copy'
                   if (isCommandGroupData(item)) {
                     return (
-                      <CommandFieldGroup
-                        key={index}
-                        group={item.group}
-                        commandlist={item.commandlist}
-                        startIndex={flatIndex}
-                        mode={mode}
-                        cheatSheetLayout={cheatSheetData.layout}
-                        commandFieldRefs={commandFieldRefs}
-                      />
+                      <Box key={index} pt={1}>
+                        <CommandFieldGroup
+                          key={index}
+                          group={item.group}
+                          commandlist={item.commandlist}
+                          startIndex={flatIndex}
+                          mode={mode}
+                          cheatSheetLayout={cheatSheetData.layout}
+                          commandFieldRefs={commandFieldRefs}
+                        />
+                      </Box>
                     )
                   }
                   return (

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -68,8 +68,9 @@ export const CheatSheet = () => {
   })
 
   useEffect(() => {
+    let unlisten: (() => void) | undefined
     ;(async () => {
-      await listen<{}>(Event.RELOAD_CHEAT_SHEET, () => {
+      unlisten = await listen<{}>(Event.RELOAD_CHEAT_SHEET, () => {
         ;(async () => {
           const inputpath = await getCheatSheetFilePath()
           if (inputpath) {
@@ -95,6 +96,10 @@ export const CheatSheet = () => {
         await loadCheatSheetTitles(inputpath)
       }
     })()
+
+    return () => {
+      unlisten?.()
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadCheatSheetTitles])
 


### PR DESCRIPTION
## Summary

- `command` / `application` タイプのチートシートでも `group` オブジェクトを使ったグループ表示に対応
- グループ内のコマンドにも数字キー（1〜9）が連続して割り当てられる
- Tauri の `listen()` の unlisten 関数を useEffect クリーンアップで呼び出すよう修正（ホットリロード時のランタイムエラーを解消）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/components/molecules/CommandFieldGroup.tsx` | 新規作成（command/application用グループ表示コンポーネント） |
| `src/components/organisms/CheatSheet.tsx` | グループ対応の描画ロジック追加、listen クリーンアップ修正 |

## Test plan

- [x] `yarn lint` エラーなし
- [x] `yarn tauri build` ビルド成功
- [x] `command` タイプでグループ表示が正常に動作すること
- [x] `application` タイプでグループ表示が正常に動作すること
- [x] グループ内コマンドに数字キーが連続して割り当てられること
- [x] 開発モード（`yarn tauri dev`）でホットリロード時にエラーが出ないこと

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)