### PR TITLE
feat: Preferences画面にログ設定セクションを追加する

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -2,5 +2,6 @@ pub mod application;
 pub mod cheatsheet;
 pub mod font_size;
 pub mod global_shortcut;
+pub mod log_settings;
 pub mod visible_on_all_workspaces;
 pub mod window;

--- a/src-tauri/src/api/log_settings.rs
+++ b/src-tauri/src/api/log_settings.rs
@@ -1,0 +1,138 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, Runtime};
+use tauri_plugin_opener::OpenerExt;
+use tauri_plugin_store::JsonValue;
+
+use crate::common;
+use crate::settings_store::{SettingsStore, TauriSettingsStore};
+
+const LOG_FILE_NAME: &str = "RightCheat.log";
+const DEFAULT_MAX_FILE_SIZE: u64 = 1_048_576;
+const DEFAULT_ROTATION_COUNT: u32 = 3;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogSettings {
+    pub output_dir: Option<String>,
+    pub max_file_size: u64,
+    pub rotation_count: u32,
+}
+
+impl Default for LogSettings {
+    fn default() -> Self {
+        Self {
+            output_dir: None,
+            max_file_size: DEFAULT_MAX_FILE_SIZE,
+            rotation_count: DEFAULT_ROTATION_COUNT,
+        }
+    }
+}
+
+pub fn read_log_settings_from_file() -> LogSettings {
+    let Some(data_dir) = dirs::data_dir() else {
+        return LogSettings::default();
+    };
+    let settings_path = data_dir
+        .join("biz.nosetech.rightcheat")
+        .join(common::config::SETTING_FILENAME);
+
+    let Ok(content) = std::fs::read_to_string(&settings_path) else {
+        return LogSettings::default();
+    };
+
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return LogSettings::default();
+    };
+
+    let Some(log_json) = json.get(common::config::LOG_SETTINGS) else {
+        return LogSettings::default();
+    };
+
+    serde_json::from_value(log_json.clone()).unwrap_or_default()
+}
+
+#[tauri::command]
+pub fn get_log_settings<R: Runtime>(app: AppHandle<R>) -> Result<LogSettings, String> {
+    let settings_store = TauriSettingsStore;
+    match settings_store.get_setting(&app, common::config::LOG_SETTINGS) {
+        Ok(Some(json)) => serde_json::from_value(json).map_err(|e| e.to_string()),
+        Ok(None) => Ok(LogSettings::default()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn set_log_settings<R: Runtime>(
+    app: AppHandle<R>,
+    settings: LogSettings,
+) -> Result<(), String> {
+    let settings_store = TauriSettingsStore;
+    let json: JsonValue = serde_json::to_value(&settings).map_err(|e| e.to_string())?;
+    settings_store
+        .set_setting(&app, common::config::LOG_SETTINGS, json)
+        .map_err(|e| e.to_string())?;
+    log::info!(
+        "[log_settings] Saved: max_file_size={}, rotation_count={}, output_dir={:?}",
+        settings.max_file_size,
+        settings.rotation_count,
+        settings.output_dir
+    );
+    Ok(())
+}
+
+#[tauri::command]
+pub fn open_latest_log_file<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    let log_dir = get_effective_log_dir(&app)?;
+    let log_file = log_dir.join(LOG_FILE_NAME);
+    log::debug!("[log_settings] Opening log file: {:?}", log_file);
+    let log_file_str = log_file.to_string_lossy().to_string();
+    app.opener()
+        .open_path(log_file_str, None::<&str>)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_log_dir<R: Runtime>(app: AppHandle<R>) -> Result<String, String> {
+    let dir = get_effective_log_dir(&app)?;
+    Ok(dir.to_string_lossy().to_string())
+}
+
+fn get_effective_log_dir<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
+    let settings_store = TauriSettingsStore;
+    let settings = match settings_store.get_setting(app, common::config::LOG_SETTINGS) {
+        Ok(Some(json)) => serde_json::from_value(json).unwrap_or_default(),
+        _ => LogSettings::default(),
+    };
+    match settings.output_dir {
+        Some(dir) => Ok(PathBuf::from(dir)),
+        None => app
+            .path()
+            .app_log_dir()
+            .map_err(|e: tauri::Error| e.to_string()),
+    }
+}
+
+pub fn init_log_settings<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std::error::Error>> {
+    let settings_store = TauriSettingsStore;
+    match settings_store.get_setting(app, common::config::LOG_SETTINGS) {
+        Ok(Some(_)) => {
+            log::info!("[log_settings] Log settings already exist");
+        }
+        Ok(None) => {
+            let default_settings = LogSettings::default();
+            settings_store.set_setting(
+                app,
+                common::config::LOG_SETTINGS,
+                serde_json::to_value(&default_settings)?,
+            )?;
+            log::info!("[log_settings] Default log settings initialized");
+        }
+        Err(e) => {
+            log::error!("[log_settings] Error checking log settings: {:?}", e);
+            return Err(Box::new(e));
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/api/log_settings.rs
+++ b/src-tauri/src/api/log_settings.rs
@@ -34,7 +34,7 @@ pub fn read_log_settings_from_file() -> LogSettings {
         return LogSettings::default();
     };
     let settings_path = data_dir
-        .join("biz.nosetech.rightcheat")
+        .join(common::bundle::identifier())
         .join(common::config::SETTING_FILENAME);
 
     let Ok(content) = std::fs::read_to_string(&settings_path) else {
@@ -102,7 +102,13 @@ pub fn get_log_dir<R: Runtime>(app: AppHandle<R>) -> Result<String, String> {
 fn get_effective_log_dir<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
     let settings_store = TauriSettingsStore;
     let settings = match settings_store.get_setting(app, common::config::LOG_SETTINGS) {
-        Ok(Some(json)) => serde_json::from_value(json).unwrap_or_default(),
+        Ok(Some(json)) => serde_json::from_value(json).unwrap_or_else(|e| {
+            log::warn!(
+                "[log_settings] Failed to deserialize log settings, using default: {}",
+                e
+            );
+            LogSettings::default()
+        }),
         _ => LogSettings::default(),
     };
     match settings.output_dir {

--- a/src-tauri/src/common.rs
+++ b/src-tauri/src/common.rs
@@ -1,6 +1,7 @@
 pub mod config {
     pub const SETTING_FILENAME: &str = "rightcheat-settings.json";
     pub const TOGGLE_VISIBLE_SHORTCUT: &str = "toggle_visibe_shortcut_settings";
+    pub const LOG_SETTINGS: &str = "log_settings";
 }
 
 pub mod event {

--- a/src-tauri/src/common.rs
+++ b/src-tauri/src/common.rs
@@ -4,6 +4,18 @@ pub mod config {
     pub const LOG_SETTINGS: &str = "log_settings";
 }
 
+pub mod bundle {
+    const TAURI_CONF: &str = include_str!("../tauri.conf.json");
+
+    pub fn identifier() -> String {
+        let v: serde_json::Value = serde_json::from_str(TAURI_CONF).unwrap_or_default();
+        v["identifier"]
+            .as_str()
+            .unwrap_or("biz.nosetech.rightcheat")
+            .to_string()
+    }
+}
+
 pub mod event {
     pub const WINDOW_VISIABLE_TOGGLE: &str = "window_visible_toggle";
     pub const RELOAD_CHEAT_SHEET: &str = "reload_cheat_sheet";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,9 @@ pub fn run() {
                 logger = logger.level(log::LevelFilter::Info)
             }
             if let Some(ref dir) = log_settings.output_dir {
+                // When a custom output directory is configured, explicitly set targets so
+                // that logs go only to the specified folder (and stdout in dev mode).
+                // Calling .target() replaces the plugin's default targets (app_log_dir).
                 logger = logger.target(tauri_plugin_log::Target::new(
                     tauri_plugin_log::TargetKind::Folder {
                         path: std::path::PathBuf::from(dir),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,14 +26,30 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin({
+            let log_settings = api::log_settings::read_log_settings_from_file();
             let mut logger = tauri_plugin_log::Builder::new()
                 .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
-                .max_file_size(1_048_576)
-                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(3));
+                .max_file_size(log_settings.max_file_size as u128)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(
+                    log_settings.rotation_count as usize,
+                ));
             if cfg!(dev) {
                 logger = logger.level(log::LevelFilter::Trace)
             } else {
                 logger = logger.level(log::LevelFilter::Info)
+            }
+            if let Some(ref dir) = log_settings.output_dir {
+                logger = logger.target(tauri_plugin_log::Target::new(
+                    tauri_plugin_log::TargetKind::Folder {
+                        path: std::path::PathBuf::from(dir),
+                        file_name: None,
+                    },
+                ));
+                if cfg!(dev) {
+                    logger = logger.target(tauri_plugin_log::Target::new(
+                        tauri_plugin_log::TargetKind::Stdout,
+                    ));
+                }
             }
             logger.build()
         })
@@ -81,6 +97,7 @@ pub fn run() {
             }
             global_shortcut_configuration(app)?;
             api::visible_on_all_workspaces::init_visible_on_all_workspaces_settings(app.handle())?;
+            api::log_settings::init_log_settings(app.handle())?;
 
             if let Some(main_window) = app.get_webview_window("main") {
                 let main_window_clone = main_window.clone();
@@ -116,6 +133,10 @@ pub fn run() {
             api::visible_on_all_workspaces::get_visible_on_all_workspaces_setting,
             api::visible_on_all_workspaces::set_visible_on_all_workspaces_setting,
             api::application::run_application,
+            api::log_settings::get_log_settings,
+            api::log_settings::set_log_settings,
+            api::log_settings::open_latest_log_file,
+            api::log_settings::get_log_dir,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -253,9 +274,9 @@ fn on_menu_event_configuration<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, 
                 tauri::WebviewUrl::App("/preferences".into()),
             )
             .title("Preferences")
-            .inner_size(520.0, 420.0)
-            .max_inner_size(800.0, 420.0)
-            .min_inner_size(520.0, 420.0)
+            .inner_size(580.0, 560.0)
+            .max_inner_size(800.0, 560.0)
+            .min_inner_size(580.0, 560.0)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .build();

--- a/src-tauri/tests/api/log_settings.rs
+++ b/src-tauri/tests/api/log_settings.rs
@@ -1,0 +1,631 @@
+// ============================================================
+// テスト対象: src-tauri/src/api/log_settings.rs
+//
+// ブラックボックステスト戦略:
+//   同値分割:
+//     - 設定が存在しない → デフォルト値クラス
+//     - 設定が存在する   → 保存値クラス
+//     - output_dir: None / Some(String)
+//     - max_file_size: 境界値 1024 (最小想定) / 1_048_576 (デフォルト) / 104_857_600 (最大想定)
+//     - rotation_count: 境界値 1 (最小) / 3 (デフォルト) / 20 (最大)
+//
+//   境界値分析:
+//     - max_file_size の最小・デフォルト・最大を検証
+//     - rotation_count の最小・デフォルト・最大を検証
+//
+// ホワイトボックステスト戦略:
+//   get_log_settings の分岐:
+//     - Ok(None)  → LogSettings::default() を返す
+//     - Ok(Some)  → serde_json::from_value でデシリアライズして返す
+//   init_log_settings の分岐:
+//     - Ok(Some(_)) → 既存設定を保持してスキップ
+//     - Ok(None)    → デフォルト設定を書き込む
+//   LogSettings のシリアライズ/デシリアライズのラウンドトリップ
+// ============================================================
+
+// ------------------------------------------------------------
+// get_log_settings のテスト
+// ------------------------------------------------------------
+#[cfg(test)]
+mod get_log_settings {
+    use app_lib::api::log_settings::{get_log_settings, set_log_settings, LogSettings};
+    use app_lib::settings_store::{SettingsStore, TauriSettingsStore};
+    use tauri::test::mock_app;
+
+    /// 設定が存在しない場合のデフォルト値取得テスト
+    /// 同値クラス: 設定が存在しない（ストレージ空）
+    /// ホワイトボックス: Ok(None) → LogSettings::default() を返すパス
+    /// 期待値: output_dir=None, max_file_size=1_048_576, rotation_count=3
+    #[test]
+    fn get_default_when_no_settings() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-get-default.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+
+        // デフォルト値を検証
+        assert_eq!(result.output_dir, None);
+        assert_eq!(result.max_file_size, 1_048_576);
+        assert_eq!(result.rotation_count, 3);
+    }
+
+    /// output_dir=Some、カスタム値の既存設定取得テスト
+    /// 同値クラス: 設定が存在、output_dir=Some(カスタムパス)
+    /// ホワイトボックス: Ok(Some(json)) → serde_json::from_value で返すパス
+    /// 期待値: 保存されたカスタム値がそのまま返される
+    #[test]
+    fn get_existing_settings_with_custom_output_dir() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-get-custom-dir.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // カスタム値を事前に保存
+        let custom_settings = LogSettings {
+            output_dir: Some("/custom/log/path".to_string()),
+            max_file_size: 2_097_152, // 2MB
+            rotation_count: 5,
+        };
+        set_log_settings(app.handle().clone(), custom_settings).unwrap();
+
+        // 取得を検証
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, Some("/custom/log/path".to_string()));
+        assert_eq!(result.max_file_size, 2_097_152);
+        assert_eq!(result.rotation_count, 5);
+    }
+
+    /// output_dir=None の既存設定取得テスト
+    /// 同値クラス: 設定が存在、output_dir=None（明示的に None を保存した場合）
+    /// 期待値: output_dir=None が正しく取得できる
+    #[test]
+    fn get_existing_settings_with_output_dir_none() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-get-dir-none.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // output_dir=None で明示的に保存
+        let settings = LogSettings {
+            output_dir: None,
+            max_file_size: 1_048_576,
+            rotation_count: 3,
+        };
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        // None が正しく取得できることを検証
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, None);
+    }
+}
+
+// ------------------------------------------------------------
+// set_log_settings のテスト
+// ------------------------------------------------------------
+#[cfg(test)]
+mod set_log_settings {
+    use app_lib::api::log_settings::{get_log_settings, set_log_settings, LogSettings};
+    use app_lib::settings_store::{SettingsStore, TauriSettingsStore};
+    use tauri::test::mock_app;
+
+    /// デフォルト値の保存テスト
+    /// 同値クラス: output_dir=None, max_file_size=デフォルト, rotation_count=デフォルト
+    /// 期待値: デフォルト値が正しく永続化される
+    #[test]
+    fn set_default_values() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-default.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        let settings = LogSettings::default();
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, None);
+        assert_eq!(result.max_file_size, 1_048_576);
+        assert_eq!(result.rotation_count, 3);
+    }
+
+    /// output_dir=Some("custom/path") の保存テスト
+    /// 同値クラス: output_dir=Some(有効なパス文字列)
+    /// 期待値: カスタムパスが正しく永続化される
+    #[test]
+    fn set_with_custom_output_dir() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-custom-dir.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        let settings = LogSettings {
+            output_dir: Some("custom/log/path".to_string()),
+            max_file_size: 1_048_576,
+            rotation_count: 3,
+        };
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, Some("custom/log/path".to_string()));
+    }
+
+    /// output_dir=None の保存テスト（None が正しく保存・取得できること）
+    /// 同値クラス: output_dir=None
+    /// 期待値: None が保存後も None として取得できる
+    #[test]
+    fn set_with_output_dir_none() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-dir-none.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        let settings = LogSettings {
+            output_dir: None,
+            max_file_size: 1_048_576,
+            rotation_count: 3,
+        };
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, None);
+    }
+
+    /// max_file_size の境界値テスト: 最小値 1024 バイト
+    /// 境界値分析: max_file_size の下限境界
+    /// 期待値: 1024 バイトが正しく保存・取得できる
+    #[test]
+    fn set_max_file_size_min_boundary() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-size-min.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 境界値: 最小 1024 バイト（1KB）
+        let settings = LogSettings {
+            output_dir: None,
+            max_file_size: 1_024,
+            rotation_count: 3,
+        };
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.max_file_size, 1_024);
+    }
+
+    /// max_file_size の境界値テスト: 最大値 104857600 バイト（100MB）
+    /// 境界値分析: max_file_size の上限境界
+    /// 期待値: 104_857_600 バイトが正しく保存・取得できる
+    #[test]
+    fn set_max_file_size_max_boundary() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-size-max.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 境界値: 最大 104_857_600 バイト（100MB）
+        let settings = LogSettings {
+            output_dir: None,
+            max_file_size: 104_857_600,
+            rotation_count: 3,
+        };
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.max_file_size, 104_857_600);
+    }
+
+    /// rotation_count の境界値テスト: 最小値 1
+    /// 境界値分析: rotation_count の下限境界
+    /// 期待値: 1 が正しく保存・取得できる
+    #[test]
+    fn set_rotation_count_min_boundary() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-rotation-min.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 境界値: rotation_count 最小 = 1
+        let settings = LogSettings {
+            output_dir: None,
+            max_file_size: 1_048_576,
+            rotation_count: 1,
+        };
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.rotation_count, 1);
+    }
+
+    /// rotation_count の境界値テスト: 最大値 20
+    /// 境界値分析: rotation_count の上限境界
+    /// 期待値: 20 が正しく保存・取得できる
+    #[test]
+    fn set_rotation_count_max_boundary() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-rotation-max.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 境界値: rotation_count 最大 = 20
+        let settings = LogSettings {
+            output_dir: None,
+            max_file_size: 1_048_576,
+            rotation_count: 20,
+        };
+        set_log_settings(app.handle().clone(), settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.rotation_count, 20);
+    }
+
+    /// 設定の上書きテスト（カスタム値 → 別のカスタム値）
+    /// 同値クラス: 既存設定を新しい値で上書き
+    /// 期待値: 最後に保存した値が正しく取得できる
+    #[test]
+    fn overwrite_existing_settings() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-set-overwrite.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 最初の設定を保存
+        let first_settings = LogSettings {
+            output_dir: Some("/first/path".to_string()),
+            max_file_size: 2_097_152,
+            rotation_count: 5,
+        };
+        set_log_settings(app.handle().clone(), first_settings).unwrap();
+
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, Some("/first/path".to_string()));
+        assert_eq!(result.max_file_size, 2_097_152);
+        assert_eq!(result.rotation_count, 5);
+
+        // 上書きする設定を保存
+        let second_settings = LogSettings {
+            output_dir: None,
+            max_file_size: 1_048_576,
+            rotation_count: 3,
+        };
+        set_log_settings(app.handle().clone(), second_settings).unwrap();
+
+        // 最後に保存した値が返されることを検証
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, None);
+        assert_eq!(result.max_file_size, 1_048_576);
+        assert_eq!(result.rotation_count, 3);
+    }
+}
+
+// ------------------------------------------------------------
+// init_log_settings のテスト
+// ------------------------------------------------------------
+#[cfg(test)]
+mod init_log_settings {
+    use app_lib::api::log_settings::{
+        get_log_settings, init_log_settings, set_log_settings, LogSettings,
+    };
+    use app_lib::settings_store::{SettingsStore, TauriSettingsStore};
+    use tauri::test::mock_app;
+
+    /// 設定が存在しない場合の初期化テスト
+    /// 同値クラス: 設定が存在しない
+    /// ホワイトボックス: Ok(None) → デフォルト設定書き込みパス
+    /// 期待値: デフォルト設定（output_dir=None, max_file_size=1_048_576, rotation_count=3）が作成される
+    #[test]
+    fn init_when_settings_do_not_exist() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-init-new.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 設定を初期化
+        init_log_settings(&app.handle()).unwrap();
+
+        // デフォルト設定が作成されたことを検証
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, None);
+        assert_eq!(result.max_file_size, 1_048_576);
+        assert_eq!(result.rotation_count, 3);
+    }
+
+    /// カスタム設定が存在する場合の初期化テスト（output_dir=Some）
+    /// 同値クラス: 設定が存在する（output_dir=Some）
+    /// ホワイトボックス: Ok(Some(_)) → スキップパス
+    /// 期待値: 既存設定が保持される（上書きされない）
+    #[test]
+    fn init_does_not_overwrite_existing_settings_with_custom_dir() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-init-existing-dir.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // カスタム設定を事前に保存
+        let custom_settings = LogSettings {
+            output_dir: Some("/pre/existing/path".to_string()),
+            max_file_size: 5_242_880, // 5MB
+            rotation_count: 10,
+        };
+        set_log_settings(app.handle().clone(), custom_settings).unwrap();
+
+        // 初期化（上書きされないはず）
+        init_log_settings(&app.handle()).unwrap();
+
+        // 設定が変わっていないことを検証
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, Some("/pre/existing/path".to_string()));
+        assert_eq!(result.max_file_size, 5_242_880);
+        assert_eq!(result.rotation_count, 10);
+    }
+
+    /// デフォルト相当の既存設定がある場合の初期化テスト（output_dir=None）
+    /// 同値クラス: 設定が存在する（output_dir=None）
+    /// 期待値: 既存設定が保持される（上書きされない）
+    #[test]
+    fn init_does_not_overwrite_existing_settings_with_none_dir() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-init-existing-none.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // output_dir=None のまま、非デフォルト値を持つ設定を事前に保存
+        let pre_settings = LogSettings {
+            output_dir: None,
+            max_file_size: 2_097_152, // デフォルト(1MB)とは異なる2MB
+            rotation_count: 7,
+        };
+        set_log_settings(app.handle().clone(), pre_settings).unwrap();
+
+        // 初期化（上書きされないはず）
+        init_log_settings(&app.handle()).unwrap();
+
+        // 設定が変わっていないことを検証
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, None);
+        assert_eq!(result.max_file_size, 2_097_152);
+        assert_eq!(result.rotation_count, 7);
+    }
+
+    /// 複数回初期化しても冪等性が保たれるテスト
+    /// 期待値: 初回初期化後に設定を変更し、再度初期化しても既存設定が保持される
+    #[test]
+    fn init_is_idempotent_multiple_times() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings("unittest-log-init-idempotent.json");
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 1回目の初期化: デフォルト設定が作成される
+        init_log_settings(&app.handle()).unwrap();
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, None);
+        assert_eq!(result.max_file_size, 1_048_576);
+        assert_eq!(result.rotation_count, 3);
+
+        // 設定をカスタム値に変更
+        let custom_settings = LogSettings {
+            output_dir: Some("/changed/path".to_string()),
+            max_file_size: 10_485_760, // 10MB
+            rotation_count: 5,
+        };
+        set_log_settings(app.handle().clone(), custom_settings).unwrap();
+
+        // 2回目の初期化（カスタム値が上書きされないはず）
+        init_log_settings(&app.handle()).unwrap();
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, Some("/changed/path".to_string()));
+        assert_eq!(result.max_file_size, 10_485_760);
+        assert_eq!(result.rotation_count, 5);
+
+        // 3回目の初期化（やはり上書きされないはず）
+        init_log_settings(&app.handle()).unwrap();
+        let result = get_log_settings(app.handle().clone()).unwrap();
+        assert_eq!(result.output_dir, Some("/changed/path".to_string()));
+        assert_eq!(result.max_file_size, 10_485_760);
+        assert_eq!(result.rotation_count, 5);
+    }
+}
+
+// ------------------------------------------------------------
+// LogSettings シリアライズ/デシリアライズのテスト
+// ------------------------------------------------------------
+#[cfg(test)]
+mod log_settings_serde {
+    use app_lib::api::log_settings::LogSettings;
+
+    /// デフォルト値のシリアライズ → デシリアライズのラウンドトリップテスト
+    /// 同値クラス: output_dir=None のデフォルト値
+    /// 期待値: シリアライズ後にデシリアライズしても値が一致する
+    #[test]
+    fn round_trip_default_values() {
+        let original = LogSettings::default();
+
+        // JSON にシリアライズ
+        let json = serde_json::to_value(&original).unwrap();
+
+        // JSON からデシリアライズ
+        let deserialized: LogSettings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(deserialized.output_dir, None);
+        assert_eq!(deserialized.max_file_size, 1_048_576);
+        assert_eq!(deserialized.rotation_count, 3);
+    }
+
+    /// output_dir=Some のシリアライズ → デシリアライズのラウンドトリップテスト
+    /// 同値クラス: output_dir=Some(パス文字列)
+    /// 期待値: シリアライズ後にデシリアライズしても値が一致する
+    #[test]
+    fn round_trip_with_output_dir_some() {
+        let original = LogSettings {
+            output_dir: Some("/path/to/logs".to_string()),
+            max_file_size: 2_097_152,
+            rotation_count: 5,
+        };
+
+        // JSON にシリアライズ
+        let json = serde_json::to_value(&original).unwrap();
+
+        // JSON からデシリアライズ
+        let deserialized: LogSettings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(deserialized.output_dir, Some("/path/to/logs".to_string()));
+        assert_eq!(deserialized.max_file_size, 2_097_152);
+        assert_eq!(deserialized.rotation_count, 5);
+    }
+
+    /// 日本語パスを含む output_dir のラウンドトリップテスト
+    /// 同値クラス: output_dir=Some(マルチバイト文字を含むパス)
+    /// 期待値: 日本語を含むパスも正しくシリアライズ/デシリアライズできる
+    #[test]
+    fn round_trip_with_japanese_path() {
+        let original = LogSettings {
+            output_dir: Some("/Users/ユーザー/ログ".to_string()),
+            max_file_size: 1_048_576,
+            rotation_count: 3,
+        };
+
+        let json = serde_json::to_value(&original).unwrap();
+        let deserialized: LogSettings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(
+            deserialized.output_dir,
+            Some("/Users/ユーザー/ログ".to_string())
+        );
+    }
+
+    /// 境界値を持つ設定のラウンドトリップテスト
+    /// 境界値分析: max_file_size=1024(最小), rotation_count=1(最小)
+    /// 期待値: 境界値もシリアライズ/デシリアライズで正確に保持される
+    #[test]
+    fn round_trip_with_min_boundary_values() {
+        let original = LogSettings {
+            output_dir: None,
+            max_file_size: 1_024, // 1KB（最小想定）
+            rotation_count: 1,    // 最小
+        };
+
+        let json = serde_json::to_value(&original).unwrap();
+        let deserialized: LogSettings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(deserialized.max_file_size, 1_024);
+        assert_eq!(deserialized.rotation_count, 1);
+    }
+
+    /// 境界値を持つ設定のラウンドトリップテスト
+    /// 境界値分析: max_file_size=104857600(100MB最大), rotation_count=20(最大)
+    /// 期待値: 境界値もシリアライズ/デシリアライズで正確に保持される
+    #[test]
+    fn round_trip_with_max_boundary_values() {
+        let original = LogSettings {
+            output_dir: None,
+            max_file_size: 104_857_600, // 100MB（最大想定）
+            rotation_count: 20,         // 最大
+        };
+
+        let json = serde_json::to_value(&original).unwrap();
+        let deserialized: LogSettings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(deserialized.max_file_size, 104_857_600);
+        assert_eq!(deserialized.rotation_count, 20);
+    }
+
+    /// JSON フィールド名の検証テスト
+    /// ホワイトボックス: serde の derive が正しいフィールド名で出力することを確認
+    /// 期待値: "output_dir", "max_file_size", "rotation_count" のキーが存在する
+    #[test]
+    fn serialized_json_has_correct_field_names() {
+        let settings = LogSettings {
+            output_dir: Some("/test".to_string()),
+            max_file_size: 1_048_576,
+            rotation_count: 3,
+        };
+
+        let json = serde_json::to_value(&settings).unwrap();
+
+        // フィールド名の存在確認
+        assert!(json.get("output_dir").is_some());
+        assert!(json.get("max_file_size").is_some());
+        assert!(json.get("rotation_count").is_some());
+
+        // フィールド値の型・値確認
+        assert_eq!(json["output_dir"], "/test");
+        assert_eq!(json["max_file_size"], 1_048_576_u64);
+        assert_eq!(json["rotation_count"], 3_u32);
+    }
+}

