### PR TITLE
fix: ピン留めシートで編集モード突入後に Esc が効かない不具合を修正する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { error } from '@tauri-apps/plugin-log'
 
 import { Event } from '@/common'
 import { CheatSheet } from '@/components/organisms/CheatSheet'
+import { FOCUS_FALLBACK_ID } from '@/constants/focus'
 import { useNotificationContext } from '@/context/NotificationContext'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
 
@@ -74,6 +75,11 @@ export default function Home() {
         ) {
           focused.blur()
           focused.focus()
+        } else {
+          // フォーカス可能な要素が無い場合（編集モード突入直後など activeElement が
+          // body に戻っているケース）でも、ルートに常設したフォールバック要素へ
+          // フォーカスして WKWebView の native first responder を取り戻す。
+          document.getElementById(FOCUS_FALLBACK_ID)?.focus()
         }
       })
       if (cancelled) {

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -28,6 +28,7 @@ import { ShortcutField } from '@/components/molecules/ShortcutField'
 import { ShortcutGroup } from '@/components/molecules/ShortcutGroup'
 import { WindowTitleBar } from '@/components/molecules/WindowTitleBar'
 import { RcDialog } from '@/components/organisms/RcDialog'
+import { FOCUS_FALLBACK_ID } from '@/constants/focus'
 import { TITLEBAR_HEIGHT } from '@/constants/layout'
 import { useNotificationContext } from '@/context/NotificationContext'
 import { useCheatSheetLoader } from '@/hooks/useCheatSheetLoader'
@@ -882,6 +883,23 @@ export const CheatSheet = () => {
         height: '100%',
       }}
     >
+      {/* ウィンドウ操作（setResizable / setSize）後に WKWebView の native
+          first responder を取り戻すためのフォールバックフォーカス要素。
+          Tab では到達せず、フォーカス可能な要素が無いときの focus 退避先となる。 */}
+      <Box
+        id={FOCUS_FALLBACK_ID}
+        tabIndex={-1}
+        aria-hidden
+        sx={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: 0,
+          height: 0,
+          outline: 'none',
+        }}
+      />
+
       {/* ドラッグ領域 */}
       <Box
         data-tauri-drag-region

--- a/src/constants/focus.ts
+++ b/src/constants/focus.ts
@@ -1,0 +1,4 @@
+// ウィンドウ操作（setResizable / setSize）で WKWebView が native first responder を
+// 失った際、フォーカス可能な要素が無くても復元できるよう、ルートに常設する
+// フォールバックフォーカス要素の id。
+export const FOCUS_FALLBACK_ID = 'rc-focus-fallback'

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -9,6 +9,7 @@ import {
 } from '@tauri-apps/api/window'
 import { debug, error as logError } from '@tauri-apps/plugin-log'
 
+import { FOCUS_FALLBACK_ID } from '@/constants/focus'
 import { useNotificationContext } from '@/context/NotificationContext'
 import { WindowSizeAPI, WindowSizeSettings } from '@/types/api/WindowSize'
 
@@ -39,6 +40,14 @@ const restoreFocusAfterWindowOp = async (): Promise<void> => {
   if (target) {
     target.blur()
     target.focus()
+  } else {
+    // フォーカス可能な要素が無い場合（通常表示や編集モード突入直後は
+    // activeElement が body に戻る）でも、ルートに常設したフォールバック要素へ
+    // フォーカスして WKWebView の native first responder を取り戻す。
+    // setFocus() 単独では first responder が復元されず、以降のキーイベント
+    // （Esc など）が document に届かずネイティブのビープ音だけ鳴るため。
+    const fallback = document.getElementById(FOCUS_FALLBACK_ID)
+    fallback?.focus()
   }
 }
 


### PR DESCRIPTION
## 概要

ピン留めされたチートシートで `e` キーから編集モードに入ると、`Esc` を押しても編集モードを抜けられず、ビープ音だけが鳴る不具合を修正します。

## 原因

1. `Esc` は `CheatSheet.tsx` の `document` への `keydown` リスナーで拾っており、発火には WKWebView がキー入力の first responder である必要がある。
2. ピン留め中のシートで編集モードに入ると `editMode` 変化により `useWindowSize` が `setResizable(true)` を実行する。
3. `setResizable()` は macOS の `NSWindow.styleMask` を変更するため WKWebView が native first responder を失う。
4. 復旧を担う `restoreFocusAfterWindowOp()` は「現在フォーカスされている DOM 要素」を `blur()→focus()` して first responder を取り戻す設計だが、編集モード突入直後は `activeElement` が `body` に戻っており復旧が no-op になる。
5. 結果として webview がキー入力を受け取れず、`Esc` が `document` に届かずネイティブのビープ音だけが鳴っていた。

※ 非ピン留めシートでは `setResizable` が走らないため再現しない（＝「ことがある」不具合だった）。

## 修正内容

- `src/constants/focus.ts`（新規）: フォールバック要素の id 定数 `FOCUS_FALLBACK_ID` を追加。
- `src/components/organisms/CheatSheet.tsx`: ルートに `tabIndex={-1}` / `aria-hidden` の不可視フォールバックフォーカス要素を常設（Tab ナビゲーションには現れない）。
- `src/hooks/useWindowSize.ts`: `restoreFocusAfterWindowOp()` でフォーカス対象が無いとき、フォールバック要素へ `focus()` して WKWebView の first responder を確実に取り戻すようにした。
- `src/app/page.tsx`: 同じ根本問題を抱える `WINDOW_FOCUSED` ハンドラー（Command+Tab 復帰時）にも同様のフォールバックを追加（コードレビュー指摘対応）。

## 確認

- `yarn tsc --noEmit` / `yarn lint:eslint` 通過。
- 動作確認: ピン留めしたシートで `e` → `Esc` で編集モードを抜けられること（ビープが鳴らないこと）。

## コードレビュー

`code-reviewer-jp` によるレビュー実施済み。重大な問題なし。指摘された `page.tsx` の `WINDOW_FOCUSED` ハンドラー同種問題は本PRに取り込み済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)