### PR TITLE
fix: フォントサイズ変更が機能しない問題を修正する

### DIFF
--- a/src/app/edit-cheatsheets/page.tsx
+++ b/src/app/edit-cheatsheets/page.tsx
@@ -253,7 +253,7 @@ function TypeBadge({
           borderRadius: 999,
           padding: '2px 8px 2px 7px',
           fontFamily: theme.typography.fontFamily,
-          fontSize: 9.5,
+          fontSize: 'calc(9.5px * var(--font-scale))',
           fontWeight: 600,
           letterSpacing: '0.06em',
           textTransform: 'uppercase',
@@ -344,7 +344,7 @@ function TypeBadge({
           >
             <div
               style={{
-                fontSize: 9.5,
+                fontSize: 'calc(9.5px * var(--font-scale))',
                 fontWeight: 600,
                 color: isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
                 letterSpacing: '0.12em',
@@ -409,7 +409,7 @@ function TypeBadge({
                   <span style={{ flex: 1, minWidth: 0 }}>
                     <div
                       style={{
-                        fontSize: 12.5,
+                        fontSize: 'calc(12.5px * var(--font-scale))',
                         fontWeight: 500,
                         color: isDark
                           ? 'rgba(255,255,255,0.92)'
@@ -420,7 +420,7 @@ function TypeBadge({
                     </div>
                     <div
                       style={{
-                        fontSize: 10.5,
+                        fontSize: 'calc(10.5px * var(--font-scale))',
                         color: isDark
                           ? 'rgba(255,255,255,0.45)'
                           : 'rgba(0,0,0,0.45)',
@@ -538,7 +538,7 @@ function LayoutBadge({
           borderRadius: 6,
           padding: '2px 6px',
           fontFamily: theme.typography.fontFamily,
-          fontSize: 11,
+          fontSize: 'calc(11px * var(--font-scale))',
           fontWeight: 500,
           color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
           cursor: locked ? 'default' : 'pointer',
@@ -564,7 +564,7 @@ function LayoutBadge({
         <span
           style={{
             fontFamily: '"JetBrains Mono","Fira Code","SF Mono",monospace',
-            fontSize: 10.5,
+            fontSize: 'calc(10.5px * var(--font-scale))',
             color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
             letterSpacing: '0.01em',
             flex: 1,
@@ -637,7 +637,7 @@ function LayoutBadge({
           >
             <div
               style={{
-                fontSize: 9.5,
+                fontSize: 'calc(9.5px * var(--font-scale))',
                 fontWeight: 600,
                 color: isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
                 letterSpacing: '0.12em',
@@ -712,7 +712,7 @@ function LayoutBadge({
                       style={{
                         fontFamily:
                           '"JetBrains Mono","Fira Code","SF Mono",monospace',
-                        fontSize: 12,
+                        fontSize: 'calc(12px * var(--font-scale))',
                         fontWeight: 500,
                         color: isDark
                           ? 'rgba(255,255,255,0.92)'
@@ -723,7 +723,7 @@ function LayoutBadge({
                     </div>
                     <div
                       style={{
-                        fontSize: 10.5,
+                        fontSize: 'calc(10.5px * var(--font-scale))',
                         color: isDark
                           ? 'rgba(255,255,255,0.45)'
                           : 'rgba(0,0,0,0.45)',
@@ -941,7 +941,7 @@ function EditRow({
             width: 18,
             flexShrink: 0,
             fontFamily: '"JetBrains Mono","Fira Code","SF Mono",monospace',
-            fontSize: 10,
+            fontSize: 'calc(10px * var(--font-scale))',
             color: isDark ? 'rgba(255,255,255,0.22)' : 'rgba(0,0,0,0.28)',
             textAlign: 'right',
             userSelect: 'none',
@@ -991,7 +991,7 @@ function EditRow({
                 borderRadius: 6,
                 padding: '4px 8px',
                 fontFamily: theme.typography.fontFamily,
-                fontSize: 13,
+                fontSize: 'calc(13px * var(--font-scale))',
                 fontWeight: 500,
                 color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
                 caretColor: accent,
@@ -1008,7 +1008,7 @@ function EditRow({
                 style={{
                   fontFamily:
                     '"JetBrains Mono","Fira Code","SF Mono",monospace',
-                  fontSize: 10,
+                  fontSize: 'calc(10px * var(--font-scale))',
                   color: error.tooLong
                     ? '#ff6b6b'
                     : isDark
@@ -1027,7 +1027,7 @@ function EditRow({
             <div
               style={{
                 fontFamily: theme.typography.fontFamily,
-                fontSize: 10.5,
+                fontSize: 'calc(10.5px * var(--font-scale))',
                 color: '#ff6b6b',
                 paddingLeft: 9,
                 lineHeight: 1.4,
@@ -1412,7 +1412,7 @@ export default function EditCheatsheetsPage() {
             <Box
               sx={{
                 padding: '16px',
-                fontSize: '12px',
+                fontSize: 'calc(12px * var(--font-scale))',
                 color: theme.palette.text.secondary,
               }}
             >
@@ -1422,7 +1422,7 @@ export default function EditCheatsheetsPage() {
             <Box
               sx={{
                 padding: '16px',
-                fontSize: '12px',
+                fontSize: 'calc(12px * var(--font-scale))',
                 color: theme.palette.text.secondary,
               }}
             >
@@ -1503,7 +1503,7 @@ export default function EditCheatsheetsPage() {
                 padding: '8px 10px',
                 cursor: 'pointer',
                 fontFamily: theme.typography.fontFamily,
-                fontSize: '12px',
+                fontSize: 'calc(12px * var(--font-scale))',
                 fontWeight: 500,
                 color: accent,
                 transition: 'all 0.14s',
@@ -1563,7 +1563,7 @@ export default function EditCheatsheetsPage() {
                     component='span'
                     sx={{
                       fontFamily: theme.typography.fontFamily,
-                      fontSize: '11px',
+                      fontSize: 'calc(11px * var(--font-scale))',
                       color: '#ff6b6b',
                       fontWeight: 500,
                     }}
@@ -1576,7 +1576,7 @@ export default function EditCheatsheetsPage() {
                   component='span'
                   sx={{
                     fontFamily: theme.typography.fontFamily,
-                    fontSize: '11px',
+                    fontSize: 'calc(11px * var(--font-scale))',
                     color: theme.palette.text.secondary,
                     fontStyle: 'italic',
                   }}
@@ -1588,7 +1588,7 @@ export default function EditCheatsheetsPage() {
                   component='span'
                   sx={{
                     fontFamily: theme.typography.fontFamily,
-                    fontSize: '11px',
+                    fontSize: 'calc(11px * var(--font-scale))',
                     color: isDark
                       ? 'rgba(255,255,255,0.22)'
                       : 'rgba(0,0,0,0.28)',

--- a/src/app/edit-cheatsheets/page.tsx
+++ b/src/app/edit-cheatsheets/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import {
   useCallback,
   useEffect,
@@ -253,7 +254,7 @@ function TypeBadge({
           borderRadius: 999,
           padding: '2px 8px 2px 7px',
           fontFamily: theme.typography.fontFamily,
-          fontSize: 'calc(9.5px * var(--font-scale))',
+          fontSize: scaledPx(9.5),
           fontWeight: 600,
           letterSpacing: '0.06em',
           textTransform: 'uppercase',
@@ -344,7 +345,7 @@ function TypeBadge({
           >
             <div
               style={{
-                fontSize: 'calc(9.5px * var(--font-scale))',
+                fontSize: scaledPx(9.5),
                 fontWeight: 600,
                 color: isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
                 letterSpacing: '0.12em',
@@ -409,7 +410,7 @@ function TypeBadge({
                   <span style={{ flex: 1, minWidth: 0 }}>
                     <div
                       style={{
-                        fontSize: 'calc(12.5px * var(--font-scale))',
+                        fontSize: scaledPx(12.5),
                         fontWeight: 500,
                         color: isDark
                           ? 'rgba(255,255,255,0.92)'
@@ -420,7 +421,7 @@ function TypeBadge({
                     </div>
                     <div
                       style={{
-                        fontSize: 'calc(10.5px * var(--font-scale))',
+                        fontSize: scaledPx(10.5),
                         color: isDark
                           ? 'rgba(255,255,255,0.45)'
                           : 'rgba(0,0,0,0.45)',
@@ -538,7 +539,7 @@ function LayoutBadge({
           borderRadius: 6,
           padding: '2px 6px',
           fontFamily: theme.typography.fontFamily,
-          fontSize: 'calc(11px * var(--font-scale))',
+          fontSize: scaledPx(11),
           fontWeight: 500,
           color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
           cursor: locked ? 'default' : 'pointer',
@@ -564,7 +565,7 @@ function LayoutBadge({
         <span
           style={{
             fontFamily: '"JetBrains Mono","Fira Code","SF Mono",monospace',
-            fontSize: 'calc(10.5px * var(--font-scale))',
+            fontSize: scaledPx(10.5),
             color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
             letterSpacing: '0.01em',
             flex: 1,
@@ -637,7 +638,7 @@ function LayoutBadge({
           >
             <div
               style={{
-                fontSize: 'calc(9.5px * var(--font-scale))',
+                fontSize: scaledPx(9.5),
                 fontWeight: 600,
                 color: isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
                 letterSpacing: '0.12em',
@@ -712,7 +713,7 @@ function LayoutBadge({
                       style={{
                         fontFamily:
                           '"JetBrains Mono","Fira Code","SF Mono",monospace',
-                        fontSize: 'calc(12px * var(--font-scale))',
+                        fontSize: scaledPx(12),
                         fontWeight: 500,
                         color: isDark
                           ? 'rgba(255,255,255,0.92)'
@@ -723,7 +724,7 @@ function LayoutBadge({
                     </div>
                     <div
                       style={{
-                        fontSize: 'calc(10.5px * var(--font-scale))',
+                        fontSize: scaledPx(10.5),
                         color: isDark
                           ? 'rgba(255,255,255,0.45)'
                           : 'rgba(0,0,0,0.45)',
@@ -941,7 +942,7 @@ function EditRow({
             width: 18,
             flexShrink: 0,
             fontFamily: '"JetBrains Mono","Fira Code","SF Mono",monospace',
-            fontSize: 'calc(10px * var(--font-scale))',
+            fontSize: scaledPx(10),
             color: isDark ? 'rgba(255,255,255,0.22)' : 'rgba(0,0,0,0.28)',
             textAlign: 'right',
             userSelect: 'none',
@@ -991,7 +992,7 @@ function EditRow({
                 borderRadius: 6,
                 padding: '4px 8px',
                 fontFamily: theme.typography.fontFamily,
-                fontSize: 'calc(13px * var(--font-scale))',
+                fontSize: scaledPx(13),
                 fontWeight: 500,
                 color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
                 caretColor: accent,
@@ -1008,7 +1009,7 @@ function EditRow({
                 style={{
                   fontFamily:
                     '"JetBrains Mono","Fira Code","SF Mono",monospace',
-                  fontSize: 'calc(10px * var(--font-scale))',
+                  fontSize: scaledPx(10),
                   color: error.tooLong
                     ? '#ff6b6b'
                     : isDark
@@ -1027,7 +1028,7 @@ function EditRow({
             <div
               style={{
                 fontFamily: theme.typography.fontFamily,
-                fontSize: 'calc(10.5px * var(--font-scale))',
+                fontSize: scaledPx(10.5),
                 color: '#ff6b6b',
                 paddingLeft: 9,
                 lineHeight: 1.4,
@@ -1412,7 +1413,7 @@ export default function EditCheatsheetsPage() {
             <Box
               sx={{
                 padding: '16px',
-                fontSize: 'calc(12px * var(--font-scale))',
+                fontSize: scaledPx(12),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -1422,7 +1423,7 @@ export default function EditCheatsheetsPage() {
             <Box
               sx={{
                 padding: '16px',
-                fontSize: 'calc(12px * var(--font-scale))',
+                fontSize: scaledPx(12),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -1503,7 +1504,7 @@ export default function EditCheatsheetsPage() {
                 padding: '8px 10px',
                 cursor: 'pointer',
                 fontFamily: theme.typography.fontFamily,
-                fontSize: 'calc(12px * var(--font-scale))',
+                fontSize: scaledPx(12),
                 fontWeight: 500,
                 color: accent,
                 transition: 'all 0.14s',
@@ -1563,7 +1564,7 @@ export default function EditCheatsheetsPage() {
                     component='span'
                     sx={{
                       fontFamily: theme.typography.fontFamily,
-                      fontSize: 'calc(11px * var(--font-scale))',
+                      fontSize: scaledPx(11),
                       color: '#ff6b6b',
                       fontWeight: 500,
                     }}
@@ -1576,7 +1577,7 @@ export default function EditCheatsheetsPage() {
                   component='span'
                   sx={{
                     fontFamily: theme.typography.fontFamily,
-                    fontSize: 'calc(11px * var(--font-scale))',
+                    fontSize: scaledPx(11),
                     color: theme.palette.text.secondary,
                     fontStyle: 'italic',
                   }}
@@ -1588,7 +1589,7 @@ export default function EditCheatsheetsPage() {
                   component='span'
                   sx={{
                     fontFamily: theme.typography.fontFamily,
-                    fontSize: 'calc(11px * var(--font-scale))',
+                    fontSize: scaledPx(11),
                     color: isDark
                       ? 'rgba(255,255,255,0.22)'
                       : 'rgba(0,0,0,0.28)',

--- a/src/app/edit-command/page.tsx
+++ b/src/app/edit-command/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { useEffect, useRef, useState } from 'react'
 
 import { Box, MenuItem, Select, TextField } from '@mui/material'
@@ -156,7 +157,7 @@ export default function EditCommandPage() {
             value={groupEditId}
             onChange={(e) => setGroupEditId(e.target.value)}
             size='small'
-            sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
+            sx={{ fontSize: scaledPx(13) }}
             displayEmpty
           >
             <MenuItem value=''>
@@ -182,7 +183,7 @@ export default function EditCommandPage() {
             }
             size='small'
             fullWidth
-            sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
+            sx={{ fontSize: scaledPx(13) }}
           />
         </FieldRow>
 
@@ -216,7 +217,7 @@ export default function EditCommandPage() {
                 sx={{
                   '& textarea': {
                     fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-                    fontSize: 'calc(12px * var(--font-scale))',
+                    fontSize: scaledPx(12),
                   },
                 }}
               />
@@ -226,7 +227,7 @@ export default function EditCommandPage() {
                 value={layout}
                 onChange={(e) => setLayout(e.target.value as CommandLayout)}
                 size='small'
-                sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
+                sx={{ fontSize: scaledPx(13) }}
               >
                 {LAYOUT_OPTIONS.map((o) => (
                   <MenuItem key={o.value} value={o.value}>
@@ -279,7 +280,7 @@ function FieldRow({
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
       <Box
         sx={{
-          fontSize: 'calc(11px * var(--font-scale))',
+          fontSize: scaledPx(11),
           fontWeight: 600,
           color: 'text.secondary',
           letterSpacing: '0.01em',
@@ -291,7 +292,7 @@ function FieldRow({
       {hint && (
         <Box
           sx={{
-            fontSize: 'calc(10.5px * var(--font-scale))',
+            fontSize: scaledPx(10.5),
             color: theme.palette.text.disabled,
             lineHeight: 1.4,
           }}

--- a/src/app/edit-command/page.tsx
+++ b/src/app/edit-command/page.tsx
@@ -156,7 +156,7 @@ export default function EditCommandPage() {
             value={groupEditId}
             onChange={(e) => setGroupEditId(e.target.value)}
             size='small'
-            sx={{ fontSize: '13px' }}
+            sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
             displayEmpty
           >
             <MenuItem value=''>
@@ -182,7 +182,7 @@ export default function EditCommandPage() {
             }
             size='small'
             fullWidth
-            sx={{ fontSize: '13px' }}
+            sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
           />
         </FieldRow>
 
@@ -216,7 +216,7 @@ export default function EditCommandPage() {
                 sx={{
                   '& textarea': {
                     fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-                    fontSize: '12px',
+                    fontSize: 'calc(12px * var(--font-scale))',
                   },
                 }}
               />
@@ -226,7 +226,7 @@ export default function EditCommandPage() {
                 value={layout}
                 onChange={(e) => setLayout(e.target.value as CommandLayout)}
                 size='small'
-                sx={{ fontSize: '13px' }}
+                sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
               >
                 {LAYOUT_OPTIONS.map((o) => (
                   <MenuItem key={o.value} value={o.value}>
@@ -279,7 +279,7 @@ function FieldRow({
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
       <Box
         sx={{
-          fontSize: '11px',
+          fontSize: 'calc(11px * var(--font-scale))',
           fontWeight: 600,
           color: 'text.secondary',
           letterSpacing: '0.01em',
@@ -291,7 +291,7 @@ function FieldRow({
       {hint && (
         <Box
           sx={{
-            fontSize: '10.5px',
+            fontSize: 'calc(10.5px * var(--font-scale))',
             color: theme.palette.text.disabled,
             lineHeight: 1.4,
           }}

--- a/src/app/edit-group/page.tsx
+++ b/src/app/edit-group/page.tsx
@@ -109,7 +109,7 @@ export default function EditGroupPage() {
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Box
             sx={{
-              fontSize: '11px',
+              fontSize: 'calc(11px * var(--font-scale))',
               fontWeight: 600,
               color: 'text.secondary',
             }}

--- a/src/app/edit-group/page.tsx
+++ b/src/app/edit-group/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Box, TextField } from '@mui/material'
@@ -109,7 +110,7 @@ export default function EditGroupPage() {
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Box
             sx={{
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               fontWeight: 600,
               color: 'text.secondary',
             }}

--- a/src/app/export/page.tsx
+++ b/src/app/export/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { useCallback, useEffect, useState } from 'react'
 
 import { Box, Typography } from '@mui/material'
@@ -150,7 +151,7 @@ function ExportRow({
         sx={{
           flex: 1,
           minWidth: 0,
-          fontSize: 'calc(13px * var(--font-scale))',
+          fontSize: scaledPx(13),
           fontWeight: sheet.checked ? 500 : 400,
           color: sheet.checked
             ? theme.palette.text.primary
@@ -275,7 +276,7 @@ function ResultModal({
 
         <Typography
           sx={{
-            fontSize: 'calc(13.5px * var(--font-scale))',
+            fontSize: scaledPx(13.5),
             fontWeight: 600,
             color: theme.palette.text.primary,
             textAlign: 'center',
@@ -288,7 +289,7 @@ function ResultModal({
           <>
             <Typography
               sx={{
-                fontSize: 'calc(11px * var(--font-scale))',
+                fontSize: scaledPx(11),
                 color: theme.palette.text.secondary,
                 textAlign: 'center',
                 lineHeight: 1.5,
@@ -300,7 +301,7 @@ function ResultModal({
             <Box
               sx={{
                 fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-                fontSize: 'calc(10.5px * var(--font-scale))',
+                fontSize: scaledPx(10.5),
                 color: theme.palette.text.primary,
                 background: isDark ? 'rgba(0,0,0,0.30)' : 'rgba(0,0,0,0.04)',
                 border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.75)'}`,
@@ -330,7 +331,7 @@ function ResultModal({
             borderRadius: '7px',
             padding: '6px 22px',
             fontFamily: theme.typography.fontFamily,
-            fontSize: 'calc(12.5px * var(--font-scale))',
+            fontSize: scaledPx(12.5),
             fontWeight: 600,
             cursor: 'pointer',
             alignSelf: 'stretch',
@@ -484,7 +485,7 @@ export default function ExportPage() {
           >
             <Typography
               sx={{
-                fontSize: 'calc(12.5px * var(--font-scale))',
+                fontSize: scaledPx(12.5),
                 fontWeight: 600,
                 color: theme.palette.text.primary,
               }}
@@ -493,7 +494,7 @@ export default function ExportPage() {
             </Typography>
             <Typography
               sx={{
-                fontSize: 'calc(10.5px * var(--font-scale))',
+                fontSize: scaledPx(10.5),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -504,7 +505,7 @@ export default function ExportPage() {
           <Box
             sx={{
               fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-              fontSize: 'calc(10px * var(--font-scale))',
+              fontSize: scaledPx(10),
               color: noneOn
                 ? isDark
                   ? 'rgba(255,255,255,0.25)'
@@ -557,7 +558,7 @@ export default function ExportPage() {
             <Typography
               sx={{
                 padding: '16px',
-                fontSize: 'calc(12px * var(--font-scale))',
+                fontSize: scaledPx(12),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -567,7 +568,7 @@ export default function ExportPage() {
             <Typography
               sx={{
                 padding: '16px',
-                fontSize: 'calc(12px * var(--font-scale))',
+                fontSize: scaledPx(12),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -626,7 +627,7 @@ export default function ExportPage() {
             </svg>
             <Typography
               sx={{
-                fontSize: 'calc(11px * var(--font-scale))',
+                fontSize: scaledPx(11),
                 color: theme.palette.text.secondary,
               }}
             >

--- a/src/app/export/page.tsx
+++ b/src/app/export/page.tsx
@@ -150,7 +150,7 @@ function ExportRow({
         sx={{
           flex: 1,
           minWidth: 0,
-          fontSize: '13px',
+          fontSize: 'calc(13px * var(--font-scale))',
           fontWeight: sheet.checked ? 500 : 400,
           color: sheet.checked
             ? theme.palette.text.primary
@@ -275,7 +275,7 @@ function ResultModal({
 
         <Typography
           sx={{
-            fontSize: '13.5px',
+            fontSize: 'calc(13.5px * var(--font-scale))',
             fontWeight: 600,
             color: theme.palette.text.primary,
             textAlign: 'center',
@@ -288,7 +288,7 @@ function ResultModal({
           <>
             <Typography
               sx={{
-                fontSize: '11px',
+                fontSize: 'calc(11px * var(--font-scale))',
                 color: theme.palette.text.secondary,
                 textAlign: 'center',
                 lineHeight: 1.5,
@@ -300,7 +300,7 @@ function ResultModal({
             <Box
               sx={{
                 fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-                fontSize: '10.5px',
+                fontSize: 'calc(10.5px * var(--font-scale))',
                 color: theme.palette.text.primary,
                 background: isDark ? 'rgba(0,0,0,0.30)' : 'rgba(0,0,0,0.04)',
                 border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.75)'}`,
@@ -330,7 +330,7 @@ function ResultModal({
             borderRadius: '7px',
             padding: '6px 22px',
             fontFamily: theme.typography.fontFamily,
-            fontSize: '12.5px',
+            fontSize: 'calc(12.5px * var(--font-scale))',
             fontWeight: 600,
             cursor: 'pointer',
             alignSelf: 'stretch',
@@ -484,7 +484,7 @@ export default function ExportPage() {
           >
             <Typography
               sx={{
-                fontSize: '12.5px',
+                fontSize: 'calc(12.5px * var(--font-scale))',
                 fontWeight: 600,
                 color: theme.palette.text.primary,
               }}
@@ -492,7 +492,10 @@ export default function ExportPage() {
               {allOn ? 'Deselect All' : 'Select All'}
             </Typography>
             <Typography
-              sx={{ fontSize: '10.5px', color: theme.palette.text.secondary }}
+              sx={{
+                fontSize: 'calc(10.5px * var(--font-scale))',
+                color: theme.palette.text.secondary,
+              }}
             >
               {selectedSheets.length} of {total} selected
             </Typography>
@@ -501,7 +504,7 @@ export default function ExportPage() {
           <Box
             sx={{
               fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-              fontSize: '10px',
+              fontSize: 'calc(10px * var(--font-scale))',
               color: noneOn
                 ? isDark
                   ? 'rgba(255,255,255,0.25)'
@@ -554,7 +557,7 @@ export default function ExportPage() {
             <Typography
               sx={{
                 padding: '16px',
-                fontSize: '12px',
+                fontSize: 'calc(12px * var(--font-scale))',
                 color: theme.palette.text.secondary,
               }}
             >
@@ -564,7 +567,7 @@ export default function ExportPage() {
             <Typography
               sx={{
                 padding: '16px',
-                fontSize: '12px',
+                fontSize: 'calc(12px * var(--font-scale))',
                 color: theme.palette.text.secondary,
               }}
             >
@@ -622,7 +625,10 @@ export default function ExportPage() {
               <polyline points='14 2 14 8 20 8' />
             </svg>
             <Typography
-              sx={{ fontSize: '11px', color: theme.palette.text.secondary }}
+              sx={{
+                fontSize: 'calc(11px * var(--font-scale))',
+                color: theme.palette.text.secondary,
+              }}
             >
               {noneOn ? (
                 <Box

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,10 @@
 @import '@fontsource/jetbrains-mono/600.css';
 @import '@fontsource/jetbrains-mono/700.css';
 
+:root {
+  --font-scale: 1;
+}
+
 html,
 body {
   height: 100%;

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -548,9 +548,7 @@ export default function Page() {
                       },
                     }}
                   >
-                    <SettingsOutlinedIcon
-                      sx={{ fontSize: 'calc(14px * var(--font-scale))' }}
-                    />
+                    <SettingsOutlinedIcon sx={{ fontSize: '14px' }} />
                   </IconButton>
                 </span>
               </Tooltip>
@@ -739,9 +737,7 @@ export default function Page() {
                         },
                       }}
                     >
-                      <InsertDriveFileOutlinedIcon
-                        sx={{ fontSize: 'calc(14px * var(--font-scale))' }}
-                      />
+                      <InsertDriveFileOutlinedIcon sx={{ fontSize: '14px' }} />
                     </IconButton>
                   </Tooltip>
                   <Box
@@ -847,9 +843,7 @@ export default function Page() {
                           },
                         }}
                       >
-                        <ArticleOutlinedIcon
-                          sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
-                        />
+                        <ArticleOutlinedIcon sx={{ fontSize: '13px' }} />
                       </IconButton>
                     </Tooltip>
                     <Tooltip title='Edit log settings'>
@@ -873,9 +867,7 @@ export default function Page() {
                           },
                         }}
                       >
-                        <EditOutlinedIcon
-                          sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
-                        />
+                        <EditOutlinedIcon sx={{ fontSize: '13px' }} />
                       </IconButton>
                     </Tooltip>
                   </Box>
@@ -1448,7 +1440,7 @@ function ShortcutSettingsDialog({
         >
           <InfoOutlinedIcon
             sx={{
-              fontSize: 'calc(14px * var(--font-scale))',
+              fontSize: '14px',
               mt: '1px',
               flexShrink: 0,
               color: isDark ? '#f5c46b' : '#a87a00',
@@ -1820,7 +1812,7 @@ function LogSettingsDialog({
         >
           <InfoOutlinedIcon
             sx={{
-              fontSize: 'calc(14px * var(--font-scale))',
+              fontSize: '14px',
               mt: '1px',
               flexShrink: 0,
               color: isDark ? '#f5c46b' : '#a87a00',
@@ -1871,9 +1863,7 @@ function LogSettingsDialog({
                   },
                 }}
               >
-                <FolderOutlinedIcon
-                  sx={{ fontSize: 'calc(14px * var(--font-scale))' }}
-                />
+                <FolderOutlinedIcon sx={{ fontSize: '14px' }} />
               </IconButton>
             </Tooltip>
             <Box

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -462,7 +462,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: 14,
+              fontSize: 'calc(14px * var(--font-scale))',
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -474,11 +474,20 @@ export default function Page() {
           <Box sx={{ pl: '14px', py: '8px' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
               <Typography
-                sx={{ fontSize: 13, fontWeight: 500, color: 'text.primary' }}
+                sx={{
+                  fontSize: 'calc(13px * var(--font-scale))',
+                  fontWeight: 500,
+                  color: 'text.primary',
+                }}
               >
                 Toggle Visible
               </Typography>
-              <Typography sx={{ color: 'text.secondary', fontSize: 13 }}>
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: 'calc(13px * var(--font-scale))',
+                }}
+              >
                 :
               </Typography>
               {toggleVisibleShortcut && (
@@ -492,7 +501,7 @@ export default function Page() {
                     borderRadius: '6px',
                     padding: '4px 11px',
                     fontFamily: 'monospace',
-                    fontSize: 12,
+                    fontSize: 'calc(12px * var(--font-scale))',
                     color: 'text.primary',
                     boxShadow: !isDark
                       ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
@@ -539,7 +548,9 @@ export default function Page() {
                       },
                     }}
                   >
-                    <SettingsOutlinedIcon sx={{ fontSize: 14 }} />
+                    <SettingsOutlinedIcon
+                      sx={{ fontSize: 'calc(14px * var(--font-scale))' }}
+                    />
                   </IconButton>
                 </span>
               </Tooltip>
@@ -553,7 +564,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: 14,
+              fontSize: 'calc(14px * var(--font-scale))',
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -577,7 +588,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: 14,
+              fontSize: 'calc(14px * var(--font-scale))',
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -614,7 +625,12 @@ export default function Page() {
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                   <RowDot />
-                  <Typography sx={{ fontSize: 13, color: 'text.primary' }}>
+                  <Typography
+                    sx={{
+                      fontSize: 'calc(13px * var(--font-scale))',
+                      color: 'text.primary',
+                    }}
+                  >
                     Visible on all workspaces
                   </Typography>
                 </Box>
@@ -637,7 +653,12 @@ export default function Page() {
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                   <RowDot />
-                  <Typography sx={{ fontSize: 13, color: 'text.primary' }}>
+                  <Typography
+                    sx={{
+                      fontSize: 'calc(13px * var(--font-scale))',
+                      color: 'text.primary',
+                    }}
+                  >
                     Confirm before actions
                   </Typography>
                 </Box>
@@ -660,7 +681,12 @@ export default function Page() {
                   }}
                 >
                   <RowDot />
-                  <Typography sx={{ fontSize: 13, color: 'text.primary' }}>
+                  <Typography
+                    sx={{
+                      fontSize: 'calc(13px * var(--font-scale))',
+                      color: 'text.primary',
+                    }}
+                  >
                     CheatSheet DB
                   </Typography>
                   <Chip
@@ -669,7 +695,7 @@ export default function Page() {
                     sx={{
                       height: 'auto',
                       py: '2px',
-                      fontSize: '9.5px',
+                      fontSize: 'calc(9.5px * var(--font-scale))',
                       fontFamily: 'monospace',
                       letterSpacing: '0.06em',
                       textTransform: 'uppercase',
@@ -713,7 +739,9 @@ export default function Page() {
                         },
                       }}
                     >
-                      <InsertDriveFileOutlinedIcon sx={{ fontSize: 14 }} />
+                      <InsertDriveFileOutlinedIcon
+                        sx={{ fontSize: 'calc(14px * var(--font-scale))' }}
+                      />
                     </IconButton>
                   </Tooltip>
                   <Box
@@ -737,7 +765,7 @@ export default function Page() {
                       component='span'
                       sx={{
                         fontFamily: 'monospace',
-                        fontSize: '11px',
+                        fontSize: 'calc(11px * var(--font-scale))',
                         display: 'block',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
@@ -769,7 +797,12 @@ export default function Page() {
                     sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}
                   >
                     <RowDot />
-                    <Typography sx={{ fontSize: 13, color: 'text.primary' }}>
+                    <Typography
+                      sx={{
+                        fontSize: 'calc(13px * var(--font-scale))',
+                        color: 'text.primary',
+                      }}
+                    >
                       Log
                     </Typography>
                     <Chip
@@ -778,7 +811,7 @@ export default function Page() {
                       sx={{
                         height: 'auto',
                         py: '2px',
-                        fontSize: '9.5px',
+                        fontSize: 'calc(9.5px * var(--font-scale))',
                         fontFamily: 'monospace',
                         letterSpacing: '0.06em',
                         textTransform: 'uppercase',
@@ -814,7 +847,9 @@ export default function Page() {
                           },
                         }}
                       >
-                        <ArticleOutlinedIcon sx={{ fontSize: 13 }} />
+                        <ArticleOutlinedIcon
+                          sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
+                        />
                       </IconButton>
                     </Tooltip>
                     <Tooltip title='Edit log settings'>
@@ -838,7 +873,9 @@ export default function Page() {
                           },
                         }}
                       >
-                        <EditOutlinedIcon sx={{ fontSize: 13 }} />
+                        <EditOutlinedIcon
+                          sx={{ fontSize: 'calc(13px * var(--font-scale))' }}
+                        />
                       </IconButton>
                     </Tooltip>
                   </Box>
@@ -945,7 +982,7 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
     >
       <Typography
         sx={{
-          fontSize: 11,
+          fontSize: 'calc(11px * var(--font-scale))',
           flexShrink: 0,
           width: 110,
           fontWeight: 500,
@@ -957,7 +994,7 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
       <Typography
         title={value}
         sx={{
-          fontSize: 11,
+          fontSize: 'calc(11px * var(--font-scale))',
           fontFamily: 'monospace',
           color: 'text.primary',
           overflow: 'hidden',
@@ -1006,7 +1043,7 @@ function NumberInputField({
     <Box>
       <Typography
         sx={{
-          fontSize: 11,
+          fontSize: 'calc(11px * var(--font-scale))',
           fontWeight: 500,
           mb: '6px',
           color: 'text.secondary',
@@ -1044,7 +1081,7 @@ function NumberInputField({
             border: 'none',
             outline: 'none',
             fontFamily: 'monospace',
-            fontSize: 12,
+            fontSize: 'calc(12px * var(--font-scale))',
             color: 'text.primary',
             caretColor: theme.palette.primary.main,
             padding: '2px 0',
@@ -1057,7 +1094,7 @@ function NumberInputField({
           component='span'
           sx={{
             fontFamily: 'monospace',
-            fontSize: 10,
+            fontSize: 'calc(10px * var(--font-scale))',
             color: 'text.disabled',
             ml: '6px',
             flexShrink: 0,
@@ -1070,7 +1107,7 @@ function NumberInputField({
       {hint && (
         <Typography
           sx={{
-            fontSize: 10.5,
+            fontSize: 'calc(10.5px * var(--font-scale))',
             color: 'error.main',
             mt: '4px',
             lineHeight: 1.4,
@@ -1123,7 +1160,9 @@ function Keycap({ children, big = false, active = true }: KeycapProps) {
             : '0 1px 0 rgba(0,0,30,0.08), inset 0 0.5px 0 rgba(255,255,255,0.9)'
           : 'none',
         fontFamily: 'monospace',
-        fontSize: big ? 15 : 12,
+        fontSize: big
+          ? 'calc(15px * var(--font-scale))'
+          : 'calc(12px * var(--font-scale))',
         fontWeight: 600,
         color: active ? 'text.primary' : 'text.secondary',
         textAlign: 'center',
@@ -1240,7 +1279,7 @@ function ShortcutCheckbox({
       <Keycap active={checked}>{symbol}</Keycap>
       <Typography
         sx={{
-          fontSize: 13,
+          fontSize: 'calc(13px * var(--font-scale))',
           color: checked ? 'text.primary' : 'text.secondary',
         }}
       >
@@ -1292,7 +1331,7 @@ function HotkeyInput({ value, onChange, invalid }: HotkeyInputProps) {
         borderRadius: '7px',
         padding: '7px 8px',
         fontFamily: 'monospace',
-        fontSize: 16,
+        fontSize: 'calc(16px * var(--font-scale))',
         fontWeight: 600,
         color: 'text.primary',
         caretColor: theme.palette.primary.main,
@@ -1378,7 +1417,7 @@ function ShortcutSettingsDialog({
       <DialogTitle
         sx={{
           padding: '14px 18px 12px',
-          fontSize: 14,
+          fontSize: 'calc(14px * var(--font-scale))',
           fontWeight: 600,
           borderBottom: `0.5px solid ${theme.palette.divider}`,
         }}
@@ -1409,7 +1448,7 @@ function ShortcutSettingsDialog({
         >
           <InfoOutlinedIcon
             sx={{
-              fontSize: 14,
+              fontSize: 'calc(14px * var(--font-scale))',
               mt: '1px',
               flexShrink: 0,
               color: isDark ? '#f5c46b' : '#a87a00',
@@ -1419,7 +1458,7 @@ function ShortcutSettingsDialog({
             sx={{
               lineHeight: 1.5,
               color: isDark ? '#f5c46b' : '#8a6300',
-              fontSize: '11.5px',
+              fontSize: 'calc(11.5px * var(--font-scale))',
             }}
           >
             Changing the global shortcut takes effect after restarting
@@ -1445,7 +1484,7 @@ function ShortcutSettingsDialog({
         >
           <Typography
             sx={{
-              fontSize: 10.5,
+              fontSize: 'calc(10.5px * var(--font-scale))',
               fontWeight: 600,
               letterSpacing: '0.08em',
               textTransform: 'uppercase',
@@ -1464,7 +1503,11 @@ function ShortcutSettingsDialog({
             </Box>
           ) : (
             <Typography
-              sx={{ fontSize: 13, color: 'text.secondary', p: '7px 0' }}
+              sx={{
+                fontSize: 'calc(13px * var(--font-scale))',
+                color: 'text.secondary',
+                p: '7px 0',
+              }}
             >
               Not set
             </Typography>
@@ -1475,7 +1518,7 @@ function ShortcutSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: 11,
+              fontSize: 'calc(11px * var(--font-scale))',
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1528,7 +1571,7 @@ function ShortcutSettingsDialog({
           {showError && !hasModifier && (
             <Typography
               sx={{
-                fontSize: 10.5,
+                fontSize: 'calc(10.5px * var(--font-scale))',
                 color: theme.palette.error.main,
                 mt: '2px',
               }}
@@ -1542,7 +1585,7 @@ function ShortcutSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: 11,
+              fontSize: 'calc(11px * var(--font-scale))',
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1560,19 +1603,28 @@ function ShortcutSettingsDialog({
               }}
               invalid={showError && !hasHotkey}
             />
-            <Typography sx={{ fontSize: 11.5, color: 'text.secondary' }}>
+            <Typography
+              sx={{
+                fontSize: 'calc(11.5px * var(--font-scale))',
+                color: 'text.secondary',
+              }}
+            >
               Type a key to set it
             </Typography>
           </Box>
           <Typography
-            sx={{ fontSize: 10.5, color: 'text.disabled', lineHeight: 1.4 }}
+            sx={{
+              fontSize: 'calc(10.5px * var(--font-scale))',
+              color: 'text.disabled',
+              lineHeight: 1.4,
+            }}
           >
             A single character — letters (A–Z, a–z) or digits (0–9) only.
           </Typography>
           {showError && !hasHotkey && (
             <Typography
               sx={{
-                fontSize: 10.5,
+                fontSize: 'calc(10.5px * var(--font-scale))',
                 color: theme.palette.error.main,
                 mt: '2px',
               }}
@@ -1596,7 +1648,7 @@ function ShortcutSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 12,
+            fontSize: 'calc(12px * var(--font-scale))',
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1620,7 +1672,7 @@ function ShortcutSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 12,
+            fontSize: 'calc(12px * var(--font-scale))',
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1737,7 +1789,7 @@ function LogSettingsDialog({
       <DialogTitle
         sx={{
           padding: '14px 18px 12px',
-          fontSize: 14,
+          fontSize: 'calc(14px * var(--font-scale))',
           fontWeight: 600,
           borderBottom: `0.5px solid ${theme.palette.divider}`,
         }}
@@ -1768,7 +1820,7 @@ function LogSettingsDialog({
         >
           <InfoOutlinedIcon
             sx={{
-              fontSize: 14,
+              fontSize: 'calc(14px * var(--font-scale))',
               mt: '1px',
               flexShrink: 0,
               color: isDark ? '#f5c46b' : '#a87a00',
@@ -1778,7 +1830,7 @@ function LogSettingsDialog({
             sx={{
               lineHeight: 1.5,
               color: isDark ? '#f5c46b' : '#8a6300',
-              fontSize: '11.5px',
+              fontSize: 'calc(11.5px * var(--font-scale))',
             }}
           >
             Log settings only take effect after restarting RightCheat.
@@ -1789,7 +1841,7 @@ function LogSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: 11,
+              fontSize: 'calc(11px * var(--font-scale))',
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1819,7 +1871,9 @@ function LogSettingsDialog({
                   },
                 }}
               >
-                <FolderOutlinedIcon sx={{ fontSize: 14 }} />
+                <FolderOutlinedIcon
+                  sx={{ fontSize: 'calc(14px * var(--font-scale))' }}
+                />
               </IconButton>
             </Tooltip>
             <Box
@@ -1842,7 +1896,7 @@ function LogSettingsDialog({
                 dir='ltr'
                 sx={{
                   fontFamily: 'monospace',
-                  fontSize: '11.5px',
+                  fontSize: 'calc(11.5px * var(--font-scale))',
                   display: 'block',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -1901,7 +1955,7 @@ function LogSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 12,
+            fontSize: 'calc(12px * var(--font-scale))',
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1925,7 +1979,7 @@ function LogSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 12,
+            fontSize: 'calc(12px * var(--font-scale))',
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { scaledPx } from '@/utils/css'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { ThemedSwitch, ThemeToggle } from '@/components/atoms'
@@ -462,7 +463,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: 'calc(14px * var(--font-scale))',
+              fontSize: scaledPx(14),
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -475,7 +476,7 @@ export default function Page() {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
               <Typography
                 sx={{
-                  fontSize: 'calc(13px * var(--font-scale))',
+                  fontSize: scaledPx(13),
                   fontWeight: 500,
                   color: 'text.primary',
                 }}
@@ -485,7 +486,7 @@ export default function Page() {
               <Typography
                 sx={{
                   color: 'text.secondary',
-                  fontSize: 'calc(13px * var(--font-scale))',
+                  fontSize: scaledPx(13),
                 }}
               >
                 :
@@ -501,7 +502,7 @@ export default function Page() {
                     borderRadius: '6px',
                     padding: '4px 11px',
                     fontFamily: 'monospace',
-                    fontSize: 'calc(12px * var(--font-scale))',
+                    fontSize: scaledPx(12),
                     color: 'text.primary',
                     boxShadow: !isDark
                       ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
@@ -562,7 +563,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: 'calc(14px * var(--font-scale))',
+              fontSize: scaledPx(14),
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -586,7 +587,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: 'calc(14px * var(--font-scale))',
+              fontSize: scaledPx(14),
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -625,7 +626,7 @@ export default function Page() {
                   <RowDot />
                   <Typography
                     sx={{
-                      fontSize: 'calc(13px * var(--font-scale))',
+                      fontSize: scaledPx(13),
                       color: 'text.primary',
                     }}
                   >
@@ -653,7 +654,7 @@ export default function Page() {
                   <RowDot />
                   <Typography
                     sx={{
-                      fontSize: 'calc(13px * var(--font-scale))',
+                      fontSize: scaledPx(13),
                       color: 'text.primary',
                     }}
                   >
@@ -681,7 +682,7 @@ export default function Page() {
                   <RowDot />
                   <Typography
                     sx={{
-                      fontSize: 'calc(13px * var(--font-scale))',
+                      fontSize: scaledPx(13),
                       color: 'text.primary',
                     }}
                   >
@@ -693,7 +694,7 @@ export default function Page() {
                     sx={{
                       height: 'auto',
                       py: '2px',
-                      fontSize: 'calc(9.5px * var(--font-scale))',
+                      fontSize: scaledPx(9.5),
                       fontFamily: 'monospace',
                       letterSpacing: '0.06em',
                       textTransform: 'uppercase',
@@ -761,7 +762,7 @@ export default function Page() {
                       component='span'
                       sx={{
                         fontFamily: 'monospace',
-                        fontSize: 'calc(11px * var(--font-scale))',
+                        fontSize: scaledPx(11),
                         display: 'block',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
@@ -795,7 +796,7 @@ export default function Page() {
                     <RowDot />
                     <Typography
                       sx={{
-                        fontSize: 'calc(13px * var(--font-scale))',
+                        fontSize: scaledPx(13),
                         color: 'text.primary',
                       }}
                     >
@@ -807,7 +808,7 @@ export default function Page() {
                       sx={{
                         height: 'auto',
                         py: '2px',
-                        fontSize: 'calc(9.5px * var(--font-scale))',
+                        fontSize: scaledPx(9.5),
                         fontFamily: 'monospace',
                         letterSpacing: '0.06em',
                         textTransform: 'uppercase',
@@ -974,7 +975,7 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
     >
       <Typography
         sx={{
-          fontSize: 'calc(11px * var(--font-scale))',
+          fontSize: scaledPx(11),
           flexShrink: 0,
           width: 110,
           fontWeight: 500,
@@ -986,7 +987,7 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
       <Typography
         title={value}
         sx={{
-          fontSize: 'calc(11px * var(--font-scale))',
+          fontSize: scaledPx(11),
           fontFamily: 'monospace',
           color: 'text.primary',
           overflow: 'hidden',
@@ -1035,7 +1036,7 @@ function NumberInputField({
     <Box>
       <Typography
         sx={{
-          fontSize: 'calc(11px * var(--font-scale))',
+          fontSize: scaledPx(11),
           fontWeight: 500,
           mb: '6px',
           color: 'text.secondary',
@@ -1073,7 +1074,7 @@ function NumberInputField({
             border: 'none',
             outline: 'none',
             fontFamily: 'monospace',
-            fontSize: 'calc(12px * var(--font-scale))',
+            fontSize: scaledPx(12),
             color: 'text.primary',
             caretColor: theme.palette.primary.main,
             padding: '2px 0',
@@ -1086,7 +1087,7 @@ function NumberInputField({
           component='span'
           sx={{
             fontFamily: 'monospace',
-            fontSize: 'calc(10px * var(--font-scale))',
+            fontSize: scaledPx(10),
             color: 'text.disabled',
             ml: '6px',
             flexShrink: 0,
@@ -1099,7 +1100,7 @@ function NumberInputField({
       {hint && (
         <Typography
           sx={{
-            fontSize: 'calc(10.5px * var(--font-scale))',
+            fontSize: scaledPx(10.5),
             color: 'error.main',
             mt: '4px',
             lineHeight: 1.4,
@@ -1152,9 +1153,7 @@ function Keycap({ children, big = false, active = true }: KeycapProps) {
             : '0 1px 0 rgba(0,0,30,0.08), inset 0 0.5px 0 rgba(255,255,255,0.9)'
           : 'none',
         fontFamily: 'monospace',
-        fontSize: big
-          ? 'calc(15px * var(--font-scale))'
-          : 'calc(12px * var(--font-scale))',
+        fontSize: big ? scaledPx(15) : scaledPx(12),
         fontWeight: 600,
         color: active ? 'text.primary' : 'text.secondary',
         textAlign: 'center',
@@ -1271,7 +1270,7 @@ function ShortcutCheckbox({
       <Keycap active={checked}>{symbol}</Keycap>
       <Typography
         sx={{
-          fontSize: 'calc(13px * var(--font-scale))',
+          fontSize: scaledPx(13),
           color: checked ? 'text.primary' : 'text.secondary',
         }}
       >
@@ -1323,7 +1322,7 @@ function HotkeyInput({ value, onChange, invalid }: HotkeyInputProps) {
         borderRadius: '7px',
         padding: '7px 8px',
         fontFamily: 'monospace',
-        fontSize: 'calc(16px * var(--font-scale))',
+        fontSize: scaledPx(16),
         fontWeight: 600,
         color: 'text.primary',
         caretColor: theme.palette.primary.main,
@@ -1409,7 +1408,7 @@ function ShortcutSettingsDialog({
       <DialogTitle
         sx={{
           padding: '14px 18px 12px',
-          fontSize: 'calc(14px * var(--font-scale))',
+          fontSize: scaledPx(14),
           fontWeight: 600,
           borderBottom: `0.5px solid ${theme.palette.divider}`,
         }}
@@ -1450,7 +1449,7 @@ function ShortcutSettingsDialog({
             sx={{
               lineHeight: 1.5,
               color: isDark ? '#f5c46b' : '#8a6300',
-              fontSize: 'calc(11.5px * var(--font-scale))',
+              fontSize: scaledPx(11.5),
             }}
           >
             Changing the global shortcut takes effect after restarting
@@ -1476,7 +1475,7 @@ function ShortcutSettingsDialog({
         >
           <Typography
             sx={{
-              fontSize: 'calc(10.5px * var(--font-scale))',
+              fontSize: scaledPx(10.5),
               fontWeight: 600,
               letterSpacing: '0.08em',
               textTransform: 'uppercase',
@@ -1496,7 +1495,7 @@ function ShortcutSettingsDialog({
           ) : (
             <Typography
               sx={{
-                fontSize: 'calc(13px * var(--font-scale))',
+                fontSize: scaledPx(13),
                 color: 'text.secondary',
                 p: '7px 0',
               }}
@@ -1510,7 +1509,7 @@ function ShortcutSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1563,7 +1562,7 @@ function ShortcutSettingsDialog({
           {showError && !hasModifier && (
             <Typography
               sx={{
-                fontSize: 'calc(10.5px * var(--font-scale))',
+                fontSize: scaledPx(10.5),
                 color: theme.palette.error.main,
                 mt: '2px',
               }}
@@ -1577,7 +1576,7 @@ function ShortcutSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1597,7 +1596,7 @@ function ShortcutSettingsDialog({
             />
             <Typography
               sx={{
-                fontSize: 'calc(11.5px * var(--font-scale))',
+                fontSize: scaledPx(11.5),
                 color: 'text.secondary',
               }}
             >
@@ -1606,7 +1605,7 @@ function ShortcutSettingsDialog({
           </Box>
           <Typography
             sx={{
-              fontSize: 'calc(10.5px * var(--font-scale))',
+              fontSize: scaledPx(10.5),
               color: 'text.disabled',
               lineHeight: 1.4,
             }}
@@ -1616,7 +1615,7 @@ function ShortcutSettingsDialog({
           {showError && !hasHotkey && (
             <Typography
               sx={{
-                fontSize: 'calc(10.5px * var(--font-scale))',
+                fontSize: scaledPx(10.5),
                 color: theme.palette.error.main,
                 mt: '2px',
               }}
@@ -1640,7 +1639,7 @@ function ShortcutSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 'calc(12px * var(--font-scale))',
+            fontSize: scaledPx(12),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1664,7 +1663,7 @@ function ShortcutSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 'calc(12px * var(--font-scale))',
+            fontSize: scaledPx(12),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1781,7 +1780,7 @@ function LogSettingsDialog({
       <DialogTitle
         sx={{
           padding: '14px 18px 12px',
-          fontSize: 'calc(14px * var(--font-scale))',
+          fontSize: scaledPx(14),
           fontWeight: 600,
           borderBottom: `0.5px solid ${theme.palette.divider}`,
         }}
@@ -1822,7 +1821,7 @@ function LogSettingsDialog({
             sx={{
               lineHeight: 1.5,
               color: isDark ? '#f5c46b' : '#8a6300',
-              fontSize: 'calc(11.5px * var(--font-scale))',
+              fontSize: scaledPx(11.5),
             }}
           >
             Log settings only take effect after restarting RightCheat.
@@ -1833,7 +1832,7 @@ function LogSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1886,7 +1885,7 @@ function LogSettingsDialog({
                 dir='ltr'
                 sx={{
                   fontFamily: 'monospace',
-                  fontSize: 'calc(11.5px * var(--font-scale))',
+                  fontSize: scaledPx(11.5),
                   display: 'block',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -1945,7 +1944,7 @@ function LogSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 'calc(12px * var(--font-scale))',
+            fontSize: scaledPx(12),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1969,7 +1968,7 @@ function LogSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: 'calc(12px * var(--font-scale))',
+            fontSize: scaledPx(12),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -148,7 +148,7 @@ export default function SearchPage() {
           <Box
             sx={{
               fontFamily: FONT_UI,
-              fontSize: '11px',
+              fontSize: 'calc(11px * var(--font-scale))',
               color: theme.palette.text.secondary,
               display: 'flex',
               alignItems: 'center',

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Box } from '@mui/material'
@@ -148,7 +149,7 @@ export default function SearchPage() {
           <Box
             sx={{
               fontFamily: FONT_UI,
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               color: theme.palette.text.secondary,
               display: 'flex',
               alignItems: 'center',

--- a/src/components/ThemeProviderWrapper.tsx
+++ b/src/components/ThemeProviderWrapper.tsx
@@ -10,13 +10,13 @@ import {
 } from '@/theme/default'
 import { ThemeProvider } from '@mui/material/styles'
 import { listen } from '@tauri-apps/api/event'
-import { error } from '@tauri-apps/plugin-log'
+import { debug, error } from '@tauri-apps/plugin-log'
 import { ReactNode, useCallback, useEffect, useState } from 'react'
 
 export function ThemeProviderWrapper({ children }: { children: ReactNode }) {
   const { themeMode: storedThemeMode, isLoading } = useThemeStore()
   const { getThemeMode } = usePreferencesStore()
-  const { fontSizeSettings } = useFontSize()
+  const { fontSizeSettings, isFontSizeLoaded } = useFontSize()
   const [currentTheme, setCurrentTheme] = useState(lightTheme)
 
   const getSystemTheme = (): 'light' | 'dark' => {
@@ -47,20 +47,25 @@ export function ThemeProviderWrapper({ children }: { children: ReactNode }) {
     [],
   )
 
-  // Sync --font-scale CSS custom property for components with hardcoded px font sizes
+  // Sync --font-scale CSS custom property and update MUI theme together to avoid double repaint
   useEffect(() => {
-    document.documentElement.style.setProperty(
-      '--font-scale',
-      String(fontSizeSettings.scale),
-    )
-  }, [fontSizeSettings.scale])
-
-  // Update theme when stored theme mode or font size changes
-  useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && isFontSizeLoaded) {
+      document.documentElement.style.setProperty(
+        '--font-scale',
+        String(fontSizeSettings.scale),
+      )
+      debug(
+        `[ThemeProviderWrapper] Applying font scale: ${fontSizeSettings.scale}, theme: ${storedThemeMode}`,
+      )
       updateTheme(storedThemeMode, fontSizeSettings.scale)
     }
-  }, [storedThemeMode, isLoading, fontSizeSettings.scale, updateTheme])
+  }, [
+    storedThemeMode,
+    isLoading,
+    isFontSizeLoaded,
+    fontSizeSettings.scale,
+    updateTheme,
+  ])
 
   // Listen for system theme changes when mode is 'system'
   useEffect(() => {
@@ -94,6 +99,9 @@ export function ThemeProviderWrapper({ children }: { children: ReactNode }) {
   }, [getThemeMode, fontSizeSettings.scale, updateTheme])
 
   return (
-    !isLoading && <ThemeProvider theme={currentTheme}>{children}</ThemeProvider>
+    !isLoading &&
+    isFontSizeLoaded && (
+      <ThemeProvider theme={currentTheme}>{children}</ThemeProvider>
+    )
   )
 }

--- a/src/components/ThemeProviderWrapper.tsx
+++ b/src/components/ThemeProviderWrapper.tsx
@@ -47,6 +47,14 @@ export function ThemeProviderWrapper({ children }: { children: ReactNode }) {
     [],
   )
 
+  // Sync --font-scale CSS custom property for components with hardcoded px font sizes
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      '--font-scale',
+      String(fontSizeSettings.scale),
+    )
+  }, [fontSizeSettings.scale])
+
   // Update theme when stored theme mode or font size changes
   useEffect(() => {
     if (!isLoading) {

--- a/src/components/atoms/AddRowButton.tsx
+++ b/src/components/atoms/AddRowButton.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
@@ -28,7 +29,7 @@ export function AddRowButton({ label, onClick, icon }: Props) {
         borderRadius: '7px',
         color: theme.palette.text.secondary,
         fontFamily: theme.typography.fontFamily,
-        fontSize: 'calc(11.5px * var(--font-scale))',
+        fontSize: scaledPx(11.5),
         cursor: 'pointer',
         transition: 'all 0.14s',
         '&:hover': {

--- a/src/components/atoms/AddRowButton.tsx
+++ b/src/components/atoms/AddRowButton.tsx
@@ -28,7 +28,7 @@ export function AddRowButton({ label, onClick, icon }: Props) {
         borderRadius: '7px',
         color: theme.palette.text.secondary,
         fontFamily: theme.typography.fontFamily,
-        fontSize: '11.5px',
+        fontSize: 'calc(11.5px * var(--font-scale))',
         cursor: 'pointer',
         transition: 'all 0.14s',
         '&:hover': {

--- a/src/components/atoms/ThemeToggle.tsx
+++ b/src/components/atoms/ThemeToggle.tsx
@@ -57,7 +57,7 @@ export function ThemeToggle({
               padding: '5px 14px',
               cursor: disabled ? 'default' : 'pointer',
               fontFamily: 'monospace',
-              fontSize: 11,
+              fontSize: 'calc(11px * var(--font-scale))',
               fontWeight: selected ? 700 : 400,
               color: selected
                 ? theme.palette.primary.main

--- a/src/components/atoms/ThemeToggle.tsx
+++ b/src/components/atoms/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { type ThemeMode } from '@/hooks/useThemeStore'
+import { scaledPx } from '@/utils/css'
 import { Box } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
@@ -57,7 +58,7 @@ export function ThemeToggle({
               padding: '5px 14px',
               cursor: disabled ? 'default' : 'pointer',
               fontFamily: 'monospace',
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               fontWeight: selected ? 700 : 400,
               color: selected
                 ? theme.palette.primary.main

--- a/src/components/molecules/CommandField.tsx
+++ b/src/components/molecules/CommandField.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { forwardRef, useState } from 'react'
 
 import { Box, Stack, StackProps, Typography } from '@mui/material'
@@ -137,7 +138,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
           <Typography
             sx={{
               fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-              fontSize: 'calc(9.5px * var(--font-scale))',
+              fontSize: scaledPx(9.5),
               color: numberHintColor,
               transition: 'color 0.14s',
             }}
@@ -180,9 +181,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: isMultiLine
-              ? 'calc(10px * var(--font-scale))'
-              : 'calc(11.5px * var(--font-scale))',
+            fontSize: isMultiLine ? scaledPx(10) : scaledPx(11.5),
             color: hasDone ? accentColor : theme.palette.text.primary,
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-all',
@@ -250,7 +249,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
             <TruncatedText
               text={description}
               sx={{
-                fontSize: 'calc(11px * var(--font-scale))',
+                fontSize: scaledPx(11),
                 color: isFocused
                   ? theme.palette.text.primary
                   : theme.palette.text.secondary,

--- a/src/components/molecules/CommandField.tsx
+++ b/src/components/molecules/CommandField.tsx
@@ -137,7 +137,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
           <Typography
             sx={{
               fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-              fontSize: '9.5px',
+              fontSize: 'calc(9.5px * var(--font-scale))',
               color: numberHintColor,
               transition: 'color 0.14s',
             }}
@@ -180,7 +180,9 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: isMultiLine ? '10px' : '11.5px',
+            fontSize: isMultiLine
+              ? 'calc(10px * var(--font-scale))'
+              : 'calc(11.5px * var(--font-scale))',
             color: hasDone ? accentColor : theme.palette.text.primary,
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-all',
@@ -248,7 +250,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
             <TruncatedText
               text={description}
               sx={{
-                fontSize: '11px',
+                fontSize: 'calc(11px * var(--font-scale))',
                 color: isFocused
                   ? theme.palette.text.primary
                   : theme.palette.text.secondary,

--- a/src/components/molecules/EditModeFooter.tsx
+++ b/src/components/molecules/EditModeFooter.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box, CircularProgress } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
@@ -85,7 +86,7 @@ export function EditModeFooter({
           {editDirty ? (
             <Box
               sx={{
-                fontSize: 'calc(11px * var(--font-scale))',
+                fontSize: scaledPx(11),
                 color: 'text.secondary',
                 fontStyle: 'italic',
               }}
@@ -95,7 +96,7 @@ export function EditModeFooter({
           ) : (
             <Box
               sx={{
-                fontSize: 'calc(11px * var(--font-scale))',
+                fontSize: scaledPx(11),
                 color: 'text.disabled',
               }}
             >

--- a/src/components/molecules/EditModeFooter.tsx
+++ b/src/components/molecules/EditModeFooter.tsx
@@ -85,7 +85,7 @@ export function EditModeFooter({
           {editDirty ? (
             <Box
               sx={{
-                fontSize: '11px',
+                fontSize: 'calc(11px * var(--font-scale))',
                 color: 'text.secondary',
                 fontStyle: 'italic',
               }}
@@ -93,7 +93,12 @@ export function EditModeFooter({
               Unsaved changes
             </Box>
           ) : (
-            <Box sx={{ fontSize: '11px', color: 'text.disabled' }}>
+            <Box
+              sx={{
+                fontSize: 'calc(11px * var(--font-scale))',
+                color: 'text.disabled',
+              }}
+            >
               No changes
             </Box>
           )}

--- a/src/components/molecules/EditableCommandRow.tsx
+++ b/src/components/molecules/EditableCommandRow.tsx
@@ -58,7 +58,9 @@ export function EditableCommandRow({
         component='pre'
         sx={{
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-          fontSize: isMultiLine ? '10px' : '11.5px',
+          fontSize: isMultiLine
+            ? 'calc(10px * var(--font-scale))'
+            : 'calc(11.5px * var(--font-scale))',
           color: theme.palette.text.primary,
           whiteSpace: 'pre-wrap',
           wordBreak: 'break-all',
@@ -103,12 +105,15 @@ export function EditableCommandRow({
           {item.description ? (
             <TruncatedText
               text={item.description}
-              sx={{ fontSize: '11px', color: theme.palette.text.secondary }}
+              sx={{
+                fontSize: 'calc(11px * var(--font-scale))',
+                color: theme.palette.text.secondary,
+              }}
             />
           ) : (
             <Typography
               sx={{
-                fontSize: '11px',
+                fontSize: 'calc(11px * var(--font-scale))',
                 color: theme.palette.text.disabled,
                 fontStyle: 'italic',
               }}
@@ -142,7 +147,7 @@ export function EditableCommandRow({
         <TruncatedText
           text={item.description!}
           sx={{
-            fontSize: '11px',
+            fontSize: 'calc(11px * var(--font-scale))',
             color: theme.palette.text.secondary,
             flexShrink: 1,
           }}

--- a/src/components/molecules/EditableCommandRow.tsx
+++ b/src/components/molecules/EditableCommandRow.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
@@ -58,9 +59,7 @@ export function EditableCommandRow({
         component='pre'
         sx={{
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-          fontSize: isMultiLine
-            ? 'calc(10px * var(--font-scale))'
-            : 'calc(11.5px * var(--font-scale))',
+          fontSize: isMultiLine ? scaledPx(10) : scaledPx(11.5),
           color: theme.palette.text.primary,
           whiteSpace: 'pre-wrap',
           wordBreak: 'break-all',
@@ -106,14 +105,14 @@ export function EditableCommandRow({
             <TruncatedText
               text={item.description}
               sx={{
-                fontSize: 'calc(11px * var(--font-scale))',
+                fontSize: scaledPx(11),
                 color: theme.palette.text.secondary,
               }}
             />
           ) : (
             <Typography
               sx={{
-                fontSize: 'calc(11px * var(--font-scale))',
+                fontSize: scaledPx(11),
                 color: theme.palette.text.disabled,
                 fontStyle: 'italic',
               }}
@@ -147,7 +146,7 @@ export function EditableCommandRow({
         <TruncatedText
           text={item.description!}
           sx={{
-            fontSize: 'calc(11px * var(--font-scale))',
+            fontSize: scaledPx(11),
             color: theme.palette.text.secondary,
             flexShrink: 1,
           }}

--- a/src/components/molecules/EditableGroupBox.tsx
+++ b/src/components/molecules/EditableGroupBox.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { useState } from 'react'
@@ -117,7 +118,7 @@ export function EditableGroupBox({
           variant='caption'
           sx={{
             color: theme.palette.text.secondary,
-            fontSize: 'calc(11px * var(--font-scale))',
+            fontSize: scaledPx(11),
             lineHeight: 1,
             userSelect: 'none',
           }}
@@ -176,7 +177,7 @@ export function EditableGroupBox({
         {isEmpty ? (
           <Typography
             sx={{
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               color: theme.palette.text.disabled,
               fontStyle: 'italic',
               textAlign: 'center',

--- a/src/components/molecules/EditableGroupBox.tsx
+++ b/src/components/molecules/EditableGroupBox.tsx
@@ -117,7 +117,7 @@ export function EditableGroupBox({
           variant='caption'
           sx={{
             color: theme.palette.text.secondary,
-            fontSize: '11px',
+            fontSize: 'calc(11px * var(--font-scale))',
             lineHeight: 1,
             userSelect: 'none',
           }}
@@ -176,7 +176,7 @@ export function EditableGroupBox({
         {isEmpty ? (
           <Typography
             sx={{
-              fontSize: '11px',
+              fontSize: 'calc(11px * var(--font-scale))',
               color: theme.palette.text.disabled,
               fontStyle: 'italic',
               textAlign: 'center',

--- a/src/components/molecules/EditableRowBase.tsx
+++ b/src/components/molecules/EditableRowBase.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { useState } from 'react'
@@ -123,7 +124,7 @@ export function EditableRowBase({
       <Typography
         sx={{
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-          fontSize: 'calc(9.5px * var(--font-scale))',
+          fontSize: scaledPx(9.5),
           color: theme.palette.text.disabled,
           minWidth: '16px',
           textAlign: 'right',

--- a/src/components/molecules/EditableRowBase.tsx
+++ b/src/components/molecules/EditableRowBase.tsx
@@ -123,7 +123,7 @@ export function EditableRowBase({
       <Typography
         sx={{
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-          fontSize: '9.5px',
+          fontSize: 'calc(9.5px * var(--font-scale))',
           color: theme.palette.text.disabled,
           minWidth: '16px',
           textAlign: 'right',

--- a/src/components/molecules/EditableShortcutRow.tsx
+++ b/src/components/molecules/EditableShortcutRow.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
@@ -67,7 +68,7 @@ export function EditableShortcutRow({
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: 'calc(11.5px * var(--font-scale))',
+            fontSize: scaledPx(11.5),
             color: theme.palette.text.primary,
             whiteSpace: 'nowrap',
             lineHeight: 1.55,
@@ -83,14 +84,14 @@ export function EditableShortcutRow({
           <TruncatedText
             text={item.description}
             sx={{
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               color: theme.palette.text.secondary,
             }}
           />
         ) : (
           <Typography
             sx={{
-              fontSize: 'calc(11px * var(--font-scale))',
+              fontSize: scaledPx(11),
               color: theme.palette.text.disabled,
               fontStyle: 'italic',
             }}

--- a/src/components/molecules/EditableShortcutRow.tsx
+++ b/src/components/molecules/EditableShortcutRow.tsx
@@ -67,7 +67,7 @@ export function EditableShortcutRow({
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: '11.5px',
+            fontSize: 'calc(11.5px * var(--font-scale))',
             color: theme.palette.text.primary,
             whiteSpace: 'nowrap',
             lineHeight: 1.55,
@@ -82,12 +82,15 @@ export function EditableShortcutRow({
         {item.description ? (
           <TruncatedText
             text={item.description}
-            sx={{ fontSize: '11px', color: theme.palette.text.secondary }}
+            sx={{
+              fontSize: 'calc(11px * var(--font-scale))',
+              color: theme.palette.text.secondary,
+            }}
           />
         ) : (
           <Typography
             sx={{
-              fontSize: '11px',
+              fontSize: 'calc(11px * var(--font-scale))',
               color: theme.palette.text.disabled,
               fontStyle: 'italic',
             }}

--- a/src/components/molecules/FooterButton.tsx
+++ b/src/components/molecules/FooterButton.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
@@ -46,7 +47,7 @@ export function FooterButton({ onClick, primary, disabled, children }: Props) {
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: 'calc(12px * var(--font-scale))',
+        fontSize: scaledPx(12),
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: disabled ? 'not-allowed' : 'pointer',

--- a/src/components/molecules/FooterButton.tsx
+++ b/src/components/molecules/FooterButton.tsx
@@ -46,7 +46,7 @@ export function FooterButton({ onClick, primary, disabled, children }: Props) {
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: '12px',
+        fontSize: 'calc(12px * var(--font-scale))',
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: disabled ? 'not-allowed' : 'pointer',

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -77,7 +77,7 @@ export const SearchBar = ({
             outline: 'none',
             fontFamily:
               '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif',
-            fontSize: '15px',
+            fontSize: 'calc(15px * var(--font-scale))',
             fontWeight: 500,
             color: theme.palette.text.primary,
             caretColor: accentSolid,

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { KeyboardEvent, RefObject } from 'react'
 
 import { Box } from '@mui/material'
@@ -77,7 +78,7 @@ export const SearchBar = ({
             outline: 'none',
             fontFamily:
               '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif',
-            fontSize: 'calc(15px * var(--font-scale))',
+            fontSize: scaledPx(15),
             fontWeight: 500,
             color: theme.palette.text.primary,
             caretColor: accentSolid,

--- a/src/components/molecules/SearchResultItem.tsx
+++ b/src/components/molecules/SearchResultItem.tsx
@@ -71,7 +71,7 @@ const SheetBadge = ({
         alignItems: 'center',
         gap: '4px',
         fontFamily: FONT_UI,
-        fontSize: '10.5px',
+        fontSize: 'calc(10.5px * var(--font-scale))',
         fontWeight: 500,
         letterSpacing: '0.01em',
         color: focused ? accentSolid : theme.palette.text.secondary,
@@ -191,7 +191,7 @@ export const SearchResultItem = ({
             component='span'
             sx={{
               fontFamily: FONT_UI,
-              fontSize: '13px',
+              fontSize: 'calc(13px * var(--font-scale))',
               fontWeight: 600,
               color: theme.palette.text.primary,
               overflow: 'hidden',
@@ -228,7 +228,7 @@ export const SearchResultItem = ({
         <Box
           sx={{
             fontFamily: FONT_CODE,
-            fontSize: '11.5px',
+            fontSize: 'calc(11.5px * var(--font-scale))',
             color: focused
               ? theme.palette.text.primary
               : theme.palette.text.secondary,

--- a/src/components/molecules/SearchResultItem.tsx
+++ b/src/components/molecules/SearchResultItem.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Fragment, useState } from 'react'
 
 import { Box } from '@mui/material'
@@ -71,7 +72,7 @@ const SheetBadge = ({
         alignItems: 'center',
         gap: '4px',
         fontFamily: FONT_UI,
-        fontSize: 'calc(10.5px * var(--font-scale))',
+        fontSize: scaledPx(10.5),
         fontWeight: 500,
         letterSpacing: '0.01em',
         color: focused ? accentSolid : theme.palette.text.secondary,
@@ -191,7 +192,7 @@ export const SearchResultItem = ({
             component='span'
             sx={{
               fontFamily: FONT_UI,
-              fontSize: 'calc(13px * var(--font-scale))',
+              fontSize: scaledPx(13),
               fontWeight: 600,
               color: theme.palette.text.primary,
               overflow: 'hidden',
@@ -228,7 +229,7 @@ export const SearchResultItem = ({
         <Box
           sx={{
             fontFamily: FONT_CODE,
-            fontSize: 'calc(11.5px * var(--font-scale))',
+            fontSize: scaledPx(11.5),
             color: focused
               ? theme.palette.text.primary
               : theme.palette.text.secondary,

--- a/src/components/molecules/SheetSwitchButton.tsx
+++ b/src/components/molecules/SheetSwitchButton.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import {
   forwardRef,
   useCallback,
@@ -243,7 +244,7 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
                     border: 'none',
                     outline: 'none',
                     fontFamily: 'inherit',
-                    fontSize: 'calc(12px * var(--font-scale))',
+                    fontSize: scaledPx(12),
                     color: theme.palette.text.primary,
                   }}
                 />
@@ -292,7 +293,7 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
                 <Typography
                   sx={{
                     padding: '10px 16px',
-                    fontSize: 'calc(12px * var(--font-scale))',
+                    fontSize: scaledPx(12),
                     color: theme.palette.text.disabled,
                     textAlign: 'center',
                   }}
@@ -363,7 +364,7 @@ const SheetDropdownItem = forwardRef<HTMLDivElement, DropdownItemProps>(
         sx={{
           padding: '7px 12px',
           cursor: 'pointer',
-          fontSize: 'calc(13px * var(--font-scale))',
+          fontSize: scaledPx(13),
           display: 'flex',
           alignItems: 'center',
           gap: '8px',

--- a/src/components/molecules/SheetSwitchButton.tsx
+++ b/src/components/molecules/SheetSwitchButton.tsx
@@ -243,7 +243,7 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
                     border: 'none',
                     outline: 'none',
                     fontFamily: 'inherit',
-                    fontSize: '12px',
+                    fontSize: 'calc(12px * var(--font-scale))',
                     color: theme.palette.text.primary,
                   }}
                 />
@@ -292,7 +292,7 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
                 <Typography
                   sx={{
                     padding: '10px 16px',
-                    fontSize: '12px',
+                    fontSize: 'calc(12px * var(--font-scale))',
                     color: theme.palette.text.disabled,
                     textAlign: 'center',
                   }}
@@ -363,7 +363,7 @@ const SheetDropdownItem = forwardRef<HTMLDivElement, DropdownItemProps>(
         sx={{
           padding: '7px 12px',
           cursor: 'pointer',
-          fontSize: '13px',
+          fontSize: 'calc(13px * var(--font-scale))',
           display: 'flex',
           alignItems: 'center',
           gap: '8px',

--- a/src/components/molecules/ShortcutField.tsx
+++ b/src/components/molecules/ShortcutField.tsx
@@ -31,7 +31,7 @@ export const ShortcutField = (props: ShortcutFieldProps) => {
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: '11.5px',
+            fontSize: 'calc(11.5px * var(--font-scale))',
             color: theme.palette.text.primary,
             whiteSpace: 'nowrap',
             lineHeight: 1.55,
@@ -43,7 +43,7 @@ export const ShortcutField = (props: ShortcutFieldProps) => {
       <TruncatedText
         text={description}
         sx={{
-          fontSize: '11px',
+          fontSize: 'calc(11px * var(--font-scale))',
           color: theme.palette.text.secondary,
         }}
       />

--- a/src/components/molecules/ShortcutField.tsx
+++ b/src/components/molecules/ShortcutField.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Box, Stack, StackProps, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
@@ -31,7 +32,7 @@ export const ShortcutField = (props: ShortcutFieldProps) => {
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: 'calc(11.5px * var(--font-scale))',
+            fontSize: scaledPx(11.5),
             color: theme.palette.text.primary,
             whiteSpace: 'nowrap',
             lineHeight: 1.55,
@@ -43,7 +44,7 @@ export const ShortcutField = (props: ShortcutFieldProps) => {
       <TruncatedText
         text={description}
         sx={{
-          fontSize: 'calc(11px * var(--font-scale))',
+          fontSize: scaledPx(11),
           color: theme.palette.text.secondary,
         }}
       />

--- a/src/components/molecules/WindowTitleBar.tsx
+++ b/src/components/molecules/WindowTitleBar.tsx
@@ -58,7 +58,7 @@ export const WindowTitleBar = ({ title, rightControls }: Props) => {
         >
           <Typography
             sx={{
-              fontSize: '12px',
+              fontSize: 'calc(12px * var(--font-scale))',
               fontWeight: 600,
               color: theme.palette.text.secondary,
               letterSpacing: '0.02em',

--- a/src/components/molecules/WindowTitleBar.tsx
+++ b/src/components/molecules/WindowTitleBar.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { ReactNode } from 'react'
 
 import { Box, Typography } from '@mui/material'
@@ -58,7 +59,7 @@ export const WindowTitleBar = ({ title, rightControls }: Props) => {
         >
           <Typography
             sx={{
-              fontSize: 'calc(12px * var(--font-scale))',
+              fontSize: scaledPx(12),
               fontWeight: 600,
               color: theme.palette.text.secondary,
               letterSpacing: '0.02em',

--- a/src/components/organisms/RcDialog.tsx
+++ b/src/components/organisms/RcDialog.tsx
@@ -92,7 +92,7 @@ function ActionButton({ variant, onClick, children }: ActionButtonProps) {
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: '12px',
+        fontSize: 'calc(12px * var(--font-scale))',
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: 'pointer',
@@ -139,7 +139,7 @@ function SecondaryButton({ onClick, children }: SecondaryButtonProps) {
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: '12px',
+        fontSize: 'calc(12px * var(--font-scale))',
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: 'pointer',
@@ -274,7 +274,7 @@ export function RcDialog({
             <Box
               id='rc-dialog-title'
               sx={{
-                fontSize: '14.5px',
+                fontSize: 'calc(14.5px * var(--font-scale))',
                 fontWeight: 600,
                 color: 'text.primary',
                 mb: '6px',
@@ -287,7 +287,7 @@ export function RcDialog({
             <Box
               id='rc-dialog-description'
               sx={{
-                fontSize: '12.5px',
+                fontSize: 'calc(12.5px * var(--font-scale))',
                 lineHeight: 1.65,
                 color: 'text.secondary',
                 whiteSpace: 'pre-line',

--- a/src/components/organisms/RcDialog.tsx
+++ b/src/components/organisms/RcDialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { scaledPx } from '@/utils/css'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
@@ -92,7 +93,7 @@ function ActionButton({ variant, onClick, children }: ActionButtonProps) {
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: 'calc(12px * var(--font-scale))',
+        fontSize: scaledPx(12),
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: 'pointer',
@@ -139,7 +140,7 @@ function SecondaryButton({ onClick, children }: SecondaryButtonProps) {
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: 'calc(12px * var(--font-scale))',
+        fontSize: scaledPx(12),
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: 'pointer',
@@ -274,7 +275,7 @@ export function RcDialog({
             <Box
               id='rc-dialog-title'
               sx={{
-                fontSize: 'calc(14.5px * var(--font-scale))',
+                fontSize: scaledPx(14.5),
                 fontWeight: 600,
                 color: 'text.primary',
                 mb: '6px',
@@ -287,7 +288,7 @@ export function RcDialog({
             <Box
               id='rc-dialog-description'
               sx={{
-                fontSize: 'calc(12.5px * var(--font-scale))',
+                fontSize: scaledPx(12.5),
                 lineHeight: 1.65,
                 color: 'text.secondary',
                 whiteSpace: 'pre-line',

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -82,7 +82,7 @@ const SearchPlaceholder = ({
       <Box
         sx={{
           fontFamily: FONT_UI,
-          fontSize: '13px',
+          fontSize: 'calc(13px * var(--font-scale))',
           fontWeight: 600,
           color: theme.palette.text.primary,
         }}
@@ -92,7 +92,7 @@ const SearchPlaceholder = ({
       <Box
         sx={{
           fontFamily: FONT_UI,
-          fontSize: '11.5px',
+          fontSize: 'calc(11.5px * var(--font-scale))',
           color: theme.palette.text.secondary,
           maxWidth: '340px',
           lineHeight: 1.55,
@@ -143,7 +143,7 @@ const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
             component='span'
             sx={{
               fontFamily: FONT_CODE,
-              fontSize: '10px',
+              fontSize: 'calc(10px * var(--font-scale))',
               fontWeight: 500,
               color: theme.palette.text.primary,
               background: isDark
@@ -169,7 +169,7 @@ const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
         component='span'
         sx={{
           fontFamily: FONT_UI,
-          fontSize: '10.5px',
+          fontSize: 'calc(10.5px * var(--font-scale))',
           color: theme.palette.text.secondary,
           letterSpacing: '0.01em',
         }}

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { scaledPx } from '@/utils/css'
 import { Fragment, useEffect, useRef } from 'react'
 
 import { Box } from '@mui/material'
@@ -82,7 +83,7 @@ const SearchPlaceholder = ({
       <Box
         sx={{
           fontFamily: FONT_UI,
-          fontSize: 'calc(13px * var(--font-scale))',
+          fontSize: scaledPx(13),
           fontWeight: 600,
           color: theme.palette.text.primary,
         }}
@@ -92,7 +93,7 @@ const SearchPlaceholder = ({
       <Box
         sx={{
           fontFamily: FONT_UI,
-          fontSize: 'calc(11.5px * var(--font-scale))',
+          fontSize: scaledPx(11.5),
           color: theme.palette.text.secondary,
           maxWidth: '340px',
           lineHeight: 1.55,
@@ -143,7 +144,7 @@ const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
             component='span'
             sx={{
               fontFamily: FONT_CODE,
-              fontSize: 'calc(10px * var(--font-scale))',
+              fontSize: scaledPx(10),
               fontWeight: 500,
               color: theme.palette.text.primary,
               background: isDark
@@ -169,7 +170,7 @@ const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
         component='span'
         sx={{
           fontFamily: FONT_UI,
-          fontSize: 'calc(10.5px * var(--font-scale))',
+          fontSize: scaledPx(10.5),
           color: theme.palette.text.secondary,
           letterSpacing: '0.01em',
         }}

--- a/src/hooks/useFontSize.ts
+++ b/src/hooks/useFontSize.ts
@@ -18,6 +18,7 @@ export const useFontSize = () => {
   const [fontSizeSettings, setFontSizeSettings] = useState<FontSizeSettings>(
     DEFAULT_FONT_SIZE_SETTINGS,
   )
+  const [isFontSizeLoaded, setIsFontSizeLoaded] = useState(false)
 
   useEffect(() => {
     // Load initial font size settings
@@ -32,6 +33,8 @@ export const useFontSize = () => {
         error(
           `[useFontSize] Failed to load font size settings: ${errorMessage}`,
         )
+      } finally {
+        setIsFontSizeLoaded(true)
       }
     }
 
@@ -88,6 +91,7 @@ export const useFontSize = () => {
 
   return {
     fontSizeSettings,
+    isFontSizeLoaded,
     increaseFontSize,
     decreaseFontSize,
     resetFontSize,

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -1,0 +1,2 @@
+export const scaledPx = (px: number): string =>
+  `calc(${px}px * var(--font-scale))`


### PR DESCRIPTION
## Summary

- CSS カスタムプロパティ `--font-scale` を `ThemeProviderWrapper.tsx` で `fontSizeSettings.scale` に同期するよう設定
- MUI テーマ経由のスケーリングが届かなかった全コンポーネントのハードコードされた `px` フォントサイズを `calc(Xpx * var(--font-scale))` に置き換え
- 対象: チートシート画面・検索画面・設定画面・編集画面・エクスポート画面など 23 ファイル

## Test plan

- [x] View メニューの Increase Font Size / Decrease Font Size / Reset Font Size を操作する
- [x] メイン画面（コマンド一覧）のテキストがスケーリングされることを確認
- [x] 検索画面（Search）のテキストがスケーリングされることを確認
- [x] 設定画面（Preferences）のテキストがスケーリングされることを確認
- [x] チートシート編集モードのテキストがスケーリングされることを確認
- [x] チートシート管理画面（Edit Cheatsheets）のテキストがスケーリングされることを確認
- [x] エクスポート画面のテキストがスケーリングされることを確認
- [x] フォントサイズをリセットで 1.0 に戻ることを確認

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)