--- a/src-tauri/tests/api/mod.rs
+++ b/src-tauri/tests/api/mod.rs
@@ -2,4 +2,5 @@ mod application;
 mod cheatsheet;
 mod font_size;
 mod global_shortcut;
+mod log_settings;
 mod visible_on_all_workspaces;

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -57,8 +57,9 @@ export default function Page() {
     rotation_count: DEFAULT_ROTATION_COUNT,
   })
   const [effectiveLogDir, setEffectiveLogDir] = useState<string>('')
-  const [logMaxFileSizeMBInput, setLogMaxFileSizeMBInput] =
-    useState<string>('1')
+  const [logMaxFileSizeMBInput, setLogMaxFileSizeMBInput] = useState<string>(
+    String(DEFAULT_MAX_FILE_SIZE_BYTES / (1024 * 1024)),
+  )
   const [logRotationCountInput, setLogRotationCountInput] = useState<string>(
     String(DEFAULT_ROTATION_COUNT),
   )
@@ -296,10 +297,10 @@ export default function Page() {
 
   const handleLogDirPick = async () => {
     const dir = await open({ directory: true, multiple: false })
-    if (dir != null) {
+    if (typeof dir === 'string') {
       const newSettings: LogSettings = {
         ...logSettings,
-        output_dir: dir as string,
+        output_dir: dir,
       }
       await saveLogSettings(newSettings)
     }

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -26,9 +26,6 @@ import {
   DialogTitle,
   Divider,
   IconButton,
-  InputAdornment,
-  Stack,
-  TextField,
   Tooltip,
   Typography,
 } from '@mui/material'
@@ -327,161 +324,236 @@ export default function Page() {
         }}
       />
       <WindowTitleBar title='Preferences' />
-      <Stack padding={1} spacing={1}>
-        <Stack direction='row' spacing={1} alignItems='center'>
-          <Typography variant='body1'>Global Shortcut</Typography>
-          {shortcutValidationError && (
-            <Typography variant='caption' color={theme.palette.alert.main}>
-              Please check at least one of ^ ⌥ ⌘.
-            </Typography>
-          )}
-        </Stack>
-        <Stack padding={1}>
-          {toggleVisibleShortcut && (
-            <ShortcutEditField
-              shortcutName='Toggle Visible'
-              shortcut={toggleVisibleShortcut}
-              callback={shortcutEditCallback}
-              onValidationChange={setShortcutValidationError}
-            />
-          )}
-        </Stack>
-        <Divider />
-        <Typography variant='body1'>Theme</Typography>
-        <Stack padding={1}>
-          <ThemeToggle
-            themeMode={themeMode}
-            onChange={handleThemeChange}
-            disabled={isLoading}
-          />
-        </Stack>
-        <Divider />
-        <Typography variant='body1'>Other Settings</Typography>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '14px',
-            p: '12px 14px',
-            backgroundColor: isDark
-              ? 'rgba(255,255,255,0.025)'
-              : 'rgba(255,255,255,0.35)',
-            border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.6)'}`,
-            borderRadius: '10px',
-            boxShadow: isDark ? 'none' : 'inset 0 1px 0 rgba(255,255,255,0.5)',
-          }}
-        >
-          {/* Visible on all workspaces */}
-          <Box
+      <Box
+        sx={{ p: '4px 20px 16px', display: 'flex', flexDirection: 'column' }}
+      >
+        {/* Global Shortcut */}
+        <Box sx={{ py: '13px' }}>
+          <Typography
             sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: '0.01em',
