### PR TITLE
fix: テキスト入力欄でコピー・ペーストができない問題を修正する

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,20 @@ fn menu_configuration<R: tauri::Runtime>(
             )?,
             &Submenu::with_items(
                 handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(handle, None)?,
+                    &PredefinedMenuItem::redo(handle, None)?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &PredefinedMenuItem::cut(handle, None)?,
+                    &PredefinedMenuItem::copy(handle, None)?,
+                    &PredefinedMenuItem::paste(handle, None)?,
+                    &PredefinedMenuItem::select_all(handle, None)?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
                 "View ", // NOTE: デフォルトメニューにならないよう、Viewの後にスペースを入れている。
                 true,
                 &[


### PR DESCRIPTION
## Summary

- `src-tauri/src/lib.rs` の `menu_configuration` 関数に Edit サブメニューを追加
- File メニューと View メニューの間に配置
- `PredefinedMenuItem` で Undo / Redo / Cut / Copy / Paste / Select All を登録し、macOS の First Responder チェーンと自動統合することでテキスト入力欄でのクリップボード操作を有効にする

## Test plan

- [x] `cargo test` が全テスト合格することを確認
- [x] アプリを起動し、メニューバーに Edit メニューが表示されることを確認
- [x] Edit Cheatsheets 画面のコマンド追加・編集ウィンドウで Cmd+C / Cmd+V / Cmd+X が動作することを確認
- [x] Preferences 画面や他のテキスト入力フィールドでも同様に動作することを確認

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)