### PR TITLE
feat: About画面のcopyright値をtauri.conf.jsonで設定できるようにする

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,6 @@ pub mod api;
 pub mod common;
 pub mod settings_store;
 
-use serde_json;
 use settings_store::{SettingsStore, TauriSettingsStore};
 use tauri::image::Image;
 use tauri::menu::{AboutMetadataBuilder, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,16 @@ use tauri::Manager;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tauri_plugin_opener::OpenerExt;
 
+const TAURI_CONF: &str = include_str!("../tauri.conf.json");
+
+fn get_copyright() -> String {
+    let v: serde_json::Value = serde_json::from_str(TAURI_CONF).unwrap_or_default();
+    v["bundle"]["copyright"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string()
+}
+
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -120,7 +130,7 @@ fn menu_configuration<R: tauri::Runtime>(
                             let mut metadata = AboutMetadataBuilder::new()
                                 .version(Some(format!("バージョン {}", app_version)))
                                 .short_version(Some(app_version))
-                                .copyright(Some("©︎ 2025 nosetech"));
+                                .copyright(Some(get_copyright()));
                             metadata = metadata.icon(Some(Image::from_bytes(include_bytes!(
                                 "../icons/icon.png"
                             ))?));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,6 +33,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "copyright": "©︎ 2025 nosetech",
     "icon": [
       "icons/32x32.png",
       "icons/64x64.png",


### PR DESCRIPTION
## Summary

- `tauri.conf.json` の `bundle.copyright` フィールドを追加し、copyright 文字列の管理をここに集約
- `lib.rs` のハードコード文字列を削除し、`include_str!` でコンパイル時に `tauri.conf.json` を埋め込んで `bundle.copyright` を取得する `get_copyright()` 関数を追加
- `handle.config().bundle.copyright` 経由では常に `None` が返される（`tauri-utils` 2.6.0 の既知制限）ため、`include_str!` 方式で回避

## Test plan

- [ ] `yarn tauri dev` で起動してメニューバーのアプリ名 → "About RightCheat" を開き、copyright 文字列が表示されることを確認
- [ ] `cargo test --verbose -- --test-threads=1` が全テスト通過することを確認

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)