+              mb: '10px',
+              color: 'text.primary',
             }}
           >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <RowDot />
-              <Typography variant='body2'>Visible on all workspaces</Typography>
-            </Box>
-            <ThemedSwitch
-              checked={visibleOnAllWorkspaces}
-              onChange={handleVisibleOnAllWorkspacesChange}
+            Global Shortcut
+          </Typography>
+          <Box sx={{ pl: '14px' }}>
+            {shortcutValidationError && (
+              <Typography
+                variant='caption'
+                color={theme.palette.alert.main}
+                sx={{ display: 'block', mb: 1 }}
+              >
+                Please check at least one of ^ ⌥ ⌘.
+              </Typography>
+            )}
+            {toggleVisibleShortcut && (
+              <ShortcutEditField
+                shortcutName='Toggle Visible'
+                shortcut={toggleVisibleShortcut}
+                callback={shortcutEditCallback}
+                onValidationChange={setShortcutValidationError}
+              />
+            )}
+          </Box>
+        </Box>
+
+        <Divider sx={{ mx: '-20px', borderBottomWidth: '0.5px' }} />
+
+        {/* Theme */}
+        <Box sx={{ py: '13px' }}>
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: '0.01em',
+              mb: '10px',
+              color: 'text.primary',
+            }}
+          >
+            Theme
+          </Typography>
+          <Box sx={{ pl: '14px' }}>
+            <ThemeToggle
+              themeMode={themeMode}
+              onChange={handleThemeChange}
+              disabled={isLoading}
             />
           </Box>
+        </Box>
 
-          <Divider sx={{ borderBottomWidth: '0.5px' }} />
+        <Divider sx={{ mx: '-20px', borderBottomWidth: '0.5px' }} />
 
-          {/* Log section */}
-          <Box>
-            {/* Header row */}
+        {/* Other Settings */}
+        <Box sx={{ py: '13px' }}>
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: '0.01em',
+              mb: '10px',
+              color: 'text.primary',
+            }}
+          >
+            Other Settings
+          </Typography>
+          <Box sx={{ pl: '14px' }}>
             <Box
               sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: '8px',
-                mb: '6px',
-              }}
-            >
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <RowDot />
-                <Typography variant='body2'>Log</Typography>
-                <Chip
-                  label='Restart Required'
-                  size='small'
-                  sx={{
-                    height: 18,
-                    fontSize: '9.5px',
-                    fontFamily: 'monospace',
-                    letterSpacing: '0.06em',
-                    textTransform: 'uppercase',
-                    backgroundColor: isDark
-                      ? 'rgba(255,180,80,0.10)'
-                      : 'rgba(180,120,0,0.07)',
-                    border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.28)' : 'rgba(180,120,0,0.22)'}`,
-                    color: isDark ? '#f5c46b' : '#8a6300',
-                    '& .MuiChip-label': { px: '6px' },
-                  }}
-                />
-              </Box>
-              <Box sx={{ display: 'flex', gap: '4px' }}>
-                <Tooltip title='Open latest log file'>
-                  <IconButton
-                    size='small'
-                    onClick={handleOpenLatestLog}
-                    sx={{ color: 'text.secondary' }}
-                  >
-                    <ArticleOutlinedIcon sx={{ fontSize: 14 }} />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title='Edit log settings'>
-                  <IconButton
-                    size='small'
-                    onClick={() => setLogDialogOpen(true)}
-                    sx={{
-                      width: 28,
-                      height: 28,
-                      borderRadius: '7px',
-                      border: `0.5px solid ${theme.palette.divider}`,
-                      backgroundColor: isDark
-                        ? 'rgba(255,255,255,0.055)'
-                        : theme.palette.background.paper,
-                      color: 'text.secondary',
-                      '&:hover': {
-                        borderColor: theme.palette.primary.main,
-                        color: 'primary.main',
-                      },
-                    }}
-                  >
-                    <EditOutlinedIcon sx={{ fontSize: 13 }} />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-            </Box>
-
-            {/* Summary rows */}
-            <Box
-              sx={{
-                pl: 2,
                 display: 'flex',
                 flexDirection: 'column',
-                gap: '4px',
+                gap: '14px',
+                p: '12px 14px',
+                backgroundColor: isDark
+                  ? 'rgba(255,255,255,0.025)'
+                  : 'rgba(255,255,255,0.35)',
+                border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.6)'}`,
+                borderRadius: '10px',
+                boxShadow: isDark
+                  ? 'none'
+                  : 'inset 0 1px 0 rgba(255,255,255,0.5)',
               }}
             >
-              <LogSummaryRow label='Output Directory' value={effectiveLogDir} />
-              <LogSummaryRow
-                label='Max File Size'
-                // Rounding is safe because validation enforces integer-MB values.
-                value={`${Math.round(logSettings.max_file_size / (1024 * 1024))} MB`}
-              />
-              <LogSummaryRow
-                label='Rotation Count'
-                value={`${logSettings.rotation_count} files`}
-              />
+              {/* Visible on all workspaces */}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <RowDot />
+                  <Typography sx={{ fontSize: 13, color: 'text.primary' }}>
+                    Visible on all workspaces
+                  </Typography>
+                </Box>
+                <ThemedSwitch
+                  checked={visibleOnAllWorkspaces}
+                  onChange={handleVisibleOnAllWorkspacesChange}
+                />
+              </Box>
+
+              <Divider sx={{ borderBottomWidth: '0.5px' }} />
+
+              {/* Log section */}
+              <Box>
+                {/* Header row */}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: '8px',
+                    mb: '6px',
+                  }}
+                >
+                  <Box
+                    sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}
+                  >
+                    <RowDot />
+                    <Typography sx={{ fontSize: 13, color: 'text.primary' }}>
+                      Log
+                    </Typography>
+                    <Chip
+                      label='Restart Required'
+                      size='small'
+                      sx={{
+                        height: 'auto',
+                        py: '2px',
+                        fontSize: '9.5px',
+                        fontFamily: 'monospace',
+                        letterSpacing: '0.06em',
+                        textTransform: 'uppercase',
+                        borderRadius: '4px',
+                        backgroundColor: isDark
+                          ? 'rgba(255,180,80,0.10)'
+                          : 'rgba(180,120,0,0.07)',
+                        border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.28)' : 'rgba(180,120,0,0.22)'}`,
+                        color: isDark ? '#f5c46b' : '#8a6300',
+                        '& .MuiChip-label': { px: '6px' },
+                      }}
+                    />
+                  </Box>
+                  <Box sx={{ display: 'flex', gap: '4px' }}>
+                    <Tooltip title='Open latest log file'>
+                      <IconButton
+                        size='small'
+                        onClick={handleOpenLatestLog}
+                        sx={{
+                          width: 28,
+                          height: 28,
+                          borderRadius: '7px',
+                          border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.14)'}`,
+                          backgroundColor: isDark
+                            ? 'rgba(100,180,255,0.10)'
+                            : 'rgba(0,113,227,0.07)',
+                          color: isDark ? 'rgba(100,180,255,0.8)' : '#0071e3',
+                          '&:hover': {
+                            borderColor: theme.palette.primary.main,
+                            color: 'primary.main',
+                          },
+                        }}
+                      >
+                        <ArticleOutlinedIcon sx={{ fontSize: 13 }} />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title='Edit log settings'>
+                      <IconButton
+                        size='small'
+                        onClick={() => setLogDialogOpen(true)}
+                        sx={{
+                          width: 28,
+                          height: 28,
+                          borderRadius: '7px',
+                          border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.14)'}`,
+                          backgroundColor: isDark
+                            ? 'rgba(100,180,255,0.10)'
+                            : 'rgba(0,113,227,0.07)',
+                          color: isDark ? 'rgba(100,180,255,0.8)' : '#0071e3',
+                          '&:hover': {
+                            borderColor: theme.palette.primary.main,
+                            color: 'primary.main',
+                          },
+                        }}
+                      >
+                        <EditOutlinedIcon sx={{ fontSize: 13 }} />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                </Box>
+
+                {/* Summary rows */}
+                <Box
+                  sx={{
+                    pl: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '4px',
+                  }}
+                >
+                  <LogSummaryRow
+                    label='Output Directory'
+                    value={effectiveLogDir}
+                  />
+                  <LogSummaryRow
+                    label='Max File Size'
+                    // Rounding is safe because validation enforces integer-MB values.
+                    value={`${Math.round(logSettings.max_file_size / (1024 * 1024))} MB`}
+                  />
+                  <LogSummaryRow
+                    label='Rotation Count'
+                    value={`${logSettings.rotation_count} files`}
+                  />
+                </Box>
+              </Box>
             </Box>
           </Box>
         </Box>
-      </Stack>
+      </Box>
 
       <LogSettingsDialog
         open={logDialogOpen}
@@ -518,8 +590,8 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
       sx={{ display: 'flex', alignItems: 'baseline', gap: '8px', minWidth: 0 }}
     >
       <Typography
-        variant='caption'
         sx={{
+          fontSize: 11,
           flexShrink: 0,
           width: 110,
           fontWeight: 500,
@@ -529,9 +601,9 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
         {label}
       </Typography>
       <Typography
-        variant='caption'
         title={value}
         sx={{
+          fontSize: 11,
           fontFamily: 'monospace',
           color: 'text.primary',
           overflow: 'hidden',
@@ -543,6 +615,116 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
       >
         {value}
       </Typography>
+    </Box>
+  )
+}
+
+type NumberInputFieldProps = {
+  label: string
+  suffix: string
+  value: string
+  onChange: (value: string) => void
+  error?: boolean
+  hint?: string
+}
+
+function NumberInputField({
+  label,
+  suffix,
+  value,
+  onChange,
+  error,
+  hint,
+}: NumberInputFieldProps) {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  const [focused, setFocused] = useState(false)
+
+  const borderColor = focused
+    ? theme.palette.primary.main
+    : error
+      ? theme.palette.error.main
+      : isDark
+        ? 'rgba(255,255,255,0.10)'
+        : 'rgba(255,255,255,0.75)'
+
+  return (
+    <Box>
+      <Typography
+        sx={{
+          fontSize: 11,
+          fontWeight: 500,
+          mb: '6px',
+          color: 'text.secondary',
+          display: 'block',
+        }}
+      >
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          backgroundColor: isDark
+            ? 'rgba(255,255,255,0.055)'
+            : 'rgba(255,255,255,0.55)',
+          border: `0.5px solid ${borderColor}`,
+          borderRadius: '7px',
+          padding: '4px 8px',
+          boxShadow: isDark ? 'none' : 'inset 0 1px 0 rgba(255,255,255,0.8)',
+        }}
+      >
+        <Box
+          component='input'
+          type='number'
+          value={value}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            onChange(e.target.value)
+          }
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            background: 'none',
+            border: 'none',
+            outline: 'none',
+            fontFamily: 'monospace',
+            fontSize: 12,
+            color: 'text.primary',
+            caretColor: theme.palette.primary.main,
+            padding: '2px 0',
+            MozAppearance: 'textfield',
+            '&::-webkit-inner-spin-button': { display: 'none' },
+            '&::-webkit-outer-spin-button': { display: 'none' },
+          }}
+        />
+        <Typography
+          component='span'
+          sx={{
+            fontFamily: 'monospace',
+            fontSize: 10,
+            color: 'text.disabled',
+            ml: '6px',
+            flexShrink: 0,
+            letterSpacing: '0.04em',
+          }}
+        >
+          {suffix}
+        </Typography>
+      </Box>
+      {hint && (
+        <Typography
+          sx={{
+            fontSize: 10.5,
+            color: 'text.disabled',
+            mt: '4px',
+            lineHeight: 1.4,
+          }}
+        >
+          {hint}
+        </Typography>
+      )}
     </Box>
   )
 }
@@ -626,9 +808,41 @@ function LogSettingsDialog({
   }
 
   return (
-    <Dialog open={dialogOpen} onClose={onCancel} maxWidth='xs' fullWidth>
-      <DialogTitle sx={{ pb: 1 }}>Log Settings</DialogTitle>
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    <Dialog
+      open={dialogOpen}
+      onClose={onCancel}
+      maxWidth='xs'
+      fullWidth
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: '14px',
+            border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.75)'}`,
+            boxShadow: isDark
+              ? '0 24px 64px rgba(0,0,0,0.65), 0 0 0 0.5px rgba(255,255,255,0.10)'
+              : '0 24px 64px rgba(0,0,50,0.30), 0 0 0 0.5px rgba(255,255,255,0.7)',
+          },
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          padding: '14px 18px 12px',
+          fontSize: 14,
+          fontWeight: 600,
+          borderBottom: `0.5px solid ${theme.palette.divider}`,
+        }}
+      >
+        Log Settings
+      </DialogTitle>
+      <DialogContent
+        sx={{
+          padding: '14px 18px 6px !important',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '14px',
+        }}
+      >
         {/* Restart-required notice */}
         <Box
           sx={{
@@ -652,7 +866,6 @@ function LogSettingsDialog({
             }}
           />
           <Typography
-            variant='caption'
             sx={{
               lineHeight: 1.5,
               color: isDark ? '#f5c46b' : '#8a6300',
@@ -664,10 +877,15 @@ function LogSettingsDialog({
         </Box>
 
         {/* Output Directory */}
-        <Box>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
-            variant='caption'
-            sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
+            sx={{
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: '0.01em',
+              color: 'text.secondary',
+              display: 'block',
+            }}
           >
             Output Directory
           </Typography>
@@ -681,10 +899,11 @@ function LogSettingsDialog({
                   height: 30,
                   borderRadius: '7px',
                   flexShrink: 0,
-                  border: `0.5px solid ${theme.palette.divider}`,
+                  border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.14)'}`,
                   backgroundColor: isDark
-                    ? 'rgba(255,255,255,0.055)'
-                    : theme.palette.background.paper,
+                    ? 'rgba(100,180,255,0.10)'
+                    : 'rgba(0,113,227,0.07)',
+                  color: isDark ? 'rgba(100,180,255,0.8)' : '#0071e3',
                   '&:hover': { borderColor: theme.palette.primary.main },
                 }}
               >
@@ -703,12 +922,12 @@ function LogSettingsDialog({
                 borderRadius: '7px',
                 px: '10px',
                 py: '6px',
+                boxShadow: isDark ? 'none' : 'inset 0 1px 2px rgba(0,0,0,0.04)',
               }}
             >
               <Typography
                 component='span'
                 dir='ltr'
-                variant='caption'
                 sx={{
                   fontFamily: 'monospace',
                   fontSize: '11.5px',
@@ -734,69 +953,91 @@ function LogSettingsDialog({
         <Box
           sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}
         >
-          <TextField
-            size='small'
-            type='number'
+          <NumberInputField
             label='Max File Size'
+            suffix='MB'
             value={maxSizeMBInput}
-            onChange={(e) => setMaxSizeMBInput(e.target.value)}
+            onChange={setMaxSizeMBInput}
             error={maxSizeMBInput !== '' && !isMaxSizeValid}
-            helperText={
-              maxSizeMBInput !== '' && !isMaxSizeValid ? '1 to 100 MB' : ' '
+            hint={
+              maxSizeMBInput !== '' && !isMaxSizeValid
+                ? '1 to 100 MB'
+                : undefined
             }
-            slotProps={{
-              input: {
-                endAdornment: (
-                  <InputAdornment position='end'>
-                    <Typography variant='caption' color='text.secondary'>
-                      MB
-                    </Typography>
-                  </InputAdornment>
-                ),
-              },
-              htmlInput: { min: 1, max: 100 },
-            }}
-            sx={{
-              '& .MuiInputBase-root': {
-                fontFamily: 'monospace',
-                fontSize: '12px',
-              },
-            }}
           />
-          <TextField
-            size='small'
-            type='number'
+          <NumberInputField
             label='Rotation Count'
+            suffix='files'
             value={rotationInput}
-            onChange={(e) => setRotationInput(e.target.value)}
+            onChange={setRotationInput}
             error={rotationInput !== '' && !isRotationValid}
-            helperText={
-              rotationInput !== '' && !isRotationValid ? '1 to 20 files' : ' '
+            hint={
+              rotationInput !== '' && !isRotationValid
+                ? '1 to 20 files'
+                : undefined
             }
-            slotProps={{
-              input: {
-                endAdornment: (
-                  <InputAdornment position='end'>
-                    <Typography variant='caption' color='text.secondary'>
-                      files
-                    </Typography>
-                  </InputAdornment>
-                ),
-              },
-              htmlInput: { min: 1, max: 20 },
-            }}
-            sx={{
-              '& .MuiInputBase-root': {
-                fontFamily: 'monospace',
-                fontSize: '12px',
-              },
-            }}
           />
         </Box>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onCancel}>Cancel</Button>
-        <Button onClick={handleSave} disabled={!dirty} variant='contained'>
+      <DialogActions
+        sx={{
+          padding: '12px 16px 14px',
+          backgroundColor: isDark
+            ? 'rgba(255,255,255,0.018)'
+            : 'rgba(255,255,255,0.30)',
+          borderTop: `0.5px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Button
+          onClick={onCancel}
+          sx={{
+            borderRadius: '7px',
+            padding: '5px 16px',
+            fontSize: 12,
+            fontWeight: 600,
+            minWidth: 78,
+            textTransform: 'none',
+            backgroundColor: isDark
+              ? 'rgba(255,255,255,0.06)'
+              : 'rgba(255,255,255,0.75)',
+            border: `0.5px solid ${theme.palette.divider}`,
+            color: 'text.primary',
+            '&:hover': {
+              backgroundColor: isDark
+                ? 'rgba(255,255,255,0.10)'
+                : 'rgba(255,255,255,0.95)',
+            },
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={!dirty}
+          sx={{
+            borderRadius: '7px',
+            padding: '5px 16px',
+            fontSize: 12,
+            fontWeight: 600,
+            minWidth: 78,
+            textTransform: 'none',
+            backgroundColor: isDark ? '#64b4ff' : '#0071e3',
+            border: '0.5px solid transparent',
+            color: '#fff',
+            boxShadow: !isDark ? 'inset 0 1px 0 rgba(255,255,255,0.5)' : 'none',
+            '&:hover': {
+              backgroundColor: isDark ? '#7cc0ff' : '#1a82eb',
+            },
+            '&.Mui-disabled': {
+              backgroundColor: isDark
+                ? 'rgba(255,255,255,0.05)'
+                : 'rgba(0,0,0,0.04)',
+              border: `0.5px solid ${theme.palette.divider}`,
+              color: 'text.disabled',
+              boxShadow: 'none',
+            },
+          }}
+        >
           Save
         </Button>
       </DialogActions>

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -717,7 +717,7 @@ function NumberInputField({
         <Typography
           sx={{
             fontSize: 10.5,
-            color: 'text.disabled',
+            color: 'error.main',
             mt: '4px',
             lineHeight: 1.4,
           }}
@@ -939,7 +939,6 @@ function LogSettingsDialog({
                   // part of the path is always visible. dir='ltr' ensures
                   // screen readers announce it left-to-right.
                   direction: 'rtl',
-                  unicodeBidi: 'bidi-override',
                   textAlign: 'left',
                 }}
               >

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -131,31 +131,31 @@ export default function Page() {
   }, [])
 
   const showRestartConfirmationDialog = async () => {
-    if (process.env.NODE_ENV === 'production') {
-      const shouldRestart = await ask(
-        'A restart is required to apply the settings.\nDo you want to restart now?',
-        {
-          title: 'Restart Confirmation',
-          kind: 'info',
-          okLabel: 'Yes',
-          cancelLabel: 'No',
-        },
-      )
+    const shouldRestart = await ask(
+      'A restart is required to apply the settings.\nDo you want to restart now?',
+      {
+        title: 'Restart Confirmation',
+        kind: 'info',
+        okLabel: 'Yes',
+        cancelLabel: 'No',
+      },
+    )
 
-      if (shouldRestart) {
+    if (shouldRestart) {
+      if (process.env.NODE_ENV === 'production') {
         await relaunch()
       } else {
-        debug('[preferences] User cancelled the restart.')
-        await message(
-          'Settings saved.\nThey will take effect on the next launch.',
-          {
-            title: 'Preferences',
-            kind: 'info',
-          },
-        )
+        debug('[preferences] Relaunch skipped in development mode.')
       }
     } else {
-      debug('[preferences] Relaunch is not execute in development mode.')
+      debug('[preferences] User cancelled the restart.')
+      await message(
+        'Settings saved.\nThey will take effect on the next launch.',
+        {
+          title: 'Preferences',
+          kind: 'info',
+        },
+      )
     }
   }
 
@@ -268,30 +268,32 @@ export default function Page() {
     })()
   }
 
-  const handleLogSettingsSave = async (
+  const handleLogSettingsSave = (
     newSettings: LogSettings,
     newEffectiveDir: string,
   ) => {
     setLogDialogOpen(false)
-    let saved = false
-    try {
-      await invoke(LogSettingsAPI.SET_LOG_SETTINGS, { settings: newSettings })
-      debug(
-        `[preferences] invoke '${LogSettingsAPI.SET_LOG_SETTINGS}' succeeded`,
-      )
-      setLogSettings(newSettings)
-      setEffectiveLogDir(newEffectiveDir)
-      saved = true
-    } catch (err) {
-      error(`[preferences] Error setting log settings: ${err}`)
-      await message('Failed to save log settings', {
-        title: 'Preferences',
-        kind: 'error',
-      })
-    }
-    if (saved) {
-      await showRestartConfirmationDialog()
-    }
+    ;(async () => {
+      let saved = false
+      try {
+        await invoke(LogSettingsAPI.SET_LOG_SETTINGS, { settings: newSettings })
+        debug(
+          `[preferences] invoke '${LogSettingsAPI.SET_LOG_SETTINGS}' succeeded`,
+        )
+        setLogSettings(newSettings)
+        setEffectiveLogDir(newEffectiveDir)
+        saved = true
+      } catch (err) {
+        error(`[preferences] Error setting log settings: ${err}`)
+        await message('Failed to save log settings', {
+          title: 'Preferences',
+          kind: 'error',
+        })
+      }
+      if (saved) {
+        await showRestartConfirmationDialog()
+      }
+    })()
   }
 
   const handleOpenLatestLog = async () => {

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -38,6 +38,8 @@ import { ask, message, open as openOsDialog } from '@tauri-apps/plugin-dialog'
 import { debug, error } from '@tauri-apps/plugin-log'
 import { relaunch } from '@tauri-apps/plugin-process'
 
+// Fallback values matching backend defaults (log_settings.rs).
+// Overwritten immediately by GET_LOG_SETTINGS on mount.
 const DEFAULT_MAX_FILE_SIZE_BYTES = 1_048_576
 const DEFAULT_ROTATION_COUNT = 3
 
@@ -104,29 +106,24 @@ export default function Page() {
       }
 
       try {
-        const settings = await invoke<LogSettings>(
-          LogSettingsAPI.GET_LOG_SETTINGS,
-        )
+        const [settings, logDir] = await Promise.all([
+          invoke<LogSettings>(LogSettingsAPI.GET_LOG_SETTINGS),
+          invoke<string>(LogSettingsAPI.GET_LOG_DIR),
+        ])
         debug(
           `[preferences] invoke '${LogSettingsAPI.GET_LOG_SETTINGS}' response=${JSON.stringify(settings)}`,
         )
+        debug(
+          `[preferences] invoke '${LogSettingsAPI.GET_LOG_DIR}' response=${logDir}`,
+        )
         setLogSettings(settings)
+        setEffectiveLogDir(logDir)
       } catch (err) {
         error(`[preferences] Error getting log settings: ${err}`)
         await message('Failed to get log settings', {
           title: 'Preferences',
           kind: 'error',
         })
-      }
-
-      try {
-        const logDir = await invoke<string>(LogSettingsAPI.GET_LOG_DIR)
-        debug(
-          `[preferences] invoke '${LogSettingsAPI.GET_LOG_DIR}' response=${logDir}`,
-        )
-        setEffectiveLogDir(logDir)
-      } catch (err) {
-        error(`[preferences] Error getting log dir: ${err}`)
       }
     })()
 
@@ -390,7 +387,7 @@ export default function Page() {
             />
           </Box>
 
-          <Divider sx={{ height: '0.5px' }} />
+          <Divider sx={{ borderBottomWidth: '0.5px' }} />
 
           {/* Log section */}
           <Box>
@@ -472,6 +469,7 @@ export default function Page() {
               <LogSummaryRow label='Output Directory' value={effectiveLogDir} />
               <LogSummaryRow
                 label='Max File Size'
+                // Rounding is safe because validation enforces integer-MB values.
                 value={`${Math.round(logSettings.max_file_size / (1024 * 1024))} MB`}
               />
               <LogSummaryRow
@@ -579,11 +577,15 @@ function LogSettingsDialog({
     if (dialogOpen) {
       setDirInput(settings.output_dir)
       setLocalEffectiveDir(effectiveDir)
+      // Rounding is safe because validation enforces integer-MB values.
       setMaxSizeMBInput(
         String(Math.round(settings.max_file_size / (1024 * 1024))),
       )
       setRotationInput(String(settings.rotation_count))
     }
+    // Reset to parent's values only when the dialog opens.
+    // Omitting settings/effectiveDir from deps is intentional: including them
+    // would overwrite in-progress edits whenever the parent re-renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dialogOpen])
 
@@ -610,6 +612,7 @@ function LogSettingsDialog({
   }
 
   const handleSave = () => {
+    if (!dirty) return
     onSave(
       {
         output_dir: dirInput,
@@ -701,6 +704,8 @@ function LogSettingsDialog({
               }}
             >
               <Typography
+                component='span'
+                dir='ltr'
                 variant='caption'
                 sx={{
                   fontFamily: 'monospace',
@@ -709,7 +714,11 @@ function LogSettingsDialog({
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
+                  // rtl makes the path truncate from the left so the deepest
+                  // part of the path is always visible. dir='ltr' ensures
+                  // screen readers announce it left-to-right.
                   direction: 'rtl',
+                  unicodeBidi: 'bidi-override',
                   textAlign: 'left',
                 }}
               >
@@ -730,6 +739,9 @@ function LogSettingsDialog({
             value={maxSizeMBInput}
             onChange={(e) => setMaxSizeMBInput(e.target.value)}
             error={maxSizeMBInput !== '' && !isMaxSizeValid}
+            helperText={
+              maxSizeMBInput !== '' && !isMaxSizeValid ? '1 to 100 MB' : ' '
+            }
             slotProps={{
               input: {
                 endAdornment: (
@@ -756,6 +768,9 @@ function LogSettingsDialog({
             value={rotationInput}
             onChange={(e) => setRotationInput(e.target.value)}
             error={rotationInput !== '' && !isRotationValid}
+            helperText={
+              rotationInput !== '' && !isRotationValid ? '1 to 20 files' : ' '
+            }
             slotProps={{
               input: {
                 endAdornment: (

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -13,9 +13,17 @@ import { LogSettings, LogSettingsAPI } from '@/types/api/LogSettings'
 import { VisibleOnAllWorkspacesAPI } from '@/types/api/VisibleOnAllWorkspaces'
 import { WindowAPI } from '@/types/api/Window'
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import {
   Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
   IconButton,
   InputAdornment,
@@ -26,7 +34,7 @@ import {
 } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
-import { ask, message, open } from '@tauri-apps/plugin-dialog'
+import { ask, message, open as openOsDialog } from '@tauri-apps/plugin-dialog'
 import { debug, error } from '@tauri-apps/plugin-log'
 import { relaunch } from '@tauri-apps/plugin-process'
 
@@ -57,12 +65,7 @@ export default function Page() {
     rotation_count: DEFAULT_ROTATION_COUNT,
   })
   const [effectiveLogDir, setEffectiveLogDir] = useState<string>('')
-  const [logMaxFileSizeMBInput, setLogMaxFileSizeMBInput] = useState<string>(
-    String(DEFAULT_MAX_FILE_SIZE_BYTES / (1024 * 1024)),
-  )
-  const [logRotationCountInput, setLogRotationCountInput] = useState<string>(
-    String(DEFAULT_ROTATION_COUNT),
-  )
+  const [logDialogOpen, setLogDialogOpen] = useState<boolean>(false)
 
   useEffect(() => {
     ;(async () => {
@@ -108,10 +111,6 @@ export default function Page() {
           `[preferences] invoke '${LogSettingsAPI.GET_LOG_SETTINGS}' response=${JSON.stringify(settings)}`,
         )
         setLogSettings(settings)
-        setLogMaxFileSizeMBInput(
-          String(Math.round(settings.max_file_size / (1024 * 1024))),
-        )
-        setLogRotationCountInput(String(settings.rotation_count))
       } catch (err) {
         error(`[preferences] Error getting log settings: ${err}`)
         await message('Failed to get log settings', {
@@ -272,7 +271,11 @@ export default function Page() {
     })()
   }
 
-  const saveLogSettings = async (newSettings: LogSettings) => {
+  const handleLogSettingsSave = async (
+    newSettings: LogSettings,
+    newEffectiveDir: string,
+  ) => {
+    setLogDialogOpen(false)
     let saved = false
     try {
       await invoke(LogSettingsAPI.SET_LOG_SETTINGS, { settings: newSettings })
@@ -280,8 +283,7 @@ export default function Page() {
         `[preferences] invoke '${LogSettingsAPI.SET_LOG_SETTINGS}' succeeded`,
       )
       setLogSettings(newSettings)
-      const logDir = await invoke<string>(LogSettingsAPI.GET_LOG_DIR)
-      setEffectiveLogDir(logDir)
+      setEffectiveLogDir(newEffectiveDir)
       saved = true
     } catch (err) {
       error(`[preferences] Error setting log settings: ${err}`)
@@ -293,45 +295,6 @@ export default function Page() {
     if (saved) {
       await showRestartConfirmationDialog()
     }
-  }
-
-  const handleLogDirPick = async () => {
-    const dir = await open({ directory: true, multiple: false })
-    if (typeof dir === 'string') {
-      const newSettings: LogSettings = {
-        ...logSettings,
-        output_dir: dir,
-      }
-      await saveLogSettings(newSettings)
-    }
-  }
-
-  const handleLogMaxFileSizeBlur = async () => {
-    const mb = parseInt(logMaxFileSizeMBInput, 10)
-    if (isNaN(mb) || mb < 1 || mb > 100) {
-      setLogMaxFileSizeMBInput(
-        String(Math.round(logSettings.max_file_size / (1024 * 1024))),
-      )
-      return
-    }
-    const newSettings: LogSettings = {
-      ...logSettings,
-      max_file_size: mb * 1024 * 1024,
-    }
-    await saveLogSettings(newSettings)
-  }
-
-  const handleLogRotationCountBlur = async () => {
-    const count = parseInt(logRotationCountInput, 10)
-    if (isNaN(count) || count < 1 || count > 20) {
-      setLogRotationCountInput(String(logSettings.rotation_count))
-      return
-    }
-    const newSettings: LogSettings = {
-      ...logSettings,
-      rotation_count: count,
-    }
-    await saveLogSettings(newSettings)
   }
 
   const handleOpenLatestLog = async () => {
@@ -431,187 +394,107 @@ export default function Page() {
 
           {/* Log section */}
           <Box>
+            {/* Header row */}
             <Box
               sx={{
                 display: 'flex',
                 alignItems: 'center',
+                justifyContent: 'space-between',
                 gap: '8px',
-                mb: '8px',
+                mb: '6px',
               }}
             >
-              <RowDot />
-              <Typography variant='body2'>Log</Typography>
-            </Box>
-            <Box
-              sx={{
-                display: 'grid',
-                gridTemplateColumns: 'minmax(0, 1fr) 140px 110px',
-                gap: '10px',
-                pl: 2,
-              }}
-            >
-              {/* Output Directory */}
-              <Box>
-                <Typography
-                  variant='caption'
-                  sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
-                >
-                  Output Directory
-                </Typography>
-                <Box
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <RowDot />
+                <Typography variant='body2'>Log</Typography>
+                <Chip
+                  label='Restart Required'
+                  size='small'
                   sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '6px',
+                    height: 18,
+                    fontSize: '9.5px',
+                    fontFamily: 'monospace',
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                    backgroundColor: isDark
+                      ? 'rgba(255,180,80,0.10)'
+                      : 'rgba(180,120,0,0.07)',
+                    border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.28)' : 'rgba(180,120,0,0.22)'}`,
+                    color: isDark ? '#f5c46b' : '#8a6300',
+                    '& .MuiChip-label': { px: '6px' },
                   }}
-                >
-                  <Tooltip title='Choose directory'>
-                    <IconButton
-                      size='small'
-                      onClick={handleLogDirPick}
-                      sx={{
-                        width: 30,
-                        height: 30,
-                        borderRadius: '7px',
-                        flexShrink: 0,
-                        border: `0.5px solid ${theme.palette.divider}`,
-                        backgroundColor: isDark
-                          ? 'rgba(255,255,255,0.055)'
-                          : theme.palette.background.paper,
-                        '&:hover': {
-                          borderColor: theme.palette.primary.main,
-                          backgroundColor: isDark
-                            ? 'rgba(255,255,255,0.08)'
-                            : theme.palette.background.paper,
-                        },
-                      }}
-                    >
-                      <FolderOutlinedIcon sx={{ fontSize: 14 }} />
-                    </IconButton>
-                  </Tooltip>
-                  <Box
-                    title={effectiveLogDir}
+                />
+              </Box>
+              <Box sx={{ display: 'flex', gap: '4px' }}>
+                <Tooltip title='Open latest log file'>
+                  <IconButton
+                    size='small'
+                    onClick={handleOpenLatestLog}
+                    sx={{ color: 'text.secondary' }}
+                  >
+                    <ArticleOutlinedIcon sx={{ fontSize: 14 }} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title='Edit log settings'>
+                  <IconButton
+                    size='small'
+                    onClick={() => setLogDialogOpen(true)}
                     sx={{
-                      flex: 1,
-                      minWidth: 0,
+                      width: 28,
+                      height: 28,
+                      borderRadius: '7px',
+                      border: `0.5px solid ${theme.palette.divider}`,
                       backgroundColor: isDark
                         ? 'rgba(255,255,255,0.055)'
-                        : 'rgba(255,255,255,0.7)',
-                      border: `0.5px solid ${theme.palette.divider}`,
-                      borderRadius: '7px',
-                      px: '9px',
-                      py: '5px',
+                        : theme.palette.background.paper,
+                      color: 'text.secondary',
+                      '&:hover': {
+                        borderColor: theme.palette.primary.main,
+                        color: 'primary.main',
+                      },
                     }}
                   >
-                    <Typography
-                      variant='caption'
-                      sx={{
-                        fontFamily: 'monospace',
-                        display: 'block',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        direction: 'rtl',
-                        textAlign: 'left',
-                      }}
-                    >
-                      {effectiveLogDir}
-                    </Typography>
-                  </Box>
-                  <Tooltip title='Open latest log file'>
-                    <IconButton
-                      size='small'
-                      onClick={handleOpenLatestLog}
-                      sx={{
-                        flexShrink: 0,
-                        color: theme.palette.text.secondary,
-                        '&:hover': { color: theme.palette.text.primary },
-                      }}
-                    >
-                      <ArticleOutlinedIcon sx={{ fontSize: 15 }} />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
+                    <EditOutlinedIcon sx={{ fontSize: 13 }} />
+                  </IconButton>
+                </Tooltip>
               </Box>
+            </Box>
 
-              {/* Max File Size */}
-              <Box>
-                <Typography
-                  variant='caption'
-                  sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
-                >
-                  Max File Size
-                </Typography>
-                <TextField
-                  size='small'
-                  type='number'
-                  value={logMaxFileSizeMBInput}
-                  onChange={(e) => setLogMaxFileSizeMBInput(e.target.value)}
-                  onBlur={handleLogMaxFileSizeBlur}
-                  slotProps={{
-                    input: {
-                      endAdornment: (
-                        <InputAdornment position='end'>
-                          <Typography variant='caption' color='text.secondary'>
-                            MB
-                          </Typography>
-                        </InputAdornment>
-                      ),
-                    },
-                    htmlInput: { min: 1, max: 100 },
-                  }}
-                  sx={{
-                    width: '100%',
-                    '& .MuiInputBase-root': {
-                      fontFamily: 'monospace',
-                      fontSize: '12px',
-                    },
-                  }}
-                />
-              </Box>
-
-              {/* Rotation Count */}
-              <Box>
-                <Typography
-                  variant='caption'
-                  sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
-                >
-                  Rotation Count
-                </Typography>
-                <TextField
-                  size='small'
-                  type='number'
-                  value={logRotationCountInput}
-                  onChange={(e) => setLogRotationCountInput(e.target.value)}
-                  onBlur={handleLogRotationCountBlur}
-                  slotProps={{
-                    input: {
-                      endAdornment: (
-                        <InputAdornment position='end'>
-                          <Typography variant='caption' color='text.secondary'>
-                            files
-                          </Typography>
-                        </InputAdornment>
-                      ),
-                    },
-                    htmlInput: { min: 1, max: 20 },
-                  }}
-                  sx={{
-                    width: '100%',
-                    '& .MuiInputBase-root': {
-                      fontFamily: 'monospace',
-                      fontSize: '12px',
-                    },
-                  }}
-                />
-              </Box>
+            {/* Summary rows */}
+            <Box
+              sx={{
+                pl: 2,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '4px',
+              }}
+            >
+              <LogSummaryRow label='Output Directory' value={effectiveLogDir} />
+              <LogSummaryRow
+                label='Max File Size'
+                value={`${Math.round(logSettings.max_file_size / (1024 * 1024))} MB`}
+              />
+              <LogSummaryRow
+                label='Rotation Count'
+                value={`${logSettings.rotation_count} files`}
+              />
             </Box>
           </Box>
         </Box>
       </Stack>
+
+      <LogSettingsDialog
+        open={logDialogOpen}
+        settings={logSettings}
+        effectiveDir={effectiveLogDir}
+        onSave={handleLogSettingsSave}
+        onCancel={() => setLogDialogOpen(false)}
+      />
     </>
   )
 }
+
+// ─── Sub-components ───────────────────────────────────────────
 
 function RowDot() {
   const theme = useTheme()
@@ -626,5 +509,280 @@ function RowDot() {
         flexShrink: 0,
       }}
     />
+  )
+}
+
+function LogSummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Box
+      sx={{ display: 'flex', alignItems: 'baseline', gap: '8px', minWidth: 0 }}
+    >
+      <Typography
+        variant='caption'
+        sx={{
+          flexShrink: 0,
+          width: 110,
+          fontWeight: 500,
+          color: 'text.secondary',
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant='caption'
+        title={value}
+        sx={{
+          fontFamily: 'monospace',
+          color: 'text.primary',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+          flex: 1,
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  )
+}
+
+type LogSettingsDialogProps = {
+  open: boolean
+  settings: LogSettings
+  effectiveDir: string
+  onSave: (newSettings: LogSettings, newEffectiveDir: string) => void
+  onCancel: () => void
+}
+
+function LogSettingsDialog({
+  open: dialogOpen,
+  settings,
+  effectiveDir,
+  onSave,
+  onCancel,
+}: LogSettingsDialogProps) {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const [dirInput, setDirInput] = useState<string | null>(settings.output_dir)
+  const [localEffectiveDir, setLocalEffectiveDir] =
+    useState<string>(effectiveDir)
+  const [maxSizeMBInput, setMaxSizeMBInput] = useState<string>(
+    String(Math.round(settings.max_file_size / (1024 * 1024))),
+  )
+  const [rotationInput, setRotationInput] = useState<string>(
+    String(settings.rotation_count),
+  )
+
+  useEffect(() => {
+    if (dialogOpen) {
+      setDirInput(settings.output_dir)
+      setLocalEffectiveDir(effectiveDir)
+      setMaxSizeMBInput(
+        String(Math.round(settings.max_file_size / (1024 * 1024))),
+      )
+      setRotationInput(String(settings.rotation_count))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dialogOpen])
+
+  const parsedMaxSize = parseInt(maxSizeMBInput, 10)
+  const parsedRotation = parseInt(rotationInput, 10)
+  const isMaxSizeValid =
+    !isNaN(parsedMaxSize) && parsedMaxSize >= 1 && parsedMaxSize <= 100
+  const isRotationValid =
+    !isNaN(parsedRotation) && parsedRotation >= 1 && parsedRotation <= 20
+
+  const dirty =
+    isMaxSizeValid &&
+    isRotationValid &&
+    (dirInput !== settings.output_dir ||
+      parsedMaxSize * 1024 * 1024 !== settings.max_file_size ||
+      parsedRotation !== settings.rotation_count)
+
+  const handleDirPick = async () => {
+    const picked = await openOsDialog({ directory: true, multiple: false })
+    if (typeof picked === 'string') {
+      setDirInput(picked)
+      setLocalEffectiveDir(picked)
+    }
+  }
+
+  const handleSave = () => {
+    onSave(
+      {
+        output_dir: dirInput,
+        max_file_size: parsedMaxSize * 1024 * 1024,
+        rotation_count: parsedRotation,
+      },
+      localEffectiveDir,
+    )
+  }
+
+  return (
+    <Dialog open={dialogOpen} onClose={onCancel} maxWidth='xs' fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>Log Settings</DialogTitle>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {/* Restart-required notice */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '9px',
+            p: '9px 11px',
+            backgroundColor: isDark
+              ? 'rgba(255,180,80,0.08)'
+              : 'rgba(180,120,0,0.06)',
+            border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.30)' : 'rgba(180,120,0,0.22)'}`,
+            borderRadius: '8px',
+          }}
+        >
+          <InfoOutlinedIcon
+            sx={{
+              fontSize: 14,
+              mt: '1px',
+              flexShrink: 0,
+              color: isDark ? '#f5c46b' : '#a87a00',
+            }}
+          />
+          <Typography
+            variant='caption'
+            sx={{
+              lineHeight: 1.5,
+              color: isDark ? '#f5c46b' : '#8a6300',
+              fontSize: '11.5px',
+            }}
+          >
+            Log settings only take effect after restarting RightCheat.
+          </Typography>
+        </Box>
+
+        {/* Output Directory */}
+        <Box>
+          <Typography
+            variant='caption'
+            sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
+          >
+            Output Directory
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <Tooltip title='Choose directory'>
+              <IconButton
+                size='small'
+                onClick={handleDirPick}
+                sx={{
+                  width: 30,
+                  height: 30,
+                  borderRadius: '7px',
+                  flexShrink: 0,
+                  border: `0.5px solid ${theme.palette.divider}`,
+                  backgroundColor: isDark
+                    ? 'rgba(255,255,255,0.055)'
+                    : theme.palette.background.paper,
+                  '&:hover': { borderColor: theme.palette.primary.main },
+                }}
+              >
+                <FolderOutlinedIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Tooltip>
+            <Box
+              title={localEffectiveDir}
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                backgroundColor: isDark
+                  ? 'rgba(0,0,0,0.25)'
+                  : 'rgba(255,255,255,0.9)',
+                border: `0.5px solid ${theme.palette.divider}`,
+                borderRadius: '7px',
+                px: '10px',
+                py: '6px',
+              }}
+            >
+              <Typography
+                variant='caption'
+                sx={{
+                  fontFamily: 'monospace',
+                  fontSize: '11.5px',
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  direction: 'rtl',
+                  textAlign: 'left',
+                }}
+              >
+                {localEffectiveDir}
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+
+        {/* Max File Size + Rotation Count */}
+        <Box
+          sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}
+        >
+          <TextField
+            size='small'
+            type='number'
+            label='Max File Size'
+            value={maxSizeMBInput}
+            onChange={(e) => setMaxSizeMBInput(e.target.value)}
+            error={maxSizeMBInput !== '' && !isMaxSizeValid}
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position='end'>
+                    <Typography variant='caption' color='text.secondary'>
+                      MB
+                    </Typography>
+                  </InputAdornment>
+                ),
+              },
+              htmlInput: { min: 1, max: 100 },
+            }}
+            sx={{
+              '& .MuiInputBase-root': {
+                fontFamily: 'monospace',
+                fontSize: '12px',
+              },
+            }}
+          />
+          <TextField
+            size='small'
+            type='number'
+            label='Rotation Count'
+            value={rotationInput}
+            onChange={(e) => setRotationInput(e.target.value)}
+            error={rotationInput !== '' && !isRotationValid}
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position='end'>
+                    <Typography variant='caption' color='text.secondary'>
+                      files
+                    </Typography>
+                  </InputAdornment>
+                ),
+              },
+              htmlInput: { min: 1, max: 20 },
+            }}
+            sx={{
+              '& .MuiInputBase-root': {
+                fontFamily: 'monospace',
+                fontSize: '12px',
+              },
+            }}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={handleSave} disabled={!dirty} variant='contained'>
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
   )
 }

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -9,14 +9,29 @@ import { TITLEBAR_HEIGHT } from '@/constants/layout'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
 import { useThemeStore } from '@/hooks/useThemeStore'
 import { GlobalShortcutAPI, ShortcutDef } from '@/types/api/GlobalShortcut'
