### PR TITLE
feat: コマンド全文検索 UI を実装する (#146)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,9 @@ Rust の慣習ではパッケージ名に小文字（`right-cheat`）を推奨�
 - `[useThemeStore]` - `src/hooks/useThemeStore.ts`
 - `[useFontSize]` - `src/hooks/useFontSize.ts`
 - `[useWindowSize]` - `src/hooks/useWindowSize.ts`
+- `[useCommandSearch]` - `src/hooks/useCommandSearch.ts`
 - `[page]` - `src/app/page.tsx`
+- `[search]` - `src/app/search/page.tsx`
 
 **バックエンド (Rust)**:
 - `[lib]` - `src-tauri/src/lib.rs`

--- a/src-tauri/src/common.rs
+++ b/src-tauri/src/common.rs
@@ -23,4 +23,5 @@ pub mod event {
     pub const THEME_CHANGED: &str = "theme_changed";
     pub const FONT_SIZE_CHANGED: &str = "font_size_changed";
     pub const WINDOW_FOCUSED: &str = "window_focused";
+    pub const OPEN_CHEAT_SHEET: &str = "open_cheat_sheet";
 }

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -1,5 +1,5 @@
 use crate::api::cheatsheet::{CheatSheet, Command, CommandGroup, CommandItem, WindowSize};
-use rusqlite::{params, Connection, Result};
+use rusqlite::{params, params_from_iter, types::ToSql, Connection, Result};
 
 pub struct CheatsheetRow {
     pub id: i64,
@@ -330,18 +330,38 @@ fn escape_like_query(query: &str) -> String {
     format!("%{}%", escaped)
 }
 
+/// クエリを空白で分割して検索語の一覧を得る（連続した空白・前後の空白は無視）。
+fn split_terms(query: &str) -> Vec<&str> {
+    query.split_whitespace().collect()
+}
+
 pub fn search_by_like(conn: &Connection, query: &str, limit: u32) -> Result<Vec<SearchRow>> {
-    let pattern = escape_like_query(query);
-    let mut stmt = conn.prepare(
+    let terms = split_terms(query);
+    // 各検索語ごとに description / command_text のいずれかに含まれることを条件とし、
+    // 語同士は AND で連結する（複数キーワードの絞り込み検索）。
+    let mut conditions = Vec::with_capacity(terms.len());
+    let mut bind: Vec<Box<dyn ToSql>> = Vec::with_capacity(terms.len() + 1);
+    for (i, term) in terms.iter().enumerate() {
+        let n = i + 1;
+        conditions.push(format!(
+            "(c.description LIKE ?{n} ESCAPE '\\' OR c.command_text LIKE ?{n} ESCAPE '\\')"
+        ));
+        bind.push(Box::new(escape_like_query(term)));
+    }
+    let limit_idx = terms.len() + 1;
+    bind.push(Box::new(limit));
+    let sql = format!(
         "SELECT c.id, c.cheatsheet_id, cs.title, COALESCE(c.description, ''), c.command_text
          FROM commands c
          JOIN cheatsheets cs ON c.cheatsheet_id = cs.id
-         WHERE c.description LIKE ?1 ESCAPE '\\' OR c.command_text LIKE ?1 ESCAPE '\\'
+         WHERE {}
          ORDER BY c.cheatsheet_id, c.sort_order
-         LIMIT ?2",
-    )?;
+         LIMIT ?{limit_idx}",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let results = stmt
-        .query_map(params![pattern, limit], |row| {
+        .query_map(params_from_iter(bind.iter()), |row| {
             Ok(SearchRow {
                 id: row.get(0)?,
                 cheatsheet_id: row.get(1)?,
@@ -355,8 +375,13 @@ pub fn search_by_like(conn: &Connection, query: &str, limit: u32) -> Result<Vec<
 }
 
 pub fn search_by_fts(conn: &Connection, query: &str, limit: u32) -> Result<Vec<SearchRow>> {
-    // Double-quote wrap for FTS5 phrase match; escape internal double quotes
-    let fts_query = format!("\"{}\"", query.replace('"', "\"\""));
+    // 各検索語をダブルクォートで囲んでフレーズ化し、空白で連結する。
+    // FTS5 では空白区切りのフレーズは暗黙の AND となるため複数キーワードの絞り込みになる。
+    let fts_query = split_terms(query)
+        .iter()
+        .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ");
     let mut stmt = conn.prepare(
         "SELECT c.id, c.cheatsheet_id, cs.title, COALESCE(c.description, ''), c.command_text
          FROM commands c
@@ -380,10 +405,13 @@ pub fn search_by_fts(conn: &Connection, query: &str, limit: u32) -> Result<Vec<S
 }
 
 pub fn search_commands(conn: &Connection, query: &str, limit: u32) -> Result<Vec<SearchRow>> {
-    if query.is_empty() {
+    let terms = split_terms(query);
+    if terms.is_empty() {
         return Ok(vec![]);
     }
-    if query.chars().count() >= 3 {
+    // 全ての検索語が 3 文字以上なら trigram FTS を使える。
+    // 1 つでも 3 文字未満の語があると FTS では一致しないため LIKE 検索にフォールバックする。
+    if terms.iter().all(|t| t.chars().count() >= 3) {
         search_by_fts(conn, query, limit)
     } else {
         search_by_like(conn, query, limit)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,25 +234,11 @@ fn menu_configuration<R: tauri::Runtime>(
             )?,
             &Submenu::with_items(
                 handle,
-                "Edit",
-                true,
-                &[
-                    &PredefinedMenuItem::undo(handle, Some("Undo"))?,
-                    &PredefinedMenuItem::redo(handle, Some("Redo"))?,
-                    &PredefinedMenuItem::separator(handle)?,
-                    &PredefinedMenuItem::cut(handle, Some("Cut"))?,
-                    &PredefinedMenuItem::copy(handle, Some("Copy"))?,
-                    &PredefinedMenuItem::paste(handle, Some("Paste"))?,
-                    &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
-                    &PredefinedMenuItem::separator(handle)?,
-                    &MenuItem::with_id(handle, "id_find", "Find...", true, Some("Cmd+F"))?,
-                ],
-            )?,
-            &Submenu::with_items(
-                handle,
                 "View ", // NOTE: デフォルトメニューにならないよう、Viewの後にスペースを入れている。
                 true,
                 &[
+                    &MenuItem::with_id(handle, "id_find", "Find...", true, Some("Cmd+F"))?,
+                    &PredefinedMenuItem::separator(handle)?,
                     &MenuItem::with_id(
                         handle,
                         "id_toggle_visible",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,22 @@ fn menu_configuration<R: tauri::Runtime>(
             )?,
             &Submenu::with_items(
                 handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(handle, Some("Undo"))?,
+                    &PredefinedMenuItem::redo(handle, Some("Redo"))?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &PredefinedMenuItem::cut(handle, Some("Cut"))?,
+                    &PredefinedMenuItem::copy(handle, Some("Copy"))?,
+                    &PredefinedMenuItem::paste(handle, Some("Paste"))?,
+                    &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &MenuItem::with_id(handle, "id_find", "Find...", true, Some("Cmd+F"))?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
                 "View ", // NOTE: デフォルトメニューにならないよう、Viewの後にスペースを入れている。
                 true,
                 &[
@@ -426,6 +442,25 @@ fn on_menu_event_configuration<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, 
             .title("Export Cheatsheets")
             .inner_size(480.0, 480.0)
             .min_inner_size(360.0, 320.0)
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            .build();
+        }
+        "id_find" => {
+            // 既に検索ウィンドウが開いている場合はフォーカスのみ移す
+            if let Some(win) = handle.get_webview_window("search") {
+                let _ = win.set_focus();
+                return;
+            }
+            let _ = tauri::webview::WebviewWindowBuilder::new(
+                handle,
+                "search",
+                tauri::WebviewUrl::App("/search".into()),
+            )
+            .title("Search")
+            .inner_size(600.0, 560.0)
+            .min_inner_size(600.0, 420.0)
+            .max_inner_size(600.0, 720.0)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .build();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -445,8 +445,7 @@ fn on_menu_event_configuration<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, 
             )
             .title("Search")
             .inner_size(600.0, 560.0)
-            .min_inner_size(600.0, 420.0)
-            .max_inner_size(600.0, 720.0)
+            .min_inner_size(480.0, 420.0)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .build();

--- a/src-tauri/tests/common.rs
+++ b/src-tauri/tests/common.rs
@@ -126,11 +126,19 @@ mod event_constants {
 
     // ブラックボックス: 同値分割 - 有効クラス① (WINDOW_FOCUSED が期待値と等しい)
     // ホワイトボックス: event::WINDOW_FOCUSED を参照するパス
-    // ※ 今回追加された新定数のテスト
     #[test]
     fn window_focused_has_expected_value() {
         // Act & Assert: 定数が期待する値と一致すること
         assert_eq!(event::WINDOW_FOCUSED, "window_focused");
+    }
+
+    // ブラックボックス: 同値分割 - 有効クラス① (OPEN_CHEAT_SHEET が期待値と等しい)
+    // ホワイトボックス: event::OPEN_CHEAT_SHEET を参照するパス
+    // ※ issue #146 (コマンド全文検索 UI) で追加された定数
+    #[test]
+    fn open_cheat_sheet_has_expected_value() {
+        // Act & Assert: 定数が期待する値と一致すること
+        assert_eq!(event::OPEN_CHEAT_SHEET, "open_cheat_sheet");
     }
 
     // ブラックボックス: 境界値分析 - 各定数が空文字列でないこと（最短境界）
@@ -158,6 +166,10 @@ mod event_constants {
             !event::WINDOW_FOCUSED.is_empty(),
             "WINDOW_FOCUSED は空文字列であってはならない"
         );
+        assert!(
+            !event::OPEN_CHEAT_SHEET.is_empty(),
+            "OPEN_CHEAT_SHEET は空文字列であってはならない"
+        );
     }
 
     // ブラックボックス: 同値分割 - 有効クラス② (event 定数同士が互いに異なる)
@@ -172,6 +184,7 @@ mod event_constants {
             event::THEME_CHANGED,
             event::FONT_SIZE_CHANGED,
             event::WINDOW_FOCUSED,
+            event::OPEN_CHEAT_SHEET,
         ];
 
         // Act: 重複チェック（O(n^2) だが定数数が少ないため許容）
@@ -216,6 +229,11 @@ mod event_constants {
             event::WINDOW_FOCUSED,
             event::WINDOW_FOCUSED.trim(),
             "WINDOW_FOCUSED に前後の空白が含まれていないこと"
+        );
+        assert_eq!(
+            event::OPEN_CHEAT_SHEET,
+            event::OPEN_CHEAT_SHEET.trim(),
+            "OPEN_CHEAT_SHEET に前後の空白が含まれていないこと"
         );
     }
 }

--- a/src-tauri/tests/db/repository.rs
+++ b/src-tauri/tests/db/repository.rs
@@ -410,6 +410,82 @@ fn like_search_escapes_special_chars() {
     assert_eq!(underscore_results[0].command_text, "echo file_name");
 }
 
+#[test]
+fn fts_search_multi_keyword_and() {
+    let conn = setup();
+    insert_sheet_with_commands(
+        &conn,
+        "MultiSheet",
+        &[
+            ("Commit changes", "git commit message"),
+            ("Show status", "git status"),
+        ],
+    );
+
+    // すべての語が3文字以上 → FTS。"git" AND "commit" の両方を含むコマンドのみヒット
+    let results = search_commands(&conn, "git commit", 100).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].command_text, "git commit message");
+
+    // 語順を入れ替えても結果は同じ（AND 検索）
+    let reversed = search_commands(&conn, "commit git", 100).unwrap();
+    assert_eq!(reversed.len(), 1);
+    assert_eq!(reversed[0].command_text, "git commit message");
+}
+
+#[test]
+fn fts_search_multi_keyword_across_columns() {
+    let conn = setup();
+    insert_sheet_with_commands(
+        &conn,
+        "CrossSheet",
+        &[("Push branch to remote", "git push origin")],
+    );
+
+    // 一方は description、もう一方は command_text に含まれる場合もヒットする
+    let results = search_commands(&conn, "branch origin", 100).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].command_text, "git push origin");
+}
+
+#[test]
+fn fts_search_multi_keyword_no_match_when_one_term_absent() {
+    let conn = setup();
+    insert_sheet_with_commands(&conn, "AbsentSheet", &[("Commit changes", "git commit")]);
+
+    // 片方の語が存在しなければ AND 条件によりヒットしない
+    let results = search_commands(&conn, "git deploy", 100).unwrap();
+    assert!(results.is_empty());
+}
+
+#[test]
+fn like_search_multi_keyword_and_with_short_term() {
+    let conn = setup();
+    insert_sheet_with_commands(
+        &conn,
+        "ShortSheet",
+        &[
+            ("List directory", "ls config"),
+            ("List all files", "ls -la"),
+        ],
+    );
+
+    // 2文字の語を含むため LIKE フォールバック。"ls" AND "config" の両方を含むもののみ
+    let results = search_commands(&conn, "ls config", 100).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].command_text, "ls config");
+}
+
+#[test]
+fn search_commands_whitespace_only_returns_empty() {
+    let conn = setup();
+    insert_sheet_with_commands(&conn, "WsSheet", &[("desc", "some command")]);
+
+    // 空白のみのクエリは検索語なしとみなして空配列を返す
+    let results = search_commands(&conn, "   ", 100).unwrap();
+    assert!(results.is_empty());
+}
+
 // ── 新規 CRUD API テスト ─────────────────────────────────────
 //
 // テスト対象: 以下の新規 repository.rs 関数

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,182 @@
+'use client'
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
+
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { emit } from '@tauri-apps/api/event'
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { debug, error as logError } from '@tauri-apps/plugin-log'
+
+import { Event } from '@/common'
+import { SearchBar } from '@/components/molecules/SearchBar'
+import { WindowTitleBar } from '@/components/molecules/WindowTitleBar'
+import { SearchResults } from '@/components/organisms/SearchResults'
+import { TITLEBAR_HEIGHT } from '@/constants/layout'
+import { useCommandSearch } from '@/hooks/useCommandSearch'
+import { CommandSearchResult } from '@/types/api/CheatSheet'
+
+const FONT_UI =
+  '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif'
+
+// コマンド全文検索ウィンドウ（RightCheat Mockup v16 / Search 画面に準拠）。
+export default function SearchPage() {
+  const theme = useTheme()
+  const { query, setQuery, debouncedQuery, results } = useCommandSearch('')
+  const [focusIdx, setFocusIdx] = useState(0)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // ヒットしたチートシート数
+  const sheetCount = useMemo(
+    () => new Set(results.map((r) => r.cheatsheet_title)).size,
+    [results],
+  )
+
+  // クエリ変更時はフォーカスを先頭へ
+  useEffect(() => {
+    setFocusIdx(0)
+  }, [debouncedQuery])
+
+  const closeWindow = async () => {
+    try {
+      await getCurrentWindow().close()
+    } catch (e) {
+      logError(`[search] close window error: ${String(e)}`)
+    }
+  }
+
+  // 選択したコマンドの属するチートシートをメインウィンドウに表示して閉じる
+  const openCheatSheet = async (hit: CommandSearchResult) => {
+    try {
+      await emit(Event.OPEN_CHEAT_SHEET, { title: hit.cheatsheet_title })
+      debug(`[search] open_cheat_sheet title='${hit.cheatsheet_title}'`)
+      const main = await WebviewWindow.getByLabel('main')
+      if (main) {
+        await main.show()
+        await main.setFocus()
+      }
+    } catch (e) {
+      logError(`[search] open_cheat_sheet error: ${String(e)}`)
+    }
+    await closeWindow()
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setFocusIdx((i) => Math.min(i + 1, results.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setFocusIdx((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const hit = results[focusIdx]
+      if (hit) void openCheatSheet(hit)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      void closeWindow()
+    }
+  }
+
+  return (
+    <>
+      <Box
+        data-tauri-drag-region
+        sx={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: `${TITLEBAR_HEIGHT}px`,
+          zIndex: 999,
+        }}
+      />
+      <WindowTitleBar title='Search' />
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: `calc(100vh - ${TITLEBAR_HEIGHT}px)`,
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <SearchBar
+          value={query}
+          onChange={setQuery}
+          onKeyDown={handleKeyDown}
+          inputRef={inputRef}
+        />
+
+        {/* Status row */}
+        <Box
+          sx={{
+            padding: '0 18px 8px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            minHeight: '18px',
+          }}
+        >
+          <Box
+            sx={{
+              fontFamily: FONT_UI,
+              fontSize: '11px',
+              color: theme.palette.text.secondary,
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+            }}
+          >
+            {debouncedQuery ? (
+              results.length > 0 ? (
+                <>
+                  <Box
+                    component='strong'
+                    sx={{ fontWeight: 600, color: theme.palette.text.primary }}
+                  >
+                    {results.length}
+                  </Box>
+                  {results.length === 1 ? ' result' : ' results'}
+                  <Box
+                    component='span'
+                    sx={{ color: theme.palette.text.disabled }}
+                  >
+                    ·
+                  </Box>
+                  <Box
+                    component='strong'
+                    sx={{ fontWeight: 600, color: theme.palette.text.primary }}
+                  >
+                    {sheetCount}
+                  </Box>
+                  {sheetCount === 1 ? ' cheatsheet' : ' cheatsheets'}
+                </>
+              ) : (
+                <Box
+                  component='span'
+                  sx={{ color: theme.palette.text.disabled }}
+                >
+                  No matches
+                </Box>
+              )
+            ) : (
+              <Box component='span' sx={{ color: theme.palette.text.disabled }}>
+                Type to search across all cheatsheets
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        <SearchResults
+          debouncedQuery={debouncedQuery}
+          results={results}
+          focusIdx={focusIdx}
+          onSelect={(hit) => void openCheatSheet(hit)}
+          onHover={setFocusIdx}
+        />
+      </Box>
+    </>
+  )
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -3,7 +3,7 @@ import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Box } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
-import { emit } from '@tauri-apps/api/event'
+import { emitTo } from '@tauri-apps/api/event'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { debug, error as logError } from '@tauri-apps/plugin-log'
@@ -45,20 +45,23 @@ export default function SearchPage() {
     }
   }
 
-  // 選択したコマンドの属するチートシートをメインウィンドウに表示して閉じる
+  // 選択したコマンドの属するチートシートをメインウィンドウに表示して閉じる。
+  // 失敗時はウィンドウを閉じず、エラーをログ出力するに留める。
   const openCheatSheet = async (hit: CommandSearchResult) => {
     try {
-      await emit(Event.OPEN_CHEAT_SHEET, { title: hit.cheatsheet_title })
+      await emitTo('main', Event.OPEN_CHEAT_SHEET, {
+        title: hit.cheatsheet_title,
+      })
       debug(`[search] open_cheat_sheet title='${hit.cheatsheet_title}'`)
       const main = await WebviewWindow.getByLabel('main')
       if (main) {
         await main.show()
         await main.setFocus()
       }
+      await getCurrentWindow().close()
     } catch (e) {
       logError(`[search] open_cheat_sheet error: ${String(e)}`)
     }
-    await closeWindow()
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -59,8 +59,11 @@ export default function SearchPage() {
     try {
       await emitTo('main', Event.OPEN_CHEAT_SHEET, {
         title: hit.cheatsheet_title,
+        commandId: hit.id,
       })
-      debug(`[search] open_cheat_sheet title='${hit.cheatsheet_title}'`)
+      debug(
+        `[search] open_cheat_sheet title='${hit.cheatsheet_title}' commandId=${hit.id}`,
+      )
       const main = await WebviewWindow.getByLabel('main')
       if (main) {
         await main.show()

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -25,6 +25,14 @@ export default function SearchPage() {
   const { query, setQuery, debouncedQuery, results } = useCommandSearch('')
   const [focusIdx, setFocusIdx] = useState(0)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  // IME 変換中フラグ。macOS の WKWebView では変換確定 Enter の keydown 時に
+  // nativeEvent.isComposing が false になることがあるため、compositionstart /
+  // compositionend で状態を自前管理する（確定 Enter の keydown は compositionend
+  // より前に発火するため、この ref はまだ true のまま）。
+  const isComposingRef = useRef(false)
+  // compositionend が keydown より先に発火する順序（この場合 isComposingRef は
+  // 既に false）に備え、確定直後の Enter をタイムスタンプでもガードする。
+  const lastCompositionEndAtRef = useRef(0)
 
   // ヒットしたチートシート数
   const sheetCount = useMemo(
@@ -67,7 +75,7 @@ export default function SearchPage() {
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     // IME 変換中（日本語入力など）のキー操作は無視する。
     // 変換確定の Enter で検索結果が開いてしまうのを防ぐ。
-    if (e.nativeEvent.isComposing) return
+    if (isComposingRef.current || e.nativeEvent.isComposing) return
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       setFocusIdx((i) => Math.min(i + 1, results.length - 1))
@@ -76,6 +84,8 @@ export default function SearchPage() {
       setFocusIdx((i) => Math.max(i - 1, 0))
     } else if (e.key === 'Enter') {
       e.preventDefault()
+      // 変換確定直後（compositionend 直後）の Enter は無視する
+      if (Date.now() - lastCompositionEndAtRef.current < 100) return
       const hit = results[focusIdx]
       if (hit) void openCheatSheet(hit)
     } else if (e.key === 'Escape') {
@@ -112,6 +122,13 @@ export default function SearchPage() {
           value={query}
           onChange={setQuery}
           onKeyDown={handleKeyDown}
+          onCompositionStart={() => {
+            isComposingRef.current = true
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false
+            lastCompositionEndAtRef.current = Date.now()
+          }}
           inputRef={inputRef}
         />
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -65,6 +65,9 @@ export default function SearchPage() {
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    // IME 変換中（日本語入力など）のキー操作は無視する。
+    // 変換確定の Enter で検索結果が開いてしまうのを防ぐ。
+    if (e.nativeEvent.isComposing) return
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       setFocusIdx((i) => Math.min(i + 1, results.length - 1))

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,6 +2,7 @@ export class Event {
   static readonly WINDOW_VISIABLE_TOGGLE = 'window_visible_toggle'
   static readonly RELOAD_CHEAT_SHEET = 'reload_cheat_sheet'
   static readonly WINDOW_FOCUSED = 'window_focused'
+  static readonly OPEN_CHEAT_SHEET = 'open_cheat_sheet'
   static readonly EDIT_COMMAND_READY = 'edit-command-ready'
   static readonly EDIT_COMMAND_INIT = 'edit-command-init'
   static readonly EDIT_COMMAND_SAVE = 'edit-command-save'

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -56,7 +56,7 @@ export const SearchBar = ({ value, onChange, onKeyDown, inputRef }: Props) => {
             onChange(e.target.value)
           }
           onKeyDown={onKeyDown}
-          placeholder='Search commands, descriptions, and cheatsheet names…'
+          placeholder='Search commands and descriptions…'
           autoFocus
           sx={{
             flex: 1,

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -36,19 +36,18 @@ export const SearchBar = ({ value, onChange, onKeyDown, inputRef }: Props) => {
             : 'inset 0 1px 0 rgba(255,255,255,0.9), 0 0 0 3px rgba(0,113,227,0.05)',
         }}
       >
-        <Box
-          component='svg'
+        <svg
           width='16'
           height='16'
           viewBox='0 0 24 24'
           fill='none'
           stroke='currentColor'
           strokeWidth='2.2'
-          sx={{ color: accentSolid, flexShrink: 0 }}
+          style={{ color: accentSolid, flexShrink: 0 }}
         >
           <circle cx='11' cy='11' r='8' />
           <line x1='21' y1='21' x2='16.65' y2='16.65' />
-        </Box>
+        </svg>
         <Box
           component='input'
           ref={inputRef}

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -8,12 +8,21 @@ type Props = {
   value: string
   onChange: (value: string) => void
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+  onCompositionStart?: () => void
+  onCompositionEnd?: () => void
   inputRef?: RefObject<HTMLInputElement | null>
 }
 
 // 検索入力欄（RightCheat Mockup v16 / Search 画面に準拠）。
 // 左に虫眼鏡アイコン、入力があるとき右端にクリアボタンを表示する。
-export const SearchBar = ({ value, onChange, onKeyDown, inputRef }: Props) => {
+export const SearchBar = ({
+  value,
+  onChange,
+  onKeyDown,
+  onCompositionStart,
+  onCompositionEnd,
+  inputRef,
+}: Props) => {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const accentSolid = isDark ? '#64b4ff' : '#0071e3'
@@ -56,6 +65,8 @@ export const SearchBar = ({ value, onChange, onKeyDown, inputRef }: Props) => {
             onChange(e.target.value)
           }
           onKeyDown={onKeyDown}
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
           placeholder='Search commands and descriptions…'
           autoFocus
           sx={{

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -1,0 +1,123 @@
+'use client'
+import { KeyboardEvent, RefObject } from 'react'
+
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+type Props = {
+  value: string
+  onChange: (value: string) => void
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+  inputRef?: RefObject<HTMLInputElement | null>
+}
+
+// 検索入力欄（RightCheat Mockup v16 / Search 画面に準拠）。
+// 左に虫眼鏡アイコン、入力があるとき右端にクリアボタンを表示する。
+export const SearchBar = ({ value, onChange, onKeyDown, inputRef }: Props) => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
+
+  return (
+    <Box sx={{ padding: '14px 16px 10px' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          background: isDark ? 'rgba(0,0,0,0.25)' : 'rgba(255,255,255,0.78)',
+          border: `0.5px solid ${
+            isDark ? 'rgba(100,180,255,0.30)' : 'rgba(0,113,227,0.25)'
+          }`,
+          borderRadius: '10px',
+          padding: '8px 12px',
+          boxShadow: isDark
+            ? 'inset 0 1px 0 rgba(0,0,0,0.30), 0 0 0 3px rgba(100,180,255,0.06)'
+            : 'inset 0 1px 0 rgba(255,255,255,0.9), 0 0 0 3px rgba(0,113,227,0.05)',
+        }}
+      >
+        <Box
+          component='svg'
+          width='16'
+          height='16'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2.2'
+          sx={{ color: accentSolid, flexShrink: 0 }}
+        >
+          <circle cx='11' cy='11' r='8' />
+          <line x1='21' y1='21' x2='16.65' y2='16.65' />
+        </Box>
+        <Box
+          component='input'
+          ref={inputRef}
+          value={value}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            onChange(e.target.value)
+          }
+          onKeyDown={onKeyDown}
+          placeholder='Search commands, descriptions, and cheatsheet names…'
+          autoFocus
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            background: 'none',
+            border: 'none',
+            outline: 'none',
+            fontFamily:
+              '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif',
+            fontSize: '15px',
+            fontWeight: 500,
+            color: theme.palette.text.primary,
+            caretColor: accentSolid,
+            '&::placeholder': {
+              color: theme.palette.text.secondary,
+              opacity: 0.7,
+            },
+          }}
+        />
+        {value && (
+          <Box
+            component='button'
+            type='button'
+            onClick={() => {
+              onChange('')
+              inputRef?.current?.focus()
+            }}
+            title='Clear'
+            aria-label='Clear search'
+            sx={{
+              background: isDark
+                ? 'rgba(255,255,255,0.10)'
+                : 'rgba(0,0,0,0.08)',
+              border: 'none',
+              borderRadius: '50%',
+              width: '18px',
+              height: '18px',
+              padding: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              flexShrink: 0,
+              color: isDark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.55)',
+            }}
+          >
+            <svg
+              width='9'
+              height='9'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='3'
+            >
+              <line x1='18' y1='6' x2='6' y2='18' />
+              <line x1='6' y1='6' x2='18' y2='18' />
+            </svg>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/molecules/SearchResultItem.tsx
+++ b/src/components/molecules/SearchResultItem.tsx
@@ -1,0 +1,275 @@
+'use client'
+import { Fragment, useState } from 'react'
+
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { CommandSearchResult } from '@/types/api/CheatSheet'
+import {
+  buildHighlights,
+  HighlightSpan,
+  snippetSpans,
+} from '@/utils/searchHighlight'
+
+const FONT_CODE = '"JetBrains Mono", "Fira Code", monospace'
+const FONT_UI =
+  '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif'
+
+// マッチ部分を <mark> で強調するインラインテキスト
+const HiText = ({
+  spans,
+  isDark,
+}: {
+  spans: HighlightSpan[]
+  isDark: boolean
+}) => (
+  <>
+    {spans.map((s, i) =>
+      s.match ? (
+        <Box
+          key={i}
+          component='mark'
+          sx={{
+            background: isDark
+              ? 'rgba(255,210,80,0.28)'
+              : 'rgba(255,200,40,0.42)',
+            color: 'inherit',
+            borderRadius: '2px',
+            padding: '0 1px',
+            boxShadow: isDark
+              ? 'inset 0 0 0 0.5px rgba(255,210,80,0.45)'
+              : 'inset 0 0 0 0.5px rgba(180,130,0,0.30)',
+            fontWeight: 'inherit',
+          }}
+        >
+          {s.text}
+        </Box>
+      ) : (
+        <Fragment key={i}>{s.text}</Fragment>
+      ),
+    )}
+  </>
+)
+
+// 所属チートシート名のピル（色付きドット + 名前）
+const SheetBadge = ({
+  name,
+  isDark,
+  focused,
+  accentSolid,
+}: {
+  name: string
+  isDark: boolean
+  focused: boolean
+  accentSolid: string
+}) => {
+  const theme = useTheme()
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '4px',
+        fontFamily: FONT_UI,
+        fontSize: '10.5px',
+        fontWeight: 500,
+        letterSpacing: '0.01em',
+        color: focused ? accentSolid : theme.palette.text.secondary,
+        background: focused
+          ? isDark
+            ? 'rgba(100,180,255,0.14)'
+            : 'rgba(0,113,227,0.08)'
+          : isDark
+            ? 'rgba(255,255,255,0.06)'
+            : 'rgba(255,255,255,0.60)',
+        border: `0.5px solid ${
+          focused
+            ? isDark
+              ? 'rgba(100,180,255,0.35)'
+              : 'rgba(0,113,227,0.28)'
+            : isDark
+              ? 'rgba(255,255,255,0.10)'
+              : 'rgba(0,0,0,0.08)'
+        }`,
+        borderRadius: '999px',
+        padding: '1.5px 8px 1.5px 6px',
+        flexShrink: 0,
+        whiteSpace: 'nowrap',
+        transition: 'all 0.14s',
+        boxShadow: !isDark ? 'inset 0 0.5px 0 rgba(255,255,255,0.7)' : 'none',
+      }}
+    >
+      <Box
+        sx={{
+          width: '6px',
+          height: '6px',
+          borderRadius: '50%',
+          background: focused ? accentSolid : theme.palette.text.disabled,
+          flexShrink: 0,
+          transition: 'background 0.14s',
+        }}
+      />
+      {name}
+    </Box>
+  )
+}
+
+type Props = {
+  hit: CommandSearchResult
+  query: string
+  focused: boolean
+  onClick: () => void
+  onHover: () => void
+}
+
+// 検索結果 1 行（説明 + SheetBadge + コマンドスニペット + ハイライト + ↵）
+export const SearchResultItem = ({
+  hit,
+  query,
+  focused,
+  onClick,
+  onHover,
+}: Props) => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
+  const [hov, setHov] = useState(false)
+
+  const descSpans = buildHighlights(hit.description || '', query)
+  const cmdSpans = snippetSpans(hit.command_text, query)
+  const active = focused || hov
+
+  return (
+    <Box
+      onMouseEnter={() => {
+        setHov(true)
+        onHover()
+      }}
+      onMouseLeave={() => setHov(false)}
+      onClick={onClick}
+      role='option'
+      aria-selected={focused}
+      sx={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '10px',
+        padding: '9px 12px 9px 14px',
+        cursor: 'pointer',
+        background: focused
+          ? isDark
+            ? 'rgba(100,180,255,0.10)'
+            : 'rgba(0,113,227,0.06)'
+          : hov
+            ? isDark
+              ? 'rgba(255,255,255,0.04)'
+              : 'rgba(255,255,255,0.55)'
+            : 'transparent',
+        borderLeft: `2.5px solid ${focused ? accentSolid : 'transparent'}`,
+        transition: 'background 0.1s, border-color 0.1s',
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '4px',
+        }}
+      >
+        {/* Row 1 — 説明 + SheetBadge */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+            minWidth: 0,
+          }}
+        >
+          <Box
+            component='span'
+            sx={{
+              fontFamily: FONT_UI,
+              fontSize: '13px',
+              fontWeight: 600,
+              color: theme.palette.text.primary,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
+            {hit.description ? (
+              <HiText spans={descSpans} isDark={isDark} />
+            ) : (
+              <Box
+                component='span'
+                sx={{
+                  color: theme.palette.text.disabled,
+                  fontWeight: 400,
+                  fontStyle: 'italic',
+                }}
+              >
+                (no description)
+              </Box>
+            )}
+          </Box>
+          <SheetBadge
+            name={hit.cheatsheet_title}
+            isDark={isDark}
+            focused={focused}
+            accentSolid={accentSolid}
+          />
+        </Box>
+
+        {/* Row 2 — コマンドスニペット */}
+        <Box
+          sx={{
+            fontFamily: FONT_CODE,
+            fontSize: '11.5px',
+            color: focused
+              ? theme.palette.text.primary
+              : theme.palette.text.secondary,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+            lineHeight: 1.45,
+            transition: 'color 0.14s',
+          }}
+        >
+          <HiText spans={cmdSpans} isDark={isDark} />
+        </Box>
+      </Box>
+
+      {/* フォーカス行の ↵ グリフ */}
+      <Box
+        sx={{
+          flexShrink: 0,
+          opacity: focused ? 0.85 : active ? 0.35 : 0,
+          transition: 'opacity 0.14s',
+          paddingTop: '6px',
+          color: focused ? accentSolid : theme.palette.text.disabled,
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <svg
+          width='13'
+          height='13'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2.2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        >
+          <polyline points='9 10 4 15 9 20' />
+          <path d='M20 4v7a4 4 0 0 1-4 4H4' />
+        </svg>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -97,6 +97,14 @@ export const CheatSheet = () => {
   const pinButtonRef = useRef<HTMLButtonElement>(null)
   const sheetSwitchRef = useRef<SheetSwitchButtonHandle>(null)
 
+  // 検索ウィンドウから指定されたコマンドへスクロール／フォーカスするための
+  // 保留中のコマンドID。データロード後の useEffect で消化する。
+  const pendingScrollCommandIdRef = useRef<number | null>(null)
+  // イベントリスナー内（クロージャが mount 時で固定される）から最新値を
+  // 参照するための ref。
+  const cheatSheetDataRef = useRef<CheatSheetData | undefined>(undefined)
+  const selectCheatSheetRef = useRef<string>('')
+
   const { loadCheatSheetTitles, loadCheatSheetData } = useCheatSheetLoader({
     setCheatSheetTitles,
     setCheatSheet,
@@ -186,20 +194,94 @@ export const CheatSheet = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectCheatSheet, loadCheatSheetData])
 
+  // イベントリスナーから最新の state を参照できるよう ref に同期する。
+  useEffect(() => {
+    cheatSheetDataRef.current = cheatSheetData
+  }, [cheatSheetData])
+  useEffect(() => {
+    selectCheatSheetRef.current = selectCheatSheet
+  }, [selectCheatSheet])
+
+  // 指定されたコマンドID（DBのコマンドID）の CommandField を画面中央へ
+  // スクロールし、フォーカスする。command / application タイプのみ対応。
+  const scrollToCommandById = useCallback((commandId: number) => {
+    const data = cheatSheetDataRef.current
+    if (!data || data.type === 'shortcut') return
+
+    // 通常モードの flatStartIndices と同仕様でフラットインデックスを算出する。
+    let flatIndex = -1
+    let acc = 0
+    for (const item of data.commandlist) {
+      if (isCommandGroupData(item)) {
+        for (const cmd of item.commandlist) {
+          if (cmd.id === commandId) {
+            flatIndex = acc
+            break
+          }
+          acc += 1
+        }
+      } else {
+        if (item.id === commandId) {
+          flatIndex = acc
+        }
+        acc += 1
+      }
+      if (flatIndex !== -1) break
+    }
+    if (flatIndex === -1) return
+
+    // 新しいデータの描画（ref 設定）が完了してから実行する。
+    requestAnimationFrame(() => {
+      const el = commandFieldRefs.current[flatIndex]
+      if (el) {
+        el.scrollIntoView({ block: 'center' })
+        el.focus()
+        debug(
+          `[CheatSheet] scroll/focus to command id=${commandId} index=${flatIndex}`,
+        )
+      }
+    })
+  }, [])
+
+  // チートシートデータ確定後、保留中のスクロール対象があれば消化する。
+  useEffect(() => {
+    if (!cheatSheetData) return
+    const pending = pendingScrollCommandIdRef.current
+    if (pending == null) return
+    pendingScrollCommandIdRef.current = null
+    scrollToCommandById(pending)
+  }, [cheatSheetData, scrollToCommandById])
+
   // ─── 検索ウィンドウからのチートシート切り替え ─────────────
   useEffect(() => {
     let cancelled = false
     let unlisten: (() => void) | undefined
     ;(async () => {
-      unlisten = await listen<{ title: string }>(
+      unlisten = await listen<{ title: string; commandId?: number }>(
         Event.OPEN_CHEAT_SHEET,
         (e) => {
           // 編集中は切り替えない（編集内容の消失を防ぐ）
           if (editModeRef.current) return
           const title = e.payload?.title
+          const commandId = e.payload?.commandId
           if (title) {
-            debug(`[CheatSheet] open_cheat_sheet: switch to '${title}'`)
-            setCheatSheet(title)
+            debug(
+              `[CheatSheet] open_cheat_sheet: switch to '${title}' commandId=${commandId}`,
+            )
+            if (typeof commandId === 'number') {
+              pendingScrollCommandIdRef.current = commandId
+            }
+            if (title === selectCheatSheetRef.current) {
+              // 既に同じシートが表示済み → 再ロードが走らず消化 effect が
+              // 発火しないため、その場で直接スクロール／フォーカスする。
+              const pending = pendingScrollCommandIdRef.current
+              if (pending != null) {
+                pendingScrollCommandIdRef.current = null
+                scrollToCommandById(pending)
+              }
+            } else {
+              setCheatSheet(title)
+            }
           }
         },
       )
@@ -212,7 +294,7 @@ export const CheatSheet = () => {
       cancelled = true
       unlisten?.()
     }
-  }, [])
+  }, [scrollToCommandById])
 
   // ─── 編集モード操作 ───────────────────────────────────────
   const enterEditMode = useCallback(async () => {

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -188,6 +188,7 @@ export const CheatSheet = () => {
 
   // ─── 検索ウィンドウからのチートシート切り替え ─────────────
   useEffect(() => {
+    let cancelled = false
     let unlisten: (() => void) | undefined
     ;(async () => {
       unlisten = await listen<{ title: string }>(
@@ -202,8 +203,13 @@ export const CheatSheet = () => {
           }
         },
       )
+      if (cancelled) {
+        unlisten()
+        unlisten = undefined
+      }
     })()
     return () => {
+      cancelled = true
       unlisten?.()
     }
   }, [])

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -186,6 +186,28 @@ export const CheatSheet = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectCheatSheet, loadCheatSheetData])
 
+  // ─── 検索ウィンドウからのチートシート切り替え ─────────────
+  useEffect(() => {
+    let unlisten: (() => void) | undefined
+    ;(async () => {
+      unlisten = await listen<{ title: string }>(
+        Event.OPEN_CHEAT_SHEET,
+        (e) => {
+          // 編集中は切り替えない（編集内容の消失を防ぐ）
+          if (editModeRef.current) return
+          const title = e.payload?.title
+          if (title) {
+            debug(`[CheatSheet] open_cheat_sheet: switch to '${title}'`)
+            setCheatSheet(title)
+          }
+        },
+      )
+    })()
+    return () => {
+      unlisten?.()
+    }
+  }, [])
+
   // ─── 編集モード操作 ───────────────────────────────────────
   const enterEditMode = useCallback(async () => {
     if (!cheatSheetData) return

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 
 import { Box } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
@@ -136,9 +136,9 @@ const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
       <Box sx={{ display: 'flex', gap: '2px' }}>
-        {chips.map((c, i) => (
+        {chips.map((c) => (
           <Box
-            key={i}
+            key={c}
             component='span'
             sx={{
               fontFamily: FONT_CODE,
@@ -198,10 +198,19 @@ export const SearchResults = ({
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const divider = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)'
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // キーボードで選択行が移動したとき、選択行をリスト表示域内へスクロールする
+  useEffect(() => {
+    if (results.length === 0) return
+    const el = listRef.current?.children[focusIdx] as HTMLElement | undefined
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [focusIdx, results])
 
   return (
     <>
       <Box
+        ref={listRef}
         role='listbox'
         sx={{
           flex: 1,

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -1,0 +1,255 @@
+'use client'
+import { Fragment } from 'react'
+
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { SearchResultItem } from '@/components/molecules/SearchResultItem'
+import { CommandSearchResult } from '@/types/api/CheatSheet'
+
+const FONT_CODE = '"JetBrains Mono", "Fira Code", monospace'
+const FONT_UI =
+  '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif'
+
+// 未入力 / 0 件のプレースホルダ
+const SearchPlaceholder = ({
+  kind,
+  query,
+}: {
+  kind: 'empty' | 'none'
+  query?: string
+}) => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
+  const empty = kind === 'empty'
+
+  return (
+    <Box
+      sx={{
+        padding: '32px 24px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '12px',
+        textAlign: 'center',
+      }}
+    >
+      <Box
+        sx={{
+          width: '44px',
+          height: '44px',
+          borderRadius: '50%',
+          background: isDark
+            ? 'rgba(100,180,255,0.10)'
+            : 'rgba(0,113,227,0.07)',
+          border: `0.5px solid ${
+            isDark ? 'rgba(100,180,255,0.22)' : 'rgba(0,113,227,0.16)'
+          }`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: accentSolid,
+        }}
+      >
+        {empty ? (
+          <svg
+            width='20'
+            height='20'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+          >
+            <circle cx='11' cy='11' r='8' />
+            <line x1='21' y1='21' x2='16.65' y2='16.65' />
+          </svg>
+        ) : (
+          <svg
+            width='20'
+            height='20'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+          >
+            <circle cx='11' cy='11' r='8' />
+            <line x1='21' y1='21' x2='16.65' y2='16.65' />
+            <line x1='8' y1='11' x2='14' y2='11' />
+          </svg>
+        )}
+      </Box>
+      <Box
+        sx={{
+          fontFamily: FONT_UI,
+          fontSize: '13px',
+          fontWeight: 600,
+          color: theme.palette.text.primary,
+        }}
+      >
+        {empty ? 'Search across all cheatsheets' : 'No matching commands'}
+      </Box>
+      <Box
+        sx={{
+          fontFamily: FONT_UI,
+          fontSize: '11.5px',
+          color: theme.palette.text.secondary,
+          maxWidth: '340px',
+          lineHeight: 1.55,
+        }}
+      >
+        {empty ? (
+          <Fragment>
+            Searches command text, descriptions, and cheatsheet names.
+            <br />
+            Use{' '}
+            <Box component='span' sx={{ fontFamily: FONT_CODE }}>
+              ↑↓
+            </Box>{' '}
+            to navigate,{' '}
+            <Box component='span' sx={{ fontFamily: FONT_CODE }}>
+              ↵
+            </Box>{' '}
+            to open the cheatsheet.
+          </Fragment>
+        ) : (
+          <Fragment>
+            No results match “
+            <Box
+              component='span'
+              sx={{ color: theme.palette.text.primary, fontFamily: FONT_CODE }}
+            >
+              {query}
+            </Box>
+            ”. Try a different keyword.
+          </Fragment>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+// キーチップ + ラベル（フッターのキーボードヒント）
+const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
+      <Box sx={{ display: 'flex', gap: '2px' }}>
+        {chips.map((c, i) => (
+          <Box
+            key={i}
+            component='span'
+            sx={{
+              fontFamily: FONT_CODE,
+              fontSize: '10px',
+              fontWeight: 500,
+              color: theme.palette.text.primary,
+              background: isDark
+                ? 'rgba(255,255,255,0.07)'
+                : 'rgba(255,255,255,0.78)',
+              border: `0.5px solid ${
+                isDark ? 'rgba(255,255,255,0.14)' : 'rgba(0,0,0,0.12)'
+              }`,
+              borderRadius: '4px',
+              padding: '1px 5px',
+              minWidth: '16px',
+              textAlign: 'center',
+              boxShadow: isDark
+                ? '0 1px 0 rgba(0,0,0,0.35)'
+                : '0 1px 0 rgba(0,0,30,0.08), inset 0 0.5px 0 rgba(255,255,255,0.9)',
+            }}
+          >
+            {c}
+          </Box>
+        ))}
+      </Box>
+      <Box
+        component='span'
+        sx={{
+          fontFamily: FONT_UI,
+          fontSize: '10.5px',
+          color: theme.palette.text.secondary,
+          letterSpacing: '0.01em',
+        }}
+      >
+        {label}
+      </Box>
+    </Box>
+  )
+}
+
+type Props = {
+  debouncedQuery: string
+  results: CommandSearchResult[]
+  focusIdx: number
+  onSelect: (hit: CommandSearchResult) => void
+  onHover: (idx: number) => void
+}
+
+// 結果リスト + プレースホルダ + フッター（キーボードヒント）
+export const SearchResults = ({
+  debouncedQuery,
+  results,
+  focusIdx,
+  onSelect,
+  onHover,
+}: Props) => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  const divider = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)'
+
+  return (
+    <>
+      <Box
+        role='listbox'
+        sx={{
+          flex: 1,
+          maxHeight: '420px',
+          minHeight: '240px',
+          overflowY: 'auto',
+          borderTop: `0.5px solid ${divider}`,
+          borderBottom: `0.5px solid ${divider}`,
+          background: isDark ? 'rgba(0,0,0,0.12)' : 'rgba(255,255,255,0.18)',
+          scrollbarWidth: 'thin',
+        }}
+      >
+        {!debouncedQuery ? (
+          <SearchPlaceholder kind='empty' />
+        ) : results.length === 0 ? (
+          <SearchPlaceholder kind='none' query={debouncedQuery} />
+        ) : (
+          results.map((hit, i) => (
+            <SearchResultItem
+              key={`${hit.id}-${i}`}
+              hit={hit}
+              query={debouncedQuery}
+              focused={i === focusIdx}
+              onHover={() => onHover(i)}
+              onClick={() => onSelect(hit)}
+            />
+          ))
+        )}
+      </Box>
+
+      {/* Footer — キーボードヒント */}
+      <Box
+        sx={{
+          padding: '8px 16px 12px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          background: isDark
+            ? 'rgba(255,255,255,0.018)'
+            : 'rgba(255,255,255,0.30)',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
+          <Hotkey chips={['↑', '↓']} label='Navigate' />
+          <Hotkey chips={['↵']} label='Open cheatsheet' />
+          <Hotkey chips={['esc']} label='Close' />
+        </Box>
+      </Box>
+    </>
+  )
+}

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -214,8 +214,7 @@ export const SearchResults = ({
         role='listbox'
         sx={{
           flex: 1,
-          maxHeight: '420px',
-          minHeight: '240px',
+          minHeight: 0,
           overflowY: 'auto',
           borderTop: `0.5px solid ${divider}`,
           borderBottom: `0.5px solid ${divider}`,

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -100,7 +100,7 @@ const SearchPlaceholder = ({
       >
         {empty ? (
           <Fragment>
-            Searches command text, descriptions, and cheatsheet names.
+            Searches command text and descriptions.
             <br />
             Use{' '}
             <Box component='span' sx={{ fontFamily: FONT_CODE }}>

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -100,7 +100,8 @@ const SearchPlaceholder = ({
       >
         {empty ? (
           <Fragment>
-            Searches command text and descriptions.
+            Searches command text and descriptions. Separate keywords with
+            spaces to narrow results.
             <br />
             Use{' '}
             <Box component='span' sx={{ fontFamily: FONT_CODE }}>

--- a/src/hooks/useCommandSearch.ts
+++ b/src/hooks/useCommandSearch.ts
@@ -1,0 +1,70 @@
+import { invoke } from '@tauri-apps/api/core'
+import { debug, error as logError } from '@tauri-apps/plugin-log'
+import { useEffect, useState } from 'react'
+
+import { CheatSheetAPI, CommandSearchResult } from '@/types/api/CheatSheet'
+
+const DEBOUNCE_MS = 150
+
+type UseCommandSearchResult = {
+  query: string
+  setQuery: (value: string) => void
+  debouncedQuery: string
+  results: CommandSearchResult[]
+  loading: boolean
+}
+
+// 入力を 150ms debounce してバックエンドの search_commands を呼び出すフック。
+// 検索範囲は全チートシート横断。ハイライトは呼び出し側で行う。
+export const useCommandSearch = (initialQuery = ''): UseCommandSearchResult => {
+  const [query, setQuery] = useState<string>(initialQuery)
+  const [debouncedQuery, setDebouncedQuery] = useState<string>(
+    initialQuery.trim(),
+  )
+  const [results, setResults] = useState<CommandSearchResult[]>([])
+  const [loading, setLoading] = useState<boolean>(false)
+
+  // 150ms debounce
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(query.trim()), DEBOUNCE_MS)
+    return () => clearTimeout(id)
+  }, [query])
+
+  // debounce 後にバックエンドを呼び出す
+  useEffect(() => {
+    let cancelled = false
+
+    if (!debouncedQuery) {
+      setResults([])
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    ;(async () => {
+      try {
+        const response = await invoke<CommandSearchResult[]>(
+          CheatSheetAPI.SEARCH_COMMANDS,
+          { query: debouncedQuery },
+        )
+        if (cancelled) return
+        debug(
+          `[useCommandSearch] search_commands query='${debouncedQuery}' hits=${response.length}`,
+        )
+        setResults(response)
+      } catch (e) {
+        if (cancelled) return
+        logError(`[useCommandSearch] search_commands error: ${String(e)}`)
+        setResults([])
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedQuery])
+
+  return { query, setQuery, debouncedQuery, results, loading }
+}

--- a/src/utils/searchHighlight.ts
+++ b/src/utils/searchHighlight.ts
@@ -1,0 +1,64 @@
+// 検索キーワードのハイライト用ユーティリティ。
+// RightCheat Mockup v16 の buildHighlights / snippetSpans を踏襲し、
+// FTS5 の highlight() / snippet() に相当する強調表示を UI 側で行う。
+
+export type HighlightSpan = {
+  text: string
+  match: boolean
+}
+
+// テキストとクエリからハイライト span 配列を生成する。
+// 大文字小文字を無視してマッチ部分を { text, match: true } として切り出す。
+export const buildHighlights = (
+  text: string,
+  query: string,
+): HighlightSpan[] => {
+  if (!query) return [{ text, match: false }]
+  const q = query.toLowerCase()
+  const lower = text.toLowerCase()
+  const out: HighlightSpan[] = []
+  let i = 0
+  while (i < text.length) {
+    const idx = lower.indexOf(q, i)
+    if (idx === -1) {
+      out.push({ text: text.slice(i), match: false })
+      break
+    }
+    if (idx > i) out.push({ text: text.slice(i, idx), match: false })
+    out.push({ text: text.slice(idx, idx + q.length), match: true })
+    i = idx + q.length
+  }
+  return out
+}
+
+// コマンド本文を最初のマッチ周辺で切り出してハイライト span を返す（FTS5 snippet() 相当）。
+// 複数行は 1 行に畳み込み、改行は ⏎ で表現する。
+export const snippetSpans = (
+  text: string,
+  query: string,
+  ctx = 48,
+): HighlightSpan[] => {
+  // 複数行はプレビュー用に 1 行へ畳み込む
+  const oneLine = text.replace(/\s*\n\s*/g, ' ⏎ ')
+  if (!query) {
+    const truncated =
+      oneLine.length > 140 ? oneLine.slice(0, 140) + '…' : oneLine
+    return [{ text: truncated, match: false }]
+  }
+  const idx = oneLine.toLowerCase().indexOf(query.toLowerCase())
+  if (idx === -1) {
+    const truncated =
+      oneLine.length > 140 ? oneLine.slice(0, 140) + '…' : oneLine
+    return buildHighlights(truncated, query)
+  }
+  const start = Math.max(0, idx - ctx)
+  const end = Math.min(oneLine.length, idx + query.length + ctx)
+  const trimmed = oneLine.slice(start, end)
+  const head = start > 0 ? '…' : ''
+  const tail = end < oneLine.length ? '…' : ''
+  // 省略記号はハイライト対象にしないため plain span として前後に付与する
+  const spans = buildHighlights(trimmed, query)
+  if (head) spans.unshift({ text: head, match: false })
+  if (tail) spans.push({ text: tail, match: false })
+  return spans
+}

--- a/src/utils/searchHighlight.ts
+++ b/src/utils/searchHighlight.ts
@@ -1,38 +1,58 @@
 // 検索キーワードのハイライト用ユーティリティ。
 // RightCheat Mockup v16 の buildHighlights / snippetSpans を踏襲し、
 // FTS5 の highlight() / snippet() に相当する強調表示を UI 側で行う。
+// クエリは空白区切りの複数キーワード（AND 検索）に対応する。
 
 export type HighlightSpan = {
   text: string
   match: boolean
 }
 
+// 正規表現で特別な意味を持つ文字をエスケープする。
+const escapeRegExp = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+// クエリを空白で分割して検索語の一覧を得る（空要素は除外）。
+const splitTerms = (query: string): string[] =>
+  query.split(/\s+/).filter(Boolean)
+
+// 複数キーワードにマッチする正規表現を生成する。
+// 長い語を優先してマッチさせるため、語の長さ降順で連結する。
+const buildTermRegExp = (terms: string[]): RegExp => {
+  const alts = terms
+    .slice()
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+  return new RegExp(`(${alts.join('|')})`, 'gi')
+}
+
 // テキストとクエリからハイライト span 配列を生成する。
-// 大文字小文字を無視してマッチ部分を { text, match: true } として切り出す。
+// 大文字小文字を無視して、いずれかの検索語にマッチする部分を
+// { text, match: true } として切り出す。
 export const buildHighlights = (
   text: string,
   query: string,
 ): HighlightSpan[] => {
-  if (!query) return [{ text, match: false }]
-  const q = query.toLowerCase()
-  const lower = text.toLowerCase()
+  const terms = splitTerms(query)
+  if (terms.length === 0) return [{ text, match: false }]
+  const re = buildTermRegExp(terms)
   const out: HighlightSpan[] = []
-  let i = 0
-  while (i < text.length) {
-    const idx = lower.indexOf(q, i)
-    if (idx === -1) {
-      out.push({ text: text.slice(i), match: false })
-      break
-    }
-    if (idx > i) out.push({ text: text.slice(i, idx), match: false })
-    out.push({ text: text.slice(idx, idx + q.length), match: true })
-    i = idx + q.length
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last)
+      out.push({ text: text.slice(last, m.index), match: false })
+    out.push({ text: m[0], match: true })
+    last = m.index + m[0].length
+    // ゼロ幅マッチによる無限ループを防止
+    if (m.index === re.lastIndex) re.lastIndex++
   }
+  if (last < text.length) out.push({ text: text.slice(last), match: false })
   return out
 }
 
 // コマンド本文を最初のマッチ周辺で切り出してハイライト span を返す（FTS5 snippet() 相当）。
-// 複数行は 1 行に畳み込み、改行は ⏎ で表現する。
+// 複数行は 1 行に畳み込み、改行は ⏎ で表現する。複数キーワードに対応する。
 export const snippetSpans = (
   text: string,
   query: string,
@@ -40,19 +60,27 @@ export const snippetSpans = (
 ): HighlightSpan[] => {
   // 複数行はプレビュー用に 1 行へ畳み込む
   const oneLine = text.replace(/\s*\n\s*/g, ' ⏎ ')
-  if (!query) {
-    const truncated =
-      oneLine.length > 140 ? oneLine.slice(0, 140) + '…' : oneLine
-    return [{ text: truncated, match: false }]
+  const terms = splitTerms(query)
+  const truncate = (s: string) => (s.length > 140 ? s.slice(0, 140) + '…' : s)
+  if (terms.length === 0) {
+    return [{ text: truncate(oneLine), match: false }]
   }
-  const idx = oneLine.toLowerCase().indexOf(query.toLowerCase())
+  // 最も先頭側に現れる検索語のマッチ位置を起点にスニペットを切り出す。
+  const lower = oneLine.toLowerCase()
+  let idx = -1
+  let matchLen = 0
+  for (const t of terms) {
+    const p = lower.indexOf(t.toLowerCase())
+    if (p !== -1 && (idx === -1 || p < idx)) {
+      idx = p
+      matchLen = t.length
+    }
+  }
   if (idx === -1) {
-    const truncated =
-      oneLine.length > 140 ? oneLine.slice(0, 140) + '…' : oneLine
-    return buildHighlights(truncated, query)
+    return buildHighlights(truncate(oneLine), query)
   }
   const start = Math.max(0, idx - ctx)
-  const end = Math.min(oneLine.length, idx + query.length + ctx)
+  const end = Math.min(oneLine.length, idx + matchLen + ctx)
   const trimmed = oneLine.slice(start, end)
   const head = start > 0 ? '…' : ''
   const tail = end < oneLine.length ? '…' : ''


### PR DESCRIPTION
## 概要

issue #146 のコマンド全文検索 UI を実装しました。UI デザインは `RightCheat Mockup v16.html` の Search 画面に忠実に準拠しています。

Closes #146

## 実装内容

### バックエンド (Rust)
- `src-tauri/src/common.rs`: シート切替イベント定数 `OPEN_CHEAT_SHEET` を追加
- `src-tauri/src/lib.rs`: **View** メニューの先頭に **Find...（⌘F）** を追加（直下に divider）し、`id_find` で `/search` ウィンドウ（幅600）を開く（既に開いている場合はフォーカスのみ）

### フロントエンド (TypeScript)
- `src/app/search/page.tsx`: 検索ウィンドウ本体（v16 `SearchCheatsheetsWindow` 相当）
- `src/components/molecules/SearchBar.tsx`: 入力欄 + 虫眼鏡 + クリアボタン
- `src/components/molecules/SearchResultItem.tsx`: 説明 + SheetBadge + コマンドスニペット + ハイライト + ↵グリフ
- `src/components/organisms/SearchResults.tsx`: 結果リスト + プレースホルダ + フッター
- `src/hooks/useCommandSearch.ts`: 150ms debounce + `search_commands` 呼び出し
- `src/utils/searchHighlight.ts`: `buildHighlights` / `snippetSpans`（ハイライトユーティリティ）
- `src/components/organisms/CheatSheet.tsx`: `OPEN_CHEAT_SHEET` リスナー追加 → 対象シートへ切替（編集中は無視）
- `src/common.ts`: `OPEN_CHEAT_SHEET` イベント追加

## 動作仕様

- メニュー **View ▸ Find...（⌘F）** から別ウィンドウで検索画面を開く
- 入力を 150ms debounce してバックエンド `search_commands` を呼び出し、**全チートシート横断**で検索
- 結果はマッチ箇所をハイライト表示。説明・コマンドスニペット・所属チートシート名（SheetBadge）を表示
- `↑↓` で結果移動、`Enter` で対象シートをメインウィンドウに表示して検索ウィンドウを閉じる、`Esc` で閉じる
- ステータス行に `N results · M cheatsheets` / `No matches` / `Type to search…` を表示
- 未入力・0件時のプレースホルダ、フッターのキーボードヒントを実装

## 対象外（issue 記載どおり）

- Recent（最近の検索）チップ
- クエリ所要時間（`12ms`）表示

## テスト

- `cargo test --verbose -- --test-threads=1`: **186 passed, 0 failed**（`OPEN_CHEAT_SHEET` 定数のテストを追加）
- `yarn lint`: パス
- `yarn build`: `/search` ルート含めビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