+import { LogSettings, LogSettingsAPI } from '@/types/api/LogSettings'
 import { VisibleOnAllWorkspacesAPI } from '@/types/api/VisibleOnAllWorkspaces'
 import { WindowAPI } from '@/types/api/Window'
-import { Box, Divider, Stack, Typography } from '@mui/material'
+import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined'
+import {
+  Box,
+  Divider,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
-import { ask, message } from '@tauri-apps/plugin-dialog'
+import { ask, message, open } from '@tauri-apps/plugin-dialog'
 import { debug, error } from '@tauri-apps/plugin-log'
 import { relaunch } from '@tauri-apps/plugin-process'
+
+const DEFAULT_MAX_FILE_SIZE_BYTES = 1_048_576
+const DEFAULT_ROTATION_COUNT = 3
 
 export default function Page() {
   const theme = useTheme()
@@ -35,6 +50,18 @@ export default function Page() {
 
   const [toggleVisibleShortcut, setToggleVisibleShortcut] =
     useState<ShortcutDef>()
+
+  const [logSettings, setLogSettings] = useState<LogSettings>({
+    output_dir: null,
+    max_file_size: DEFAULT_MAX_FILE_SIZE_BYTES,
+    rotation_count: DEFAULT_ROTATION_COUNT,
+  })
+  const [effectiveLogDir, setEffectiveLogDir] = useState<string>('')
+  const [logMaxFileSizeMBInput, setLogMaxFileSizeMBInput] =
+    useState<string>('1')
+  const [logRotationCountInput, setLogRotationCountInput] = useState<string>(
+    String(DEFAULT_ROTATION_COUNT),
+  )
 
   useEffect(() => {
     ;(async () => {
@@ -70,6 +97,36 @@ export default function Page() {
           title: 'Preferences',
           kind: 'error',
         })
+      }
+
+      try {
+        const settings = await invoke<LogSettings>(
+          LogSettingsAPI.GET_LOG_SETTINGS,
+        )
+        debug(
+          `[preferences] invoke '${LogSettingsAPI.GET_LOG_SETTINGS}' response=${JSON.stringify(settings)}`,
+        )
+        setLogSettings(settings)
+        setLogMaxFileSizeMBInput(
+          String(Math.round(settings.max_file_size / (1024 * 1024))),
+        )
+        setLogRotationCountInput(String(settings.rotation_count))
+      } catch (err) {
+        error(`[preferences] Error getting log settings: ${err}`)
+        await message('Failed to get log settings', {
+          title: 'Preferences',
+          kind: 'error',
+        })
+      }
+
+      try {
+        const logDir = await invoke<string>(LogSettingsAPI.GET_LOG_DIR)
+        debug(
+          `[preferences] invoke '${LogSettingsAPI.GET_LOG_DIR}' response=${logDir}`,
+        )
+        setEffectiveLogDir(logDir)
+      } catch (err) {
+        error(`[preferences] Error getting log dir: ${err}`)
       }
     })()
 
@@ -214,6 +271,85 @@ export default function Page() {
     })()
   }
 
+  const saveLogSettings = async (newSettings: LogSettings) => {
+    let saved = false
+    try {
+      await invoke(LogSettingsAPI.SET_LOG_SETTINGS, { settings: newSettings })
+      debug(
+        `[preferences] invoke '${LogSettingsAPI.SET_LOG_SETTINGS}' succeeded`,
+      )
+      setLogSettings(newSettings)
+      const logDir = await invoke<string>(LogSettingsAPI.GET_LOG_DIR)
+      setEffectiveLogDir(logDir)
+      saved = true
+    } catch (err) {
+      error(`[preferences] Error setting log settings: ${err}`)
+      await message('Failed to save log settings', {
+        title: 'Preferences',
+        kind: 'error',
+      })
+    }
+    if (saved) {
+      await showRestartConfirmationDialog()
+    }
+  }
+
+  const handleLogDirPick = async () => {
+    const dir = await open({ directory: true, multiple: false })
+    if (dir != null) {
+      const newSettings: LogSettings = {
+        ...logSettings,
+        output_dir: dir as string,
+      }
+      await saveLogSettings(newSettings)
+    }
+  }
+
+  const handleLogMaxFileSizeBlur = async () => {
+    const mb = parseInt(logMaxFileSizeMBInput, 10)
+    if (isNaN(mb) || mb < 1 || mb > 100) {
+      setLogMaxFileSizeMBInput(
+        String(Math.round(logSettings.max_file_size / (1024 * 1024))),
+      )
+      return
+    }
+    const newSettings: LogSettings = {
+      ...logSettings,
+      max_file_size: mb * 1024 * 1024,
+    }
+    await saveLogSettings(newSettings)
+  }
+
+  const handleLogRotationCountBlur = async () => {
+    const count = parseInt(logRotationCountInput, 10)
+    if (isNaN(count) || count < 1 || count > 20) {
+      setLogRotationCountInput(String(logSettings.rotation_count))
+      return
+    }
+    const newSettings: LogSettings = {
+      ...logSettings,
+      rotation_count: count,
+    }
+    await saveLogSettings(newSettings)
+  }
+
+  const handleOpenLatestLog = async () => {
+    try {
+      await invoke(LogSettingsAPI.OPEN_LATEST_LOG_FILE)
+      debug(
+        `[preferences] invoke '${LogSettingsAPI.OPEN_LATEST_LOG_FILE}' succeeded`,
+      )
+    } catch (err) {
+      error(`[preferences] Error opening latest log file: ${err}`)
+      await message('Failed to open log file', {
+        title: 'Preferences',
+        kind: 'error',
+      })
+    }
+  }
+
+  const isDark = theme.palette.mode === 'dark'
+
   return (
     <>
       <Box
@@ -258,14 +394,236 @@ export default function Page() {
         </Stack>
         <Divider />
         <Typography variant='body1'>Other Settings</Typography>
-        <Stack direction='row' px={1} spacing={1} alignItems='center'>
-          <Typography variant='body1'>Visible on all workspaces</Typography>
-          <ThemedSwitch
-            checked={visibleOnAllWorkspaces}
-            onChange={handleVisibleOnAllWorkspacesChange}
-          />
-        </Stack>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '14px',
+            p: '12px 14px',
+            backgroundColor: isDark
+              ? 'rgba(255,255,255,0.025)'
+              : 'rgba(255,255,255,0.35)',
+            border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.6)'}`,
+            borderRadius: '10px',
+            boxShadow: isDark ? 'none' : 'inset 0 1px 0 rgba(255,255,255,0.5)',
+          }}
+        >
+          {/* Visible on all workspaces */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <RowDot />
+              <Typography variant='body2'>Visible on all workspaces</Typography>
+            </Box>
+            <ThemedSwitch
+              checked={visibleOnAllWorkspaces}
+              onChange={handleVisibleOnAllWorkspacesChange}
+            />
+          </Box>
+
+          <Divider sx={{ height: '0.5px' }} />
+
+          {/* Log section */}
+          <Box>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                mb: '8px',
+              }}
+            >
+              <RowDot />
+              <Typography variant='body2'>Log</Typography>
+            </Box>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'minmax(0, 1fr) 140px 110px',
+                gap: '10px',
+                pl: 2,
+              }}
+            >
+              {/* Output Directory */}
+              <Box>
+                <Typography
+                  variant='caption'
+                  sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
+                >
+                  Output Directory
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  <Tooltip title='Choose directory'>
+                    <IconButton
+                      size='small'
+                      onClick={handleLogDirPick}
+                      sx={{
+                        width: 30,
+                        height: 30,
+                        borderRadius: '7px',
+                        flexShrink: 0,
+                        border: `0.5px solid ${theme.palette.divider}`,
+                        backgroundColor: isDark
+                          ? 'rgba(255,255,255,0.055)'
+                          : theme.palette.background.paper,
+                        '&:hover': {
+                          borderColor: theme.palette.primary.main,
+                          backgroundColor: isDark
+                            ? 'rgba(255,255,255,0.08)'
+                            : theme.palette.background.paper,
+                        },
+                      }}
+                    >
+                      <FolderOutlinedIcon sx={{ fontSize: 14 }} />
+                    </IconButton>
+                  </Tooltip>
+                  <Box
+                    title={effectiveLogDir}
+                    sx={{
+                      flex: 1,
+                      minWidth: 0,
+                      backgroundColor: isDark
+                        ? 'rgba(255,255,255,0.055)'
+                        : 'rgba(255,255,255,0.7)',
+                      border: `0.5px solid ${theme.palette.divider}`,
+                      borderRadius: '7px',
+                      px: '9px',
+                      py: '5px',
+                    }}
+                  >
+                    <Typography
+                      variant='caption'
+                      sx={{
+                        fontFamily: 'monospace',
+                        display: 'block',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        direction: 'rtl',
+                        textAlign: 'left',
+                      }}
+                    >
+                      {effectiveLogDir}
+                    </Typography>
+                  </Box>
+                  <Tooltip title='Open latest log file'>
+                    <IconButton
+                      size='small'
+                      onClick={handleOpenLatestLog}
+                      sx={{
+                        flexShrink: 0,
+                        color: theme.palette.text.secondary,
+                        '&:hover': { color: theme.palette.text.primary },
+                      }}
+                    >
+                      <ArticleOutlinedIcon sx={{ fontSize: 15 }} />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              </Box>
+
+              {/* Max File Size */}
+              <Box>
+                <Typography
+                  variant='caption'
+                  sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
+                >
+                  Max File Size
+                </Typography>
+                <TextField
+                  size='small'
+                  type='number'
+                  value={logMaxFileSizeMBInput}
+                  onChange={(e) => setLogMaxFileSizeMBInput(e.target.value)}
+                  onBlur={handleLogMaxFileSizeBlur}
+                  slotProps={{
+                    input: {
+                      endAdornment: (
+                        <InputAdornment position='end'>
+                          <Typography variant='caption' color='text.secondary'>
+                            MB
+                          </Typography>
+                        </InputAdornment>
+                      ),
+                    },
+                    htmlInput: { min: 1, max: 100 },
+                  }}
+                  sx={{
+                    width: '100%',
+                    '& .MuiInputBase-root': {
+                      fontFamily: 'monospace',
+                      fontSize: '12px',
+                    },
+                  }}
+                />
+              </Box>
+
+              {/* Rotation Count */}
+              <Box>
+                <Typography
+                  variant='caption'
+                  sx={{ display: 'block', mb: '6px', fontWeight: 500 }}
+                >
+                  Rotation Count
+                </Typography>
+                <TextField
+                  size='small'
+                  type='number'
+                  value={logRotationCountInput}
+                  onChange={(e) => setLogRotationCountInput(e.target.value)}
+                  onBlur={handleLogRotationCountBlur}
+                  slotProps={{
+                    input: {
+                      endAdornment: (
+                        <InputAdornment position='end'>
+                          <Typography variant='caption' color='text.secondary'>
+                            files
+                          </Typography>
+                        </InputAdornment>
+                      ),
+                    },
+                    htmlInput: { min: 1, max: 20 },
+                  }}
+                  sx={{
+                    width: '100%',
+                    '& .MuiInputBase-root': {
+                      fontFamily: 'monospace',
+                      fontSize: '12px',
+                    },
+                  }}
+                />
+              </Box>
+            </Box>
+          </Box>
+        </Box>
       </Stack>
     </>
+  )
+}
+
+function RowDot() {
+  const theme = useTheme()
+  return (
+    <Box
+      sx={{
+        width: 4,
+        height: 4,
+        borderRadius: '50%',
+        backgroundColor: theme.palette.primary.main,
+        opacity: 0.7,
+        flexShrink: 0,
+      }}
+    />
   )
 }

--- a/src/types/api/LogSettings.ts
+++ b/src/types/api/LogSettings.ts
@@ -1,0 +1,12 @@
+export type LogSettings = {
+  output_dir: string | null
+  max_file_size: number
+  rotation_count: number
+}
+
+export const LogSettingsAPI = {
+  GET_LOG_SETTINGS: 'get_log_settings',
+  SET_LOG_SETTINGS: 'set_log_settings',
+  OPEN_LATEST_LOG_FILE: 'open_latest_log_file',
+  GET_LOG_DIR: 'get_log_dir',
+} as const


### PR DESCRIPTION
## Summary

- Preferences画面の「Other Settings」セクションにログ設定（Log）サブセクションを追加
- ログ出力ディレクトリ・最大ファイルサイズ（MB）・ローテーション保持数を設定可能に
- 最新ログファイルをデフォルトエディタで開くボタンを設置
- 設定は `tauri-plugin-store` 経由で永続化し、アプリ起動時に `tauri_plugin_log::Builder` へ反映
- Mockup v11 のデザインに合わせ「Other Settings」セクションにカード風スタイルを適用

## Changes

### Backend (Rust)
- `src-tauri/src/common.rs`: `LOG_SETTINGS` 設定キー追加
- `src-tauri/src/api/log_settings.rs` (新規): `LogSettings` struct、get/set/open/getDir コマンド、起動時ファイル直読み関数
- `src-tauri/src/api.rs`: `log_settings` モジュール登録
- `src-tauri/src/lib.rs`: 起動時にログ設定を読み込んでBuilderへ適用、コマンド登録、Preferencesウィンドウサイズ拡大 (520×420 → 580×560)

### Frontend (TypeScript/React)
- `src/types/api/LogSettings.ts` (新規): `LogSettings` 型定義と API 定数
- `src/app/preferences/page.tsx`: Log セクション UI 追加、「Other Settings」カード風スタイル適用

### Tests (Rust)
- `src-tauri/tests/api/log_settings.rs` (新規): 21テスト（get/set/init/シリアライズ）

## Test plan

- [x] `cargo test --verbose -- --test-threads=1` で全120テストがパスすること
- [x] Preferences画面でログ設定UIが表示されること
- [x] ディレクトリ選択ダイアログが開くこと
- [x] 最大ファイルサイズ・ローテーション数の数値入力が保存されること
- [x] 「Open latest log」ボタンでログファイルが開くこと
- [x] 設定変更後に再起動確認ダイアログが表示されること

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)