### PR TITLE
refactor: フォントサイズ・カラートークンをMUIテーマで一元管理する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,73 @@ if (saved) {
 - **イベント駆動**: ウィンドウの表示切り替えとリロードに Tauri イベントを使用
 - **型安全性**: フロントエンドとバックエンド間通信で TypeScript 型を共有
 
+### フロントエンドのテーマ管理（フォントサイズ・色）
+
+**ルール: フォントサイズと色は必ず `src/theme/default.ts` の MUI テーマで一元管理する。コンポーネントへのハードコーディングは禁止。**
+
+#### フォントサイズ
+
+`scaledPx()` にリテラル数値を直接渡してはいけない。必ず `theme.custom.fontSize.*` を経由する。
+
+```tsx
+// NG
+fontSize: scaledPx(11)
+
+// OK
+const theme = useTheme()
+fontSize: scaledPx(theme.custom.fontSize.captionSm)
+```
+
+`src/theme/default.ts` の `FONT_SIZE_SCALE` に定義されたキーと対応する用途:
+
+| キー | px値 | 用途 |
+|-----|------|------|
+| `numberHint` | 9.5 | 行番号ヒント（1〜9） |
+| `commandMultiline` | 10 | 複数行コマンドテキスト |
+| `hint` | 10.5 | エラーヒント・補足説明 |
+| `captionSm` | 11 | 説明文・ラベル（小） |
+| `caption` | 11.5 | コマンドテキスト（1行）・バッジ |
+| `body` | 12 | 標準ボディ |
+| `dialogMessage` | 12.5 | ダイアログ本文 |
+| `label` | 13 | 主要ラベル・リストアイテム |
+| `sectionHeader` | 14 | セクションヘッダー |
+| `dialogTitle` | 14.5 | ダイアログタイトル |
+| `searchInput` | 15 | 検索入力フィールド |
+| `hotkeyChar` | 16 | ホットキー入力フィールド |
+
+新しいフォントサイズが必要な場合は `FONT_SIZE_SCALE` と TypeScript 型定義（`Theme['custom']['fontSize']`）の両方に追加する。
+
+#### 色
+
+コンポーネントでは以下のテーマトークンを使用する。`rgba()` や `#xxxxxx` の直書きは禁止。
+
+**アクセントカラー**（ライト: `#0071e3` / ダーク: `#64b4ff`）:
+```tsx
+// 単色
+color: theme.palette.accent.main
+
+// アルファバリアント
+import { alpha } from '@mui/material/styles'
+backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07)
+```
+
+**セマンティックカラートークン** (`theme.palette.*`):
+
+| トークン | 用途 |
+|--------|------|
+| `glass.panel` | カード・パネル・フッター背景 |
+| `glass.field` | 入力フィールド・ホバー背景 |
+| `glass.overlay` | ドロップダウン・ポップオーバー背景 |
+| `surface.hover` | ホバー時背景 |
+| `surface.selected` | 選択時背景 |
+| `amber.text` | 警告テキスト（"Restart Required" 等） |
+| `amber.background` | 警告ボックス背景 |
+| `amber.border` | 警告ボックスボーダー |
+| `divider` | 汎用ボーダー（MUI 標準） |
+| `text.disabled` | 無効・補助的なテキスト色 |
+
+ライト/ダーク両モードの具体的な色値は `src/theme/default.ts` の `getLightPalette()` / `getDarkPalette()` を参照すること。
+
 ### ファイル構造
 - `src/`: Next.js フロントエンドコード
   - `src/app/export/`: チートシートエクスポート選択画面

--- a/src/app/edit-cheatsheets/page.tsx
+++ b/src/app/edit-cheatsheets/page.tsx
@@ -834,7 +834,7 @@ function EditRow({
             height: 2,
             background: accent,
             borderRadius: 2,
-            boxShadow: `0 0 0 2px ${alpha(theme.palette.accent.main, isDark ? 0.20 : 0.18)}`,
+            boxShadow: `0 0 0 2px ${alpha(theme.palette.accent.main, isDark ? 0.2 : 0.18)}`,
             pointerEvents: 'none',
             zIndex: 2,
           }}
@@ -1484,7 +1484,7 @@ export default function EditCheatsheetsPage() {
                 ;(e.currentTarget as HTMLButtonElement).style.background =
                   'transparent'
                 ;(e.currentTarget as HTMLButtonElement).style.borderColor =
-                  alpha(theme.palette.accent.main, isDark ? 0.32 : 0.30)
+                  alpha(theme.palette.accent.main, isDark ? 0.32 : 0.3)
               }}
               sx={{
                 width: '100%',
@@ -1493,7 +1493,7 @@ export default function EditCheatsheetsPage() {
                 justifyContent: 'center',
                 gap: '6px',
                 background: 'transparent',
-                border: `1px dashed ${alpha(theme.palette.accent.main, isDark ? 0.32 : 0.30)}`,
+                border: `1px dashed ${alpha(theme.palette.accent.main, isDark ? 0.32 : 0.3)}`,
                 borderRadius: '8px',
                 padding: '8px 10px',
                 cursor: 'pointer',

--- a/src/app/edit-cheatsheets/page.tsx
+++ b/src/app/edit-cheatsheets/page.tsx
@@ -10,7 +10,7 @@ import {
 import ReactDOM from 'react-dom'
 
 import { Box } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { debug, info, error as logError } from '@tauri-apps/plugin-log'
@@ -195,7 +195,7 @@ function TypeBadge({
   const color = isDark ? meta.colorDark : meta.colorLight
   const bg = isDark ? meta.bgDark : meta.bgLight
   const border = isDark ? meta.borderDark : meta.borderLight
-  const accent = isDark ? '#64b4ff' : '#0071e3'
+  const accent = theme.palette.accent.main
 
   const [open, setOpen] = useState(false)
   const [pos, setPos] = useState<{ top: number; right: number } | null>(null)
@@ -254,7 +254,7 @@ function TypeBadge({
           borderRadius: 999,
           padding: '2px 8px 2px 7px',
           fontFamily: theme.typography.fontFamily,
-          fontSize: scaledPx(9.5),
+          fontSize: scaledPx(theme.custom.fontSize.numberHint),
           fontWeight: 600,
           letterSpacing: '0.06em',
           textTransform: 'uppercase',
@@ -328,9 +328,7 @@ function TypeBadge({
               position: 'fixed',
               top: pos.top,
               right: pos.right,
-              background: isDark
-                ? 'rgba(20,30,48,0.97)'
-                : 'rgba(248,250,254,0.97)',
+              background: theme.palette.glass.overlay,
               border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.75)'}`,
               borderRadius: 10,
               padding: 5,
@@ -345,7 +343,7 @@ function TypeBadge({
           >
             <div
               style={{
-                fontSize: scaledPx(9.5),
+                fontSize: scaledPx(theme.custom.fontSize.numberHint),
                 fontWeight: 600,
                 color: isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
                 letterSpacing: '0.12em',
@@ -410,7 +408,7 @@ function TypeBadge({
                   <span style={{ flex: 1, minWidth: 0 }}>
                     <div
                       style={{
-                        fontSize: scaledPx(12.5),
+                        fontSize: scaledPx(theme.custom.fontSize.dialogMessage),
                         fontWeight: 500,
                         color: isDark
                           ? 'rgba(255,255,255,0.92)'
@@ -421,7 +419,7 @@ function TypeBadge({
                     </div>
                     <div
                       style={{
-                        fontSize: scaledPx(10.5),
+                        fontSize: scaledPx(theme.custom.fontSize.hint),
                         color: isDark
                           ? 'rgba(255,255,255,0.45)'
                           : 'rgba(0,0,0,0.45)',
@@ -470,7 +468,7 @@ function LayoutBadge({
   const locked = sheetType === 'shortcut'
   const effectiveValue = locked ? 'inline' : value
   const meta = LAYOUT_META[effectiveValue]
-  const accent = isDark ? '#64b4ff' : '#0071e3'
+  const accent = theme.palette.accent.main
 
   const [open, setOpen] = useState(false)
   const [pos, setPos] = useState<{ top: number; right: number } | null>(null)
@@ -539,7 +537,7 @@ function LayoutBadge({
           borderRadius: 6,
           padding: '2px 6px',
           fontFamily: theme.typography.fontFamily,
-          fontSize: scaledPx(11),
+          fontSize: scaledPx(theme.custom.fontSize.captionSm),
           fontWeight: 500,
           color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
           cursor: locked ? 'default' : 'pointer',
@@ -565,7 +563,7 @@ function LayoutBadge({
         <span
           style={{
             fontFamily: '"JetBrains Mono","Fira Code","SF Mono",monospace',
-            fontSize: scaledPx(10.5),
+            fontSize: scaledPx(theme.custom.fontSize.hint),
             color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
             letterSpacing: '0.01em',
             flex: 1,
@@ -621,9 +619,7 @@ function LayoutBadge({
               position: 'fixed',
               top: pos.top,
               right: pos.right,
-              background: isDark
-                ? 'rgba(20,30,48,0.97)'
-                : 'rgba(248,250,254,0.97)',
+              background: theme.palette.glass.overlay,
               border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.75)'}`,
               borderRadius: 10,
               padding: 5,
@@ -638,7 +634,7 @@ function LayoutBadge({
           >
             <div
               style={{
-                fontSize: scaledPx(9.5),
+                fontSize: scaledPx(theme.custom.fontSize.numberHint),
                 fontWeight: 600,
                 color: isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
                 letterSpacing: '0.12em',
@@ -713,7 +709,7 @@ function LayoutBadge({
                       style={{
                         fontFamily:
                           '"JetBrains Mono","Fira Code","SF Mono",monospace',
-                        fontSize: scaledPx(12),
+                        fontSize: scaledPx(theme.custom.fontSize.body),
                         fontWeight: 500,
                         color: isDark
                           ? 'rgba(255,255,255,0.92)'
@@ -724,7 +720,7 @@ function LayoutBadge({
                     </div>
                     <div
                       style={{
-                        fontSize: scaledPx(10.5),
+                        fontSize: scaledPx(theme.custom.fontSize.hint),
                         color: isDark
                           ? 'rgba(255,255,255,0.45)'
                           : 'rgba(0,0,0,0.45)',
@@ -802,7 +798,7 @@ function EditRow({
 }) {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accent = isDark ? '#64b4ff' : '#0071e3'
+  const accent = theme.palette.accent.main
   const panelBorder = isDark
     ? 'rgba(255,255,255,0.10)'
     : 'rgba(255,255,255,0.75)'
@@ -838,7 +834,7 @@ function EditRow({
             height: 2,
             background: accent,
             borderRadius: 2,
-            boxShadow: `0 0 0 2px ${isDark ? 'rgba(100,180,255,0.20)' : 'rgba(0,113,227,0.18)'}`,
+            boxShadow: `0 0 0 2px ${alpha(theme.palette.accent.main, isDark ? 0.20 : 0.18)}`,
             pointerEvents: 'none',
             zIndex: 2,
           }}
@@ -992,7 +988,7 @@ function EditRow({
                 borderRadius: 6,
                 padding: '4px 8px',
                 fontFamily: theme.typography.fontFamily,
-                fontSize: scaledPx(13),
+                fontSize: scaledPx(theme.custom.fontSize.label),
                 fontWeight: 500,
                 color: isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.85)',
                 caretColor: accent,
@@ -1028,7 +1024,7 @@ function EditRow({
             <div
               style={{
                 fontFamily: theme.typography.fontFamily,
-                fontSize: scaledPx(10.5),
+                fontSize: scaledPx(theme.custom.fontSize.hint),
                 color: '#ff6b6b',
                 paddingLeft: 9,
                 lineHeight: 1.4,
@@ -1115,8 +1111,8 @@ function EditRow({
 export default function EditCheatsheetsPage() {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accent = isDark ? '#64b4ff' : '#0071e3'
-  const divider = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)'
+  const accent = theme.palette.accent.main
+  const divider = theme.palette.divider
 
   const { getConfirmActions } = usePreferencesStore()
   const { showError } = useNotificationContext() ?? {}
@@ -1413,7 +1409,7 @@ export default function EditCheatsheetsPage() {
             <Box
               sx={{
                 padding: '16px',
-                fontSize: scaledPx(12),
+                fontSize: scaledPx(theme.custom.fontSize.body),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -1423,7 +1419,7 @@ export default function EditCheatsheetsPage() {
             <Box
               sx={{
                 padding: '16px',
-                fontSize: scaledPx(12),
+                fontSize: scaledPx(theme.custom.fontSize.body),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -1470,9 +1466,7 @@ export default function EditCheatsheetsPage() {
           sx={{
             flexShrink: 0,
             borderTop: `0.5px solid ${divider}`,
-            background: isDark
-              ? 'rgba(255,255,255,0.018)'
-              : 'rgba(255,255,255,0.30)',
+            background: theme.palette.glass.panel,
           }}
         >
           {/* Add row button */}
@@ -1482,7 +1476,7 @@ export default function EditCheatsheetsPage() {
               onClick={addRow}
               onMouseEnter={(e) => {
                 ;(e.currentTarget as HTMLButtonElement).style.background =
-                  isDark ? 'rgba(100,180,255,0.06)' : 'rgba(0,113,227,0.05)'
+                  alpha(theme.palette.accent.main, isDark ? 0.06 : 0.05)
                 ;(e.currentTarget as HTMLButtonElement).style.borderColor =
                   accent
               }}
@@ -1490,7 +1484,7 @@ export default function EditCheatsheetsPage() {
                 ;(e.currentTarget as HTMLButtonElement).style.background =
                   'transparent'
                 ;(e.currentTarget as HTMLButtonElement).style.borderColor =
-                  isDark ? 'rgba(100,180,255,0.32)' : 'rgba(0,113,227,0.30)'
+                  alpha(theme.palette.accent.main, isDark ? 0.32 : 0.30)
               }}
               sx={{
                 width: '100%',
@@ -1499,12 +1493,12 @@ export default function EditCheatsheetsPage() {
                 justifyContent: 'center',
                 gap: '6px',
                 background: 'transparent',
-                border: `1px dashed ${isDark ? 'rgba(100,180,255,0.32)' : 'rgba(0,113,227,0.30)'}`,
+                border: `1px dashed ${alpha(theme.palette.accent.main, isDark ? 0.32 : 0.30)}`,
                 borderRadius: '8px',
                 padding: '8px 10px',
                 cursor: 'pointer',
                 fontFamily: theme.typography.fontFamily,
-                fontSize: scaledPx(12),
+                fontSize: scaledPx(theme.custom.fontSize.body),
                 fontWeight: 500,
                 color: accent,
                 transition: 'all 0.14s',
@@ -1564,7 +1558,7 @@ export default function EditCheatsheetsPage() {
                     component='span'
                     sx={{
                       fontFamily: theme.typography.fontFamily,
-                      fontSize: scaledPx(11),
+                      fontSize: scaledPx(theme.custom.fontSize.captionSm),
                       color: '#ff6b6b',
                       fontWeight: 500,
                     }}
@@ -1577,7 +1571,7 @@ export default function EditCheatsheetsPage() {
                   component='span'
                   sx={{
                     fontFamily: theme.typography.fontFamily,
-                    fontSize: scaledPx(11),
+                    fontSize: scaledPx(theme.custom.fontSize.captionSm),
                     color: theme.palette.text.secondary,
                     fontStyle: 'italic',
                   }}
@@ -1589,7 +1583,7 @@ export default function EditCheatsheetsPage() {
                   component='span'
                   sx={{
                     fontFamily: theme.typography.fontFamily,
-                    fontSize: scaledPx(11),
+                    fontSize: scaledPx(theme.custom.fontSize.captionSm),
                     color: isDark
                       ? 'rgba(255,255,255,0.22)'
                       : 'rgba(0,0,0,0.28)',

--- a/src/app/edit-command/page.tsx
+++ b/src/app/edit-command/page.tsx
@@ -157,7 +157,7 @@ export default function EditCommandPage() {
             value={groupEditId}
             onChange={(e) => setGroupEditId(e.target.value)}
             size='small'
-            sx={{ fontSize: scaledPx(13) }}
+            sx={{ fontSize: scaledPx(theme.custom.fontSize.label) }}
             displayEmpty
           >
             <MenuItem value=''>
@@ -183,7 +183,7 @@ export default function EditCommandPage() {
             }
             size='small'
             fullWidth
-            sx={{ fontSize: scaledPx(13) }}
+            sx={{ fontSize: scaledPx(theme.custom.fontSize.label) }}
           />
         </FieldRow>
 
@@ -217,7 +217,7 @@ export default function EditCommandPage() {
                 sx={{
                   '& textarea': {
                     fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-                    fontSize: scaledPx(12),
+                    fontSize: scaledPx(theme.custom.fontSize.body),
                   },
                 }}
               />
@@ -227,7 +227,7 @@ export default function EditCommandPage() {
                 value={layout}
                 onChange={(e) => setLayout(e.target.value as CommandLayout)}
                 size='small'
-                sx={{ fontSize: scaledPx(13) }}
+                sx={{ fontSize: scaledPx(theme.custom.fontSize.label) }}
               >
                 {LAYOUT_OPTIONS.map((o) => (
                   <MenuItem key={o.value} value={o.value}>
@@ -280,7 +280,7 @@ function FieldRow({
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
       <Box
         sx={{
-          fontSize: scaledPx(11),
+          fontSize: scaledPx(theme.custom.fontSize.captionSm),
           fontWeight: 600,
           color: 'text.secondary',
           letterSpacing: '0.01em',
@@ -292,7 +292,7 @@ function FieldRow({
       {hint && (
         <Box
           sx={{
-            fontSize: scaledPx(10.5),
+            fontSize: scaledPx(theme.custom.fontSize.hint),
             color: theme.palette.text.disabled,
             lineHeight: 1.4,
           }}

--- a/src/app/edit-group/page.tsx
+++ b/src/app/edit-group/page.tsx
@@ -110,7 +110,7 @@ export default function EditGroupPage() {
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Box
             sx={{
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               fontWeight: 600,
               color: 'text.secondary',
             }}

--- a/src/app/export/page.tsx
+++ b/src/app/export/page.tsx
@@ -72,7 +72,7 @@ function ExportCheckbox({
         transition: 'background 0.12s, border-color 0.12s',
         '&:hover': {
           boxShadow: active
-            ? `0 0 0 6px ${alpha(theme.palette.accent.main, 0.10)}`
+            ? `0 0 0 6px ${alpha(theme.palette.accent.main, 0.1)}`
             : `0 0 0 6px ${isDark ? 'rgba(255,255,255,0.04)' : alpha(theme.palette.accent.main, 0.06)}`,
           borderColor: active
             ? accentSolid
@@ -504,12 +504,10 @@ export default function ExportPage() {
             sx={{
               fontFamily: '"JetBrains Mono", "Fira Code", monospace',
               fontSize: scaledPx(10),
-              color: noneOn
-                ? theme.palette.text.disabled
-                : accentSolid,
+              color: noneOn ? theme.palette.text.disabled : accentSolid,
               background: noneOn
                 ? theme.palette.surface.hover
-                : alpha(theme.palette.accent.main, isDark ? 0.12 : 0.10),
+                : alpha(theme.palette.accent.main, isDark ? 0.12 : 0.1),
               border: `0.5px solid ${
                 noneOn
                   ? theme.palette.divider

--- a/src/app/export/page.tsx
+++ b/src/app/export/page.tsx
@@ -3,7 +3,7 @@ import { scaledPx } from '@/utils/css'
 import { useCallback, useEffect, useState } from 'react'
 
 import { Box, Typography } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { save } from '@tauri-apps/plugin-dialog'
@@ -34,7 +34,7 @@ function ExportCheckbox({
 }) {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
+  const accentSolid = theme.palette.accent.main
   const active = checked || !!indeterminate
 
   return (
@@ -72,8 +72,8 @@ function ExportCheckbox({
         transition: 'background 0.12s, border-color 0.12s',
         '&:hover': {
           boxShadow: active
-            ? `0 0 0 6px ${isDark ? 'rgba(100,180,255,0.10)' : 'rgba(0,113,227,0.10)'}`
-            : `0 0 0 6px ${isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,113,227,0.06)'}`,
+            ? `0 0 0 6px ${alpha(theme.palette.accent.main, 0.10)}`
+            : `0 0 0 6px ${isDark ? 'rgba(255,255,255,0.04)' : alpha(theme.palette.accent.main, 0.06)}`,
           borderColor: active
             ? accentSolid
             : isDark
@@ -140,9 +140,7 @@ function ExportRow({
         transition: 'background 0.1s',
         userSelect: 'none',
         '&:hover': {
-          background: isDark
-            ? 'rgba(255,255,255,0.045)'
-            : 'rgba(255,255,255,0.55)',
+          background: theme.palette.glass.field,
         },
       }}
     >
@@ -151,7 +149,7 @@ function ExportRow({
         sx={{
           flex: 1,
           minWidth: 0,
-          fontSize: scaledPx(13),
+          fontSize: scaledPx(theme.custom.fontSize.label),
           fontWeight: sheet.checked ? 500 : 400,
           color: sheet.checked
             ? theme.palette.text.primary
@@ -182,7 +180,7 @@ function ResultModal({
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const ok = kind === 'success'
-  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
+  const accentSolid = theme.palette.accent.main
 
   return (
     <Box
@@ -289,7 +287,7 @@ function ResultModal({
           <>
             <Typography
               sx={{
-                fontSize: scaledPx(11),
+                fontSize: scaledPx(theme.custom.fontSize.captionSm),
                 color: theme.palette.text.secondary,
                 textAlign: 'center',
                 lineHeight: 1.5,
@@ -301,7 +299,7 @@ function ResultModal({
             <Box
               sx={{
                 fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-                fontSize: scaledPx(10.5),
+                fontSize: scaledPx(theme.custom.fontSize.hint),
                 color: theme.palette.text.primary,
                 background: isDark ? 'rgba(0,0,0,0.30)' : 'rgba(0,0,0,0.04)',
                 border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.75)'}`,
@@ -331,7 +329,7 @@ function ResultModal({
             borderRadius: '7px',
             padding: '6px 22px',
             fontFamily: theme.typography.fontFamily,
-            fontSize: scaledPx(12.5),
+            fontSize: scaledPx(theme.custom.fontSize.dialogMessage),
             fontWeight: 600,
             cursor: 'pointer',
             alignSelf: 'stretch',
@@ -349,7 +347,7 @@ function ResultModal({
 export default function ExportPage() {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
+  const accentSolid = theme.palette.accent.main
 
   const [sheets, setSheets] = useState<SheetInfo[]>([])
   const [loading, setLoading] = useState(true)
@@ -424,7 +422,7 @@ export default function ExportPage() {
   const panelBorder = isDark
     ? 'rgba(255,255,255,0.10)'
     : 'rgba(255,255,255,0.75)'
-  const divider = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)'
+  const divider = theme.palette.divider
 
   return (
     <>
@@ -485,7 +483,7 @@ export default function ExportPage() {
           >
             <Typography
               sx={{
-                fontSize: scaledPx(12.5),
+                fontSize: scaledPx(theme.custom.fontSize.dialogMessage),
                 fontWeight: 600,
                 color: theme.palette.text.primary,
               }}
@@ -494,7 +492,7 @@ export default function ExportPage() {
             </Typography>
             <Typography
               sx={{
-                fontSize: scaledPx(10.5),
+                fontSize: scaledPx(theme.custom.fontSize.hint),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -507,25 +505,15 @@ export default function ExportPage() {
               fontFamily: '"JetBrains Mono", "Fira Code", monospace',
               fontSize: scaledPx(10),
               color: noneOn
-                ? isDark
-                  ? 'rgba(255,255,255,0.25)'
-                  : 'rgba(0,0,0,0.28)'
+                ? theme.palette.text.disabled
                 : accentSolid,
               background: noneOn
-                ? isDark
-                  ? 'rgba(255,255,255,0.06)'
-                  : 'rgba(0,0,0,0.05)'
-                : isDark
-                  ? 'rgba(100,180,255,0.12)'
-                  : 'rgba(0,113,227,0.10)',
+                ? theme.palette.surface.hover
+                : alpha(theme.palette.accent.main, isDark ? 0.12 : 0.10),
               border: `0.5px solid ${
                 noneOn
-                  ? isDark
-                    ? 'rgba(255,255,255,0.08)'
-                    : 'rgba(0,0,0,0.06)'
-                  : isDark
-                    ? 'rgba(100,180,255,0.28)'
-                    : 'rgba(0,113,227,0.22)'
+                  ? theme.palette.divider
+                  : alpha(theme.palette.accent.main, isDark ? 0.28 : 0.22)
               }`,
               padding: '2px 8px',
               borderRadius: '999px',
@@ -558,7 +546,7 @@ export default function ExportPage() {
             <Typography
               sx={{
                 padding: '16px',
-                fontSize: scaledPx(12),
+                fontSize: scaledPx(theme.custom.fontSize.body),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -568,7 +556,7 @@ export default function ExportPage() {
             <Typography
               sx={{
                 padding: '16px',
-                fontSize: scaledPx(12),
+                fontSize: scaledPx(theme.custom.fontSize.body),
                 color: theme.palette.text.secondary,
               }}
             >
@@ -627,7 +615,7 @@ export default function ExportPage() {
             </svg>
             <Typography
               sx={{
-                fontSize: scaledPx(11),
+                fontSize: scaledPx(theme.custom.fontSize.captionSm),
                 color: theme.palette.text.secondary,
               }}
             >

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -33,7 +33,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
 import { open as openOsDialog } from '@tauri-apps/plugin-dialog'
 import { debug, error } from '@tauri-apps/plugin-log'
@@ -463,7 +463,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: scaledPx(14),
+              fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -476,7 +476,7 @@ export default function Page() {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
               <Typography
                 sx={{
-                  fontSize: scaledPx(13),
+                  fontSize: scaledPx(theme.custom.fontSize.label),
                   fontWeight: 500,
                   color: 'text.primary',
                 }}
@@ -486,7 +486,7 @@ export default function Page() {
               <Typography
                 sx={{
                   color: 'text.secondary',
-                  fontSize: scaledPx(13),
+                  fontSize: scaledPx(theme.custom.fontSize.label),
                 }}
               >
                 :
@@ -502,7 +502,7 @@ export default function Page() {
                     borderRadius: '6px',
                     padding: '4px 11px',
                     fontFamily: 'monospace',
-                    fontSize: scaledPx(12),
+                    fontSize: scaledPx(theme.custom.fontSize.body),
                     color: 'text.primary',
                     boxShadow: !isDark
                       ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
@@ -536,13 +536,9 @@ export default function Page() {
                       width: 28,
                       height: 28,
                       borderRadius: '7px',
-                      border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.14)'}`,
-                      backgroundColor: isDark
-                        ? 'rgba(100,180,255,0.10)'
-                        : 'rgba(0,113,227,0.07)',
-                      color: isDark
-                        ? 'rgba(255,255,255,0.25)'
-                        : 'rgba(0,0,0,0.28)',
+                      border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
+                      backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                      color: theme.palette.text.disabled,
                       '&:hover': {
                         borderColor: theme.palette.primary.main,
                         color: theme.palette.primary.main,
@@ -563,7 +559,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: scaledPx(14),
+              fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -587,7 +583,7 @@ export default function Page() {
         <Box sx={{ py: '12px' }}>
           <Typography
             sx={{
-              fontSize: scaledPx(14),
+              fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
               fontWeight: 600,
               letterSpacing: '0.01em',
               mb: '10px',
@@ -603,9 +599,7 @@ export default function Page() {
                 flexDirection: 'column',
                 gap: '14px',
                 p: '12px 14px',
-                backgroundColor: isDark
-                  ? 'rgba(255,255,255,0.025)'
-                  : 'rgba(255,255,255,0.35)',
+                backgroundColor: theme.palette.glass.panel,
                 border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.6)'}`,
                 borderRadius: '10px',
                 boxShadow: isDark
@@ -626,7 +620,7 @@ export default function Page() {
                   <RowDot />
                   <Typography
                     sx={{
-                      fontSize: scaledPx(13),
+                      fontSize: scaledPx(theme.custom.fontSize.label),
                       color: 'text.primary',
                     }}
                   >
@@ -654,7 +648,7 @@ export default function Page() {
                   <RowDot />
                   <Typography
                     sx={{
-                      fontSize: scaledPx(13),
+                      fontSize: scaledPx(theme.custom.fontSize.label),
                       color: 'text.primary',
                     }}
                   >
@@ -682,7 +676,7 @@ export default function Page() {
                   <RowDot />
                   <Typography
                     sx={{
-                      fontSize: scaledPx(13),
+                      fontSize: scaledPx(theme.custom.fontSize.label),
                       color: 'text.primary',
                     }}
                   >
@@ -694,16 +688,14 @@ export default function Page() {
                     sx={{
                       height: 'auto',
                       py: '2px',
-                      fontSize: scaledPx(9.5),
+                      fontSize: scaledPx(theme.custom.fontSize.numberHint),
                       fontFamily: 'monospace',
                       letterSpacing: '0.06em',
                       textTransform: 'uppercase',
                       borderRadius: '4px',
-                      backgroundColor: isDark
-                        ? 'rgba(255,180,80,0.10)'
-                        : 'rgba(180,120,0,0.07)',
-                      border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.28)' : 'rgba(180,120,0,0.22)'}`,
-                      color: isDark ? '#f5c46b' : '#8a6300',
+                      backgroundColor: theme.palette.amber.background,
+                      border: `0.5px solid ${theme.palette.amber.border}`,
+                      color: theme.palette.amber.text,
                       '& .MuiChip-label': { px: '6px' },
                     }}
                   />
@@ -725,13 +717,9 @@ export default function Page() {
                         height: 30,
                         borderRadius: '7px',
                         flexShrink: 0,
-                        border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.14)'}`,
-                        backgroundColor: isDark
-                          ? 'rgba(100,180,255,0.10)'
-                          : 'rgba(0,113,227,0.07)',
-                        color: isDark
-                          ? 'rgba(255,255,255,0.25)'
-                          : 'rgba(0,0,0,0.28)',
+                        border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
+                        backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                        color: theme.palette.text.disabled,
                         '&:hover': {
                           borderColor: theme.palette.primary.main,
                           color: theme.palette.primary.main,
@@ -746,9 +734,7 @@ export default function Page() {
                     sx={{
                       flex: 1,
                       minWidth: 0,
-                      backgroundColor: isDark
-                        ? 'rgba(255,255,255,0.055)'
-                        : 'rgba(255,255,255,0.55)',
+                      backgroundColor: theme.palette.glass.field,
                       border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.75)'}`,
                       borderRadius: '7px',
                       px: '10px',
@@ -762,7 +748,7 @@ export default function Page() {
                       component='span'
                       sx={{
                         fontFamily: 'monospace',
-                        fontSize: scaledPx(11),
+                        fontSize: scaledPx(theme.custom.fontSize.captionSm),
                         display: 'block',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
@@ -796,7 +782,7 @@ export default function Page() {
                     <RowDot />
                     <Typography
                       sx={{
-                        fontSize: scaledPx(13),
+                        fontSize: scaledPx(theme.custom.fontSize.label),
                         color: 'text.primary',
                       }}
                     >
@@ -808,16 +794,14 @@ export default function Page() {
                       sx={{
                         height: 'auto',
                         py: '2px',
-                        fontSize: scaledPx(9.5),
+                        fontSize: scaledPx(theme.custom.fontSize.numberHint),
                         fontFamily: 'monospace',
                         letterSpacing: '0.06em',
                         textTransform: 'uppercase',
                         borderRadius: '4px',
-                        backgroundColor: isDark
-                          ? 'rgba(255,180,80,0.10)'
-                          : 'rgba(180,120,0,0.07)',
-                        border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.28)' : 'rgba(180,120,0,0.22)'}`,
-                        color: isDark ? '#f5c46b' : '#8a6300',
+                        backgroundColor: theme.palette.amber.background,
+                        border: `0.5px solid ${theme.palette.amber.border}`,
+                        color: theme.palette.amber.text,
                         '& .MuiChip-label': { px: '6px' },
                       }}
                     />
@@ -831,13 +815,9 @@ export default function Page() {
                           width: 28,
                           height: 28,
                           borderRadius: '7px',
-                          border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.14)'}`,
-                          backgroundColor: isDark
-                            ? 'rgba(100,180,255,0.10)'
-                            : 'rgba(0,113,227,0.07)',
-                          color: isDark
-                            ? 'rgba(255,255,255,0.25)'
-                            : 'rgba(0,0,0,0.28)',
+                          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
+                          backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                          color: theme.palette.text.disabled,
                           '&:hover': {
                             borderColor: theme.palette.primary.main,
                             color: theme.palette.primary.main,
@@ -855,13 +835,9 @@ export default function Page() {
                           width: 28,
                           height: 28,
                           borderRadius: '7px',
-                          border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.14)'}`,
-                          backgroundColor: isDark
-                            ? 'rgba(100,180,255,0.10)'
-                            : 'rgba(0,113,227,0.07)',
-                          color: isDark
-                            ? 'rgba(255,255,255,0.25)'
-                            : 'rgba(0,0,0,0.28)',
+                          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
+                          backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                          color: theme.palette.text.disabled,
                           '&:hover': {
                             borderColor: theme.palette.primary.main,
                             color: theme.palette.primary.main,
@@ -969,13 +945,14 @@ function dialogPaperSx(isDark: boolean) {
 }
 
 function LogSummaryRow({ label, value }: { label: string; value: string }) {
+  const theme = useTheme()
   return (
     <Box
       sx={{ display: 'flex', alignItems: 'baseline', gap: '8px', minWidth: 0 }}
     >
       <Typography
         sx={{
-          fontSize: scaledPx(11),
+          fontSize: scaledPx(theme.custom.fontSize.captionSm),
           flexShrink: 0,
           width: 110,
           fontWeight: 500,
@@ -987,7 +964,7 @@ function LogSummaryRow({ label, value }: { label: string; value: string }) {
       <Typography
         title={value}
         sx={{
-          fontSize: scaledPx(11),
+          fontSize: scaledPx(theme.custom.fontSize.captionSm),
           fontFamily: 'monospace',
           color: 'text.primary',
           overflow: 'hidden',
@@ -1036,7 +1013,7 @@ function NumberInputField({
     <Box>
       <Typography
         sx={{
-          fontSize: scaledPx(11),
+          fontSize: scaledPx(theme.custom.fontSize.captionSm),
           fontWeight: 500,
           mb: '6px',
           color: 'text.secondary',
@@ -1049,9 +1026,7 @@ function NumberInputField({
         sx={{
           display: 'flex',
           alignItems: 'center',
-          backgroundColor: isDark
-            ? 'rgba(255,255,255,0.055)'
-            : 'rgba(255,255,255,0.55)',
+          backgroundColor: theme.palette.glass.field,
           border: `0.5px solid ${borderColor}`,
           borderRadius: '7px',
           padding: '4px 8px',
@@ -1074,7 +1049,7 @@ function NumberInputField({
             border: 'none',
             outline: 'none',
             fontFamily: 'monospace',
-            fontSize: scaledPx(12),
+            fontSize: scaledPx(theme.custom.fontSize.body),
             color: 'text.primary',
             caretColor: theme.palette.primary.main,
             padding: '2px 0',
@@ -1100,7 +1075,7 @@ function NumberInputField({
       {hint && (
         <Typography
           sx={{
-            fontSize: scaledPx(10.5),
+            fontSize: scaledPx(theme.custom.fontSize.hint),
             color: 'error.main',
             mt: '4px',
             lineHeight: 1.4,
@@ -1153,7 +1128,7 @@ function Keycap({ children, big = false, active = true }: KeycapProps) {
             : '0 1px 0 rgba(0,0,30,0.08), inset 0 0.5px 0 rgba(255,255,255,0.9)'
           : 'none',
         fontFamily: 'monospace',
-        fontSize: big ? scaledPx(15) : scaledPx(12),
+        fontSize: big ? scaledPx(theme.custom.fontSize.searchInput) : scaledPx(theme.custom.fontSize.body),
         fontWeight: 600,
         color: active ? 'text.primary' : 'text.secondary',
         textAlign: 'center',
@@ -1213,19 +1188,13 @@ function ShortcutCheckbox({
           outlineOffset: '2px',
         },
         backgroundColor: checked
-          ? isDark
-            ? 'rgba(100,180,255,0.10)'
-            : 'rgba(0,113,227,0.06)'
+          ? alpha(theme.palette.accent.main, isDark ? 0.10 : 0.06)
           : hovered
-            ? isDark
-              ? 'rgba(255,255,255,0.04)'
-              : 'rgba(255,255,255,0.55)'
+            ? theme.palette.surface.hover
             : 'transparent',
         border: `0.5px solid ${
           checked
-            ? isDark
-              ? 'rgba(100,180,255,0.30)'
-              : 'rgba(0,113,227,0.22)'
+            ? alpha(theme.palette.accent.main, isDark ? 0.30 : 0.22)
             : hovered
               ? theme.palette.divider
               : 'transparent'
@@ -1270,7 +1239,7 @@ function ShortcutCheckbox({
       <Keycap active={checked}>{symbol}</Keycap>
       <Typography
         sx={{
-          fontSize: scaledPx(13),
+          fontSize: scaledPx(theme.custom.fontSize.label),
           color: checked ? 'text.primary' : 'text.secondary',
         }}
       >
@@ -1322,13 +1291,13 @@ function HotkeyInput({ value, onChange, invalid }: HotkeyInputProps) {
         borderRadius: '7px',
         padding: '7px 8px',
         fontFamily: 'monospace',
-        fontSize: scaledPx(16),
+        fontSize: scaledPx(theme.custom.fontSize.hotkeyChar),
         fontWeight: 600,
         color: 'text.primary',
         caretColor: theme.palette.primary.main,
         outline: 'none',
         boxShadow: focused
-          ? `0 0 0 3px ${isDark ? 'rgba(100,180,255,0.13)' : 'rgba(0,113,227,0.10)'}`
+          ? `0 0 0 3px ${alpha(theme.palette.accent.main, isDark ? 0.13 : 0.10)}`
           : !isDark
             ? 'inset 0 1px 2px rgba(0,0,0,0.04)'
             : 'none',
@@ -1408,7 +1377,7 @@ function ShortcutSettingsDialog({
       <DialogTitle
         sx={{
           padding: '14px 18px 12px',
-          fontSize: scaledPx(14),
+          fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
           fontWeight: 600,
           borderBottom: `0.5px solid ${theme.palette.divider}`,
         }}
@@ -1430,10 +1399,8 @@ function ShortcutSettingsDialog({
             alignItems: 'flex-start',
             gap: '9px',
             p: '9px 11px',
-            backgroundColor: isDark
-              ? 'rgba(255,180,80,0.08)'
-              : 'rgba(180,120,0,0.06)',
-            border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.30)' : 'rgba(180,120,0,0.22)'}`,
+            backgroundColor: theme.palette.amber.background,
+            border: `0.5px solid ${theme.palette.amber.border}`,
             borderRadius: '8px',
           }}
         >
@@ -1442,14 +1409,14 @@ function ShortcutSettingsDialog({
               fontSize: '14px',
               mt: '1px',
               flexShrink: 0,
-              color: isDark ? '#f5c46b' : '#a87a00',
+              color: theme.palette.amber.text,
             }}
           />
           <Typography
             sx={{
               lineHeight: 1.5,
-              color: isDark ? '#f5c46b' : '#8a6300',
-              fontSize: scaledPx(11.5),
+              color: theme.palette.amber.text,
+              fontSize: scaledPx(theme.custom.fontSize.caption),
             }}
           >
             Changing the global shortcut takes effect after restarting
@@ -1465,9 +1432,7 @@ function ShortcutSettingsDialog({
             alignItems: 'center',
             gap: '8px',
             p: '16px 12px',
-            backgroundColor: isDark
-              ? 'rgba(255,255,255,0.025)'
-              : 'rgba(255,255,255,0.35)',
+            backgroundColor: theme.palette.glass.panel,
             border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.6)'}`,
             borderRadius: '10px',
             boxShadow: !isDark ? 'inset 0 1px 0 rgba(255,255,255,0.5)' : 'none',
@@ -1475,7 +1440,7 @@ function ShortcutSettingsDialog({
         >
           <Typography
             sx={{
-              fontSize: scaledPx(10.5),
+              fontSize: scaledPx(theme.custom.fontSize.hint),
               fontWeight: 600,
               letterSpacing: '0.08em',
               textTransform: 'uppercase',
@@ -1495,7 +1460,7 @@ function ShortcutSettingsDialog({
           ) : (
             <Typography
               sx={{
-                fontSize: scaledPx(13),
+                fontSize: scaledPx(theme.custom.fontSize.label),
                 color: 'text.secondary',
                 p: '7px 0',
               }}
@@ -1509,7 +1474,7 @@ function ShortcutSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1562,7 +1527,7 @@ function ShortcutSettingsDialog({
           {showError && !hasModifier && (
             <Typography
               sx={{
-                fontSize: scaledPx(10.5),
+                fontSize: scaledPx(theme.custom.fontSize.hint),
                 color: theme.palette.error.main,
                 mt: '2px',
               }}
@@ -1576,7 +1541,7 @@ function ShortcutSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1596,7 +1561,7 @@ function ShortcutSettingsDialog({
             />
             <Typography
               sx={{
-                fontSize: scaledPx(11.5),
+                fontSize: scaledPx(theme.custom.fontSize.caption),
                 color: 'text.secondary',
               }}
             >
@@ -1605,7 +1570,7 @@ function ShortcutSettingsDialog({
           </Box>
           <Typography
             sx={{
-              fontSize: scaledPx(10.5),
+              fontSize: scaledPx(theme.custom.fontSize.hint),
               color: 'text.disabled',
               lineHeight: 1.4,
             }}
@@ -1615,7 +1580,7 @@ function ShortcutSettingsDialog({
           {showError && !hasHotkey && (
             <Typography
               sx={{
-                fontSize: scaledPx(10.5),
+                fontSize: scaledPx(theme.custom.fontSize.hint),
                 color: theme.palette.error.main,
                 mt: '2px',
               }}
@@ -1639,7 +1604,7 @@ function ShortcutSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: scaledPx(12),
+            fontSize: scaledPx(theme.custom.fontSize.body),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1663,11 +1628,11 @@ function ShortcutSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: scaledPx(12),
+            fontSize: scaledPx(theme.custom.fontSize.body),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
-            backgroundColor: isDark ? '#64b4ff' : '#0071e3',
+            backgroundColor: theme.palette.accent.main,
             border: '0.5px solid transparent',
             color: '#fff',
             boxShadow: !isDark ? 'inset 0 1px 0 rgba(255,255,255,0.5)' : 'none',
@@ -1780,7 +1745,7 @@ function LogSettingsDialog({
       <DialogTitle
         sx={{
           padding: '14px 18px 12px',
-          fontSize: scaledPx(14),
+          fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
           fontWeight: 600,
           borderBottom: `0.5px solid ${theme.palette.divider}`,
         }}
@@ -1802,10 +1767,8 @@ function LogSettingsDialog({
             alignItems: 'flex-start',
             gap: '9px',
             p: '9px 11px',
-            backgroundColor: isDark
-              ? 'rgba(255,180,80,0.08)'
-              : 'rgba(180,120,0,0.06)',
-            border: `0.5px solid ${isDark ? 'rgba(255,180,80,0.30)' : 'rgba(180,120,0,0.22)'}`,
+            backgroundColor: theme.palette.amber.background,
+            border: `0.5px solid ${theme.palette.amber.border}`,
             borderRadius: '8px',
           }}
         >
@@ -1814,14 +1777,14 @@ function LogSettingsDialog({
               fontSize: '14px',
               mt: '1px',
               flexShrink: 0,
-              color: isDark ? '#f5c46b' : '#a87a00',
+              color: theme.palette.amber.text,
             }}
           />
           <Typography
             sx={{
               lineHeight: 1.5,
-              color: isDark ? '#f5c46b' : '#8a6300',
-              fontSize: scaledPx(11.5),
+              color: theme.palette.amber.text,
+              fontSize: scaledPx(theme.custom.fontSize.caption),
             }}
           >
             Log settings only take effect after restarting RightCheat.
@@ -1832,7 +1795,7 @@ function LogSettingsDialog({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <Typography
             sx={{
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               fontWeight: 600,
               letterSpacing: '0.01em',
               color: 'text.secondary',
@@ -1885,7 +1848,7 @@ function LogSettingsDialog({
                 dir='ltr'
                 sx={{
                   fontFamily: 'monospace',
-                  fontSize: scaledPx(11.5),
+                  fontSize: scaledPx(theme.custom.fontSize.caption),
                   display: 'block',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -1944,7 +1907,7 @@ function LogSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: scaledPx(12),
+            fontSize: scaledPx(theme.custom.fontSize.body),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
@@ -1968,11 +1931,11 @@ function LogSettingsDialog({
           sx={{
             borderRadius: '7px',
             padding: '5px 16px',
-            fontSize: scaledPx(12),
+            fontSize: scaledPx(theme.custom.fontSize.body),
             fontWeight: 600,
             minWidth: 78,
             textTransform: 'none',
-            backgroundColor: isDark ? '#64b4ff' : '#0071e3',
+            backgroundColor: theme.palette.accent.main,
             border: '0.5px solid transparent',
             color: '#fff',
             boxShadow: !isDark ? 'inset 0 1px 0 rgba(255,255,255,0.5)' : 'none',

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -537,7 +537,10 @@ export default function Page() {
                       height: 28,
                       borderRadius: '7px',
                       border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
-                      backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                      backgroundColor: alpha(
+                        theme.palette.accent.main,
+                        isDark ? 0.1 : 0.07,
+                      ),
                       color: theme.palette.text.disabled,
                       '&:hover': {
                         borderColor: theme.palette.primary.main,
@@ -718,7 +721,10 @@ export default function Page() {
                         borderRadius: '7px',
                         flexShrink: 0,
                         border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
-                        backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                        backgroundColor: alpha(
+                          theme.palette.accent.main,
+                          isDark ? 0.1 : 0.07,
+                        ),
                         color: theme.palette.text.disabled,
                         '&:hover': {
                           borderColor: theme.palette.primary.main,
@@ -816,7 +822,10 @@ export default function Page() {
                           height: 28,
                           borderRadius: '7px',
                           border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
-                          backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                          backgroundColor: alpha(
+                            theme.palette.accent.main,
+                            isDark ? 0.1 : 0.07,
+                          ),
                           color: theme.palette.text.disabled,
                           '&:hover': {
                             borderColor: theme.palette.primary.main,
@@ -836,7 +845,10 @@ export default function Page() {
                           height: 28,
                           borderRadius: '7px',
                           border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
-                          backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+                          backgroundColor: alpha(
+                            theme.palette.accent.main,
+                            isDark ? 0.1 : 0.07,
+                          ),
                           color: theme.palette.text.disabled,
                           '&:hover': {
                             borderColor: theme.palette.primary.main,
@@ -1128,7 +1140,9 @@ function Keycap({ children, big = false, active = true }: KeycapProps) {
             : '0 1px 0 rgba(0,0,30,0.08), inset 0 0.5px 0 rgba(255,255,255,0.9)'
           : 'none',
         fontFamily: 'monospace',
-        fontSize: big ? scaledPx(theme.custom.fontSize.searchInput) : scaledPx(theme.custom.fontSize.body),
+        fontSize: big
+          ? scaledPx(theme.custom.fontSize.searchInput)
+          : scaledPx(theme.custom.fontSize.body),
         fontWeight: 600,
         color: active ? 'text.primary' : 'text.secondary',
         textAlign: 'center',
@@ -1188,13 +1202,13 @@ function ShortcutCheckbox({
           outlineOffset: '2px',
         },
         backgroundColor: checked
-          ? alpha(theme.palette.accent.main, isDark ? 0.10 : 0.06)
+          ? alpha(theme.palette.accent.main, isDark ? 0.1 : 0.06)
           : hovered
             ? theme.palette.surface.hover
             : 'transparent',
         border: `0.5px solid ${
           checked
-            ? alpha(theme.palette.accent.main, isDark ? 0.30 : 0.22)
+            ? alpha(theme.palette.accent.main, isDark ? 0.3 : 0.22)
             : hovered
               ? theme.palette.divider
               : 'transparent'
@@ -1297,7 +1311,7 @@ function HotkeyInput({ value, onChange, invalid }: HotkeyInputProps) {
         caretColor: theme.palette.primary.main,
         outline: 'none',
         boxShadow: focused
-          ? `0 0 0 3px ${alpha(theme.palette.accent.main, isDark ? 0.13 : 0.10)}`
+          ? `0 0 0 3px ${alpha(theme.palette.accent.main, isDark ? 0.13 : 0.1)}`
           : !isDark
             ? 'inset 0 1px 2px rgba(0,0,0,0.04)'
             : 'none',

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -149,7 +149,7 @@ export default function SearchPage() {
           <Box
             sx={{
               fontFamily: FONT_UI,
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               color: theme.palette.text.secondary,
               display: 'flex',
               alignItems: 'center',

--- a/src/components/atoms/AddRowButton.tsx
+++ b/src/components/atoms/AddRowButton.tsx
@@ -29,7 +29,7 @@ export function AddRowButton({ label, onClick, icon }: Props) {
         borderRadius: '7px',
         color: theme.palette.text.secondary,
         fontFamily: theme.typography.fontFamily,
-        fontSize: scaledPx(11.5),
+        fontSize: scaledPx(theme.custom.fontSize.caption),
         cursor: 'pointer',
         transition: 'all 0.14s',
         '&:hover': {

--- a/src/components/atoms/ThemeToggle.tsx
+++ b/src/components/atoms/ThemeToggle.tsx
@@ -24,9 +24,7 @@ export function ThemeToggle({
 }: ThemeToggleProps) {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const borderColor = isDark
-    ? 'rgba(255,255,255,0.10)'
-    : 'rgba(255,255,255,0.72)'
+  const borderColor = isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.72)'
 
   return (
     <Box sx={{ display: 'flex' }} role='group' aria-label='Theme selection'>
@@ -45,11 +43,7 @@ export function ThemeToggle({
             aria-pressed={selected}
             sx={{
               position: 'relative',
-              background: selected
-                ? isDark
-                  ? 'rgba(255,255,255,0.12)'
-                  : 'rgba(255,255,255,0.7)'
-                : 'transparent',
+              background: selected ? theme.palette.glass.panel : 'transparent',
               backdropFilter: 'blur(12px)',
               borderTop: `0.5px solid ${borderColor}`,
               borderRight: `0.5px solid ${borderColor}`,
@@ -58,13 +52,9 @@ export function ThemeToggle({
               padding: '5px 14px',
               cursor: disabled ? 'default' : 'pointer',
               fontFamily: 'monospace',
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               fontWeight: selected ? 700 : 400,
-              color: selected
-                ? theme.palette.primary.main
-                : isDark
-                  ? 'rgba(255,255,255,0.28)'
-                  : 'rgba(0,0,0,0.28)',
+              color: selected ? theme.palette.primary.main : theme.palette.text.disabled,
               transition: 'color 0.14s, background 0.14s, box-shadow 0.14s',
               borderRadius,
               boxShadow:

--- a/src/components/atoms/ThemeToggle.tsx
+++ b/src/components/atoms/ThemeToggle.tsx
@@ -24,7 +24,9 @@ export function ThemeToggle({
 }: ThemeToggleProps) {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const borderColor = isDark ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.72)'
+  const borderColor = isDark
+    ? 'rgba(255,255,255,0.10)'
+    : 'rgba(255,255,255,0.72)'
 
   return (
     <Box sx={{ display: 'flex' }} role='group' aria-label='Theme selection'>
@@ -54,7 +56,9 @@ export function ThemeToggle({
               fontFamily: 'monospace',
               fontSize: scaledPx(theme.custom.fontSize.captionSm),
               fontWeight: selected ? 700 : 400,
-              color: selected ? theme.palette.primary.main : theme.palette.text.disabled,
+              color: selected
+                ? theme.palette.primary.main
+                : theme.palette.text.disabled,
               transition: 'color 0.14s, background 0.14s, box-shadow 0.14s',
               borderRadius,
               boxShadow:

--- a/src/components/molecules/CommandField.tsx
+++ b/src/components/molecules/CommandField.tsx
@@ -3,7 +3,7 @@ import { scaledPx } from '@/utils/css'
 import { forwardRef, useState } from 'react'
 
 import { Box, Stack, StackProps, Typography } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
 import { error as logError } from '@tauri-apps/plugin-log'
 
@@ -87,34 +87,24 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
       }
       if (hasDone) {
         return {
-          background: isDark
-            ? 'rgba(100,180,255,0.09)'
-            : 'rgba(0,113,227,0.06)',
-          border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.32)' : 'rgba(0,113,227,0.30)'}`,
+          background: alpha(theme.palette.accent.main, isDark ? 0.09 : 0.06),
+          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.32 : 0.30)}`,
           borderRadius: 1,
         }
       }
       if (isFocused) {
         return {
-          background: isDark
-            ? 'rgba(255,255,255,0.06)'
-            : 'rgba(255,255,255,0.78)',
-          border: `0.5px solid ${isDark ? 'rgba(100,180,255,0.18)' : 'rgba(0,113,227,0.22)'}`,
+          background: theme.palette.glass.field,
+          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.22)}`,
           borderLeft: `2.5px solid ${accentColor}`,
           borderRadius: '0 4px 4px 0',
         }
       }
       return {
         background: isHovered
-          ? isDark
-            ? 'rgba(255,255,255,0.10)'
-            : 'rgba(255,255,255,0.78)'
-          : isDark
-            ? 'rgba(255,255,255,0.055)'
-            : 'rgba(255,255,255,0.48)',
-        border: `0.5px solid ${
-          isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
-        }`,
+          ? theme.palette.glass.field
+          : theme.palette.glass.panel,
+        border: `0.5px solid ${theme.palette.divider}`,
         borderRadius: 1,
       }
     }
@@ -138,7 +128,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
           <Typography
             sx={{
               fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-              fontSize: scaledPx(9.5),
+              fontSize: scaledPx(theme.custom.fontSize.numberHint),
               color: numberHintColor,
               transition: 'color 0.14s',
             }}
@@ -181,7 +171,9 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: isMultiLine ? scaledPx(10) : scaledPx(11.5),
+            fontSize: isMultiLine
+              ? scaledPx(theme.custom.fontSize.commandMultiline)
+              : scaledPx(theme.custom.fontSize.caption),
             color: hasDone ? accentColor : theme.palette.text.primary,
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-all',
@@ -249,7 +241,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
             <TruncatedText
               text={description}
               sx={{
-                fontSize: scaledPx(11),
+                fontSize: scaledPx(theme.custom.fontSize.captionSm),
                 color: isFocused
                   ? theme.palette.text.primary
                   : theme.palette.text.secondary,

--- a/src/components/molecules/CommandField.tsx
+++ b/src/components/molecules/CommandField.tsx
@@ -88,7 +88,7 @@ export const CommandField = forwardRef<HTMLDivElement, CommandFieldProps>(
       if (hasDone) {
         return {
           background: alpha(theme.palette.accent.main, isDark ? 0.09 : 0.06),
-          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.32 : 0.30)}`,
+          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.32 : 0.3)}`,
           borderRadius: 1,
         }
       }

--- a/src/components/molecules/EditModeFooter.tsx
+++ b/src/components/molecules/EditModeFooter.tsx
@@ -86,7 +86,7 @@ export function EditModeFooter({
           {editDirty ? (
             <Box
               sx={{
-                fontSize: scaledPx(11),
+                fontSize: scaledPx(theme.custom.fontSize.captionSm),
                 color: 'text.secondary',
                 fontStyle: 'italic',
               }}
@@ -96,7 +96,7 @@ export function EditModeFooter({
           ) : (
             <Box
               sx={{
-                fontSize: scaledPx(11),
+                fontSize: scaledPx(theme.custom.fontSize.captionSm),
                 color: 'text.disabled',
               }}
             >

--- a/src/components/molecules/EditableCommandRow.tsx
+++ b/src/components/molecules/EditableCommandRow.tsx
@@ -59,7 +59,7 @@ export function EditableCommandRow({
         component='pre'
         sx={{
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-          fontSize: isMultiLine ? scaledPx(10) : scaledPx(11.5),
+          fontSize: isMultiLine ? scaledPx(10) : scaledPx(theme.custom.fontSize.caption),
           color: theme.palette.text.primary,
           whiteSpace: 'pre-wrap',
           wordBreak: 'break-all',
@@ -105,14 +105,14 @@ export function EditableCommandRow({
             <TruncatedText
               text={item.description}
               sx={{
-                fontSize: scaledPx(11),
+                fontSize: scaledPx(theme.custom.fontSize.captionSm),
                 color: theme.palette.text.secondary,
               }}
             />
           ) : (
             <Typography
               sx={{
-                fontSize: scaledPx(11),
+                fontSize: scaledPx(theme.custom.fontSize.captionSm),
                 color: theme.palette.text.disabled,
                 fontStyle: 'italic',
               }}
@@ -146,7 +146,7 @@ export function EditableCommandRow({
         <TruncatedText
           text={item.description!}
           sx={{
-            fontSize: scaledPx(11),
+            fontSize: scaledPx(theme.custom.fontSize.captionSm),
             color: theme.palette.text.secondary,
             flexShrink: 1,
           }}

--- a/src/components/molecules/EditableCommandRow.tsx
+++ b/src/components/molecules/EditableCommandRow.tsx
@@ -59,7 +59,9 @@ export function EditableCommandRow({
         component='pre'
         sx={{
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-          fontSize: isMultiLine ? scaledPx(10) : scaledPx(theme.custom.fontSize.caption),
+          fontSize: isMultiLine
+            ? scaledPx(10)
+            : scaledPx(theme.custom.fontSize.caption),
           color: theme.palette.text.primary,
           whiteSpace: 'pre-wrap',
           wordBreak: 'break-all',

--- a/src/components/molecules/EditableGroupBox.tsx
+++ b/src/components/molecules/EditableGroupBox.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { scaledPx } from '@/utils/css'
 import { Box, Typography } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import { useState } from 'react'
 
 import { EditIconButton } from '@/components/atoms/EditIconButton'
@@ -41,8 +41,6 @@ export function EditableGroupBox({
   const isDark = theme.palette.mode === 'dark'
   const [isHovered, setIsHovered] = useState(false)
   const [grabbing, setGrabbing] = useState(false)
-  const accent = isDark ? '#64b4ff' : '#0071e3'
-
   return (
     <Box
       ref={blockRef}
@@ -50,7 +48,7 @@ export function EditableGroupBox({
       onMouseLeave={() => setIsHovered(false)}
       sx={{
         position: 'relative',
-        border: `0.5px solid ${isDropTarget ? accent : theme.palette.divider}`,
+        border: `0.5px solid ${isDropTarget ? theme.palette.accent.main : theme.palette.divider}`,
         borderRadius: '6px',
         pt: '22px',
         pb: 1,
@@ -58,9 +56,7 @@ export function EditableGroupBox({
         opacity: isDragging ? 0.35 : 1,
         transition: 'all 0.12s',
         background: isDropTarget
-          ? isDark
-            ? 'rgba(100,180,255,0.05)'
-            : 'rgba(0,113,227,0.03)'
+          ? alpha(theme.palette.accent.main, isDark ? 0.05 : 0.03)
           : 'transparent',
       }}
     >
@@ -118,7 +114,7 @@ export function EditableGroupBox({
           variant='caption'
           sx={{
             color: theme.palette.text.secondary,
-            fontSize: scaledPx(11),
+            fontSize: scaledPx(theme.custom.fontSize.captionSm),
             lineHeight: 1,
             userSelect: 'none',
           }}
@@ -177,7 +173,7 @@ export function EditableGroupBox({
         {isEmpty ? (
           <Typography
             sx={{
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               color: theme.palette.text.disabled,
               fontStyle: 'italic',
               textAlign: 'center',

--- a/src/components/molecules/EditableRowBase.tsx
+++ b/src/components/molecules/EditableRowBase.tsx
@@ -56,7 +56,7 @@ export function EditableRowBase({
         padding: '5px 6px',
         borderRadius: '6px',
         background: isDropTarget
-          ? alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07)
+          ? alpha(theme.palette.accent.main, isDark ? 0.1 : 0.07)
           : isHovered
             ? theme.palette.surface.hover
             : 'transparent',

--- a/src/components/molecules/EditableRowBase.tsx
+++ b/src/components/molecules/EditableRowBase.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { scaledPx } from '@/utils/css'
 import { Box, Typography } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import { useState } from 'react'
 
 import { EditIconButton } from '@/components/atoms/EditIconButton'
@@ -43,8 +43,6 @@ export function EditableRowBase({
   const isDark = theme.palette.mode === 'dark'
   const [isHovered, setIsHovered] = useState(false)
   const [grabbing, setGrabbing] = useState(false)
-  const accent = isDark ? '#64b4ff' : '#0071e3'
-
   return (
     <Box
       ref={rowRef}
@@ -58,21 +56,15 @@ export function EditableRowBase({
         padding: '5px 6px',
         borderRadius: '6px',
         background: isDropTarget
-          ? isDark
-            ? 'rgba(100,180,255,0.10)'
-            : 'rgba(0,113,227,0.07)'
+          ? alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07)
           : isHovered
-            ? isDark
-              ? 'rgba(255,255,255,0.05)'
-              : 'rgba(0,0,0,0.03)'
+            ? theme.palette.surface.hover
             : 'transparent',
         border: `0.5px solid ${
           isDropTarget
-            ? accent
+            ? theme.palette.accent.main
             : isHovered
-              ? isDark
-                ? 'rgba(255,255,255,0.08)'
-                : 'rgba(0,0,0,0.08)'
+              ? theme.palette.divider
               : 'transparent'
         }`,
         opacity: isDragging ? 0.35 : 1,
@@ -124,7 +116,7 @@ export function EditableRowBase({
       <Typography
         sx={{
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-          fontSize: scaledPx(9.5),
+          fontSize: scaledPx(theme.custom.fontSize.numberHint),
           color: theme.palette.text.disabled,
           minWidth: '16px',
           textAlign: 'right',

--- a/src/components/molecules/EditableShortcutRow.tsx
+++ b/src/components/molecules/EditableShortcutRow.tsx
@@ -68,7 +68,7 @@ export function EditableShortcutRow({
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: scaledPx(11.5),
+            fontSize: scaledPx(theme.custom.fontSize.caption),
             color: theme.palette.text.primary,
             whiteSpace: 'nowrap',
             lineHeight: 1.55,
@@ -84,14 +84,14 @@ export function EditableShortcutRow({
           <TruncatedText
             text={item.description}
             sx={{
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               color: theme.palette.text.secondary,
             }}
           />
         ) : (
           <Typography
             sx={{
-              fontSize: scaledPx(11),
+              fontSize: scaledPx(theme.custom.fontSize.captionSm),
               color: theme.palette.text.disabled,
               fontStyle: 'italic',
             }}

--- a/src/components/molecules/FooterButton.tsx
+++ b/src/components/molecules/FooterButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { scaledPx } from '@/utils/css'
 import { Box } from '@mui/material'
-import { alpha, useTheme } from '@mui/material/styles'
+import { useTheme } from '@mui/material/styles'
 
 type Props = {
   onClick?: () => void
@@ -30,9 +30,7 @@ export function FooterButton({ onClick, primary, disabled, children }: Props) {
             ? '#fff'
             : theme.palette.text.primary,
         border: `0.5px solid ${
-          primary && !disabled
-            ? 'transparent'
-            : theme.palette.divider
+          primary && !disabled ? 'transparent' : theme.palette.divider
         }`,
         borderRadius: '7px',
         padding: '5px 16px',

--- a/src/components/molecules/FooterButton.tsx
+++ b/src/components/molecules/FooterButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { scaledPx } from '@/utils/css'
 import { Box } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 
 type Props = {
   onClick?: () => void
@@ -13,8 +13,6 @@ type Props = {
 export function FooterButton({ onClick, primary, disabled, children }: Props) {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accent = isDark ? '#64b4ff' : '#0071e3'
-
   return (
     <Box
       component='button'
@@ -22,32 +20,24 @@ export function FooterButton({ onClick, primary, disabled, children }: Props) {
       disabled={disabled}
       sx={{
         background: disabled
-          ? isDark
-            ? 'rgba(255,255,255,0.05)'
-            : 'rgba(0,0,0,0.04)'
+          ? theme.palette.surface.hover
           : primary
-            ? accent
-            : isDark
-              ? 'rgba(255,255,255,0.06)'
-              : 'rgba(255,255,255,0.75)',
+            ? theme.palette.accent.main
+            : theme.palette.glass.field,
         color: disabled
-          ? isDark
-            ? 'rgba(255,255,255,0.25)'
-            : 'rgba(0,0,0,0.28)'
+          ? theme.palette.text.disabled
           : primary
             ? '#fff'
             : theme.palette.text.primary,
         border: `0.5px solid ${
           primary && !disabled
             ? 'transparent'
-            : isDark
-              ? 'rgba(255,255,255,0.10)'
-              : 'rgba(0,0,0,0.12)'
+            : theme.palette.divider
         }`,
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: scaledPx(12),
+        fontSize: scaledPx(theme.custom.fontSize.body),
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: disabled ? 'not-allowed' : 'pointer',
@@ -60,9 +50,7 @@ export function FooterButton({ onClick, primary, disabled, children }: Props) {
             ? isDark
               ? '#7cc0ff'
               : '#1a82eb'
-            : isDark
-              ? 'rgba(255,255,255,0.10)'
-              : 'rgba(255,255,255,0.95)',
+            : theme.palette.glass.panel,
         },
       }}
     >

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -36,7 +36,7 @@ export const SearchBar = ({
           alignItems: 'center',
           gap: '10px',
           background: theme.palette.glass.field,
-          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.30 : 0.25)}`,
+          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.3 : 0.25)}`,
           borderRadius: '10px',
           padding: '8px 12px',
           boxShadow: isDark

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -3,7 +3,7 @@ import { scaledPx } from '@/utils/css'
 import { KeyboardEvent, RefObject } from 'react'
 
 import { Box } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 
 type Props = {
   value: string
@@ -26,7 +26,7 @@ export const SearchBar = ({
 }: Props) => {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
+  const accentSolid = theme.palette.accent.main
 
   return (
     <Box sx={{ padding: '14px 16px 10px' }}>
@@ -35,15 +35,13 @@ export const SearchBar = ({
           display: 'flex',
           alignItems: 'center',
           gap: '10px',
-          background: isDark ? 'rgba(0,0,0,0.25)' : 'rgba(255,255,255,0.78)',
-          border: `0.5px solid ${
-            isDark ? 'rgba(100,180,255,0.30)' : 'rgba(0,113,227,0.25)'
-          }`,
+          background: theme.palette.glass.field,
+          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.30 : 0.25)}`,
           borderRadius: '10px',
           padding: '8px 12px',
           boxShadow: isDark
-            ? 'inset 0 1px 0 rgba(0,0,0,0.30), 0 0 0 3px rgba(100,180,255,0.06)'
-            : 'inset 0 1px 0 rgba(255,255,255,0.9), 0 0 0 3px rgba(0,113,227,0.05)',
+            ? `inset 0 1px 0 rgba(0,0,0,0.30), 0 0 0 3px ${alpha(theme.palette.accent.main, 0.06)}`
+            : `inset 0 1px 0 rgba(255,255,255,0.9), 0 0 0 3px ${alpha(theme.palette.accent.main, 0.05)}`,
         }}
       >
         <svg
@@ -78,7 +76,7 @@ export const SearchBar = ({
             outline: 'none',
             fontFamily:
               '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif',
-            fontSize: scaledPx(15),
+            fontSize: scaledPx(theme.custom.fontSize.searchInput),
             fontWeight: 500,
             color: theme.palette.text.primary,
             caretColor: accentSolid,
@@ -99,9 +97,7 @@ export const SearchBar = ({
             title='Clear'
             aria-label='Clear search'
             sx={{
-              background: isDark
-                ? 'rgba(255,255,255,0.10)'
-                : 'rgba(0,0,0,0.08)',
+              background: theme.palette.surface.hover,
               border: 'none',
               borderRadius: '50%',
               width: '18px',
@@ -112,7 +108,7 @@ export const SearchBar = ({
               justifyContent: 'center',
               cursor: 'pointer',
               flexShrink: 0,
-              color: isDark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.55)',
+              color: theme.palette.text.secondary,
             }}
           >
             <svg

--- a/src/components/molecules/SearchResultItem.tsx
+++ b/src/components/molecules/SearchResultItem.tsx
@@ -3,7 +3,7 @@ import { scaledPx } from '@/utils/css'
 import { Fragment, useState } from 'react'
 
 import { Box } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 
 import { CommandSearchResult } from '@/types/api/CheatSheet'
 import {
@@ -57,12 +57,10 @@ const SheetBadge = ({
   name,
   isDark,
   focused,
-  accentSolid,
 }: {
   name: string
   isDark: boolean
   focused: boolean
-  accentSolid: string
 }) => {
   const theme = useTheme()
   return (
@@ -72,25 +70,17 @@ const SheetBadge = ({
         alignItems: 'center',
         gap: '4px',
         fontFamily: FONT_UI,
-        fontSize: scaledPx(10.5),
+        fontSize: scaledPx(theme.custom.fontSize.hint),
         fontWeight: 500,
         letterSpacing: '0.01em',
-        color: focused ? accentSolid : theme.palette.text.secondary,
+        color: focused ? theme.palette.accent.main : theme.palette.text.secondary,
         background: focused
-          ? isDark
-            ? 'rgba(100,180,255,0.14)'
-            : 'rgba(0,113,227,0.08)'
-          : isDark
-            ? 'rgba(255,255,255,0.06)'
-            : 'rgba(255,255,255,0.60)',
+          ? alpha(theme.palette.accent.main, isDark ? 0.14 : 0.08)
+          : theme.palette.glass.field,
         border: `0.5px solid ${
           focused
-            ? isDark
-              ? 'rgba(100,180,255,0.35)'
-              : 'rgba(0,113,227,0.28)'
-            : isDark
-              ? 'rgba(255,255,255,0.10)'
-              : 'rgba(0,0,0,0.08)'
+            ? alpha(theme.palette.accent.main, isDark ? 0.35 : 0.28)
+            : theme.palette.divider
         }`,
         borderRadius: '999px',
         padding: '1.5px 8px 1.5px 6px',
@@ -105,7 +95,7 @@ const SheetBadge = ({
           width: '6px',
           height: '6px',
           borderRadius: '50%',
-          background: focused ? accentSolid : theme.palette.text.disabled,
+          background: focused ? theme.palette.accent.main : theme.palette.text.disabled,
           flexShrink: 0,
           transition: 'background 0.14s',
         }}
@@ -133,7 +123,6 @@ export const SearchResultItem = ({
 }: Props) => {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
   const [hov, setHov] = useState(false)
 
   const descSpans = buildHighlights(hit.description || '', query)
@@ -158,15 +147,11 @@ export const SearchResultItem = ({
         padding: '9px 12px 9px 14px',
         cursor: 'pointer',
         background: focused
-          ? isDark
-            ? 'rgba(100,180,255,0.10)'
-            : 'rgba(0,113,227,0.06)'
+          ? theme.palette.surface.selected
           : hov
-            ? isDark
-              ? 'rgba(255,255,255,0.04)'
-              : 'rgba(255,255,255,0.55)'
+            ? theme.palette.surface.hover
             : 'transparent',
-        borderLeft: `2.5px solid ${focused ? accentSolid : 'transparent'}`,
+        borderLeft: `2.5px solid ${focused ? theme.palette.accent.main : 'transparent'}`,
         transition: 'background 0.1s, border-color 0.1s',
       }}
     >
@@ -192,7 +177,7 @@ export const SearchResultItem = ({
             component='span'
             sx={{
               fontFamily: FONT_UI,
-              fontSize: scaledPx(13),
+              fontSize: scaledPx(theme.custom.fontSize.label),
               fontWeight: 600,
               color: theme.palette.text.primary,
               overflow: 'hidden',
@@ -221,7 +206,6 @@ export const SearchResultItem = ({
             name={hit.cheatsheet_title}
             isDark={isDark}
             focused={focused}
-            accentSolid={accentSolid}
           />
         </Box>
 
@@ -229,7 +213,7 @@ export const SearchResultItem = ({
         <Box
           sx={{
             fontFamily: FONT_CODE,
-            fontSize: scaledPx(11.5),
+            fontSize: scaledPx(theme.custom.fontSize.caption),
             color: focused
               ? theme.palette.text.primary
               : theme.palette.text.secondary,
@@ -252,7 +236,7 @@ export const SearchResultItem = ({
           opacity: focused ? 0.85 : active ? 0.35 : 0,
           transition: 'opacity 0.14s',
           paddingTop: '6px',
-          color: focused ? accentSolid : theme.palette.text.disabled,
+          color: focused ? theme.palette.accent.main : theme.palette.text.disabled,
           display: 'flex',
           alignItems: 'center',
         }}

--- a/src/components/molecules/SearchResultItem.tsx
+++ b/src/components/molecules/SearchResultItem.tsx
@@ -73,7 +73,9 @@ const SheetBadge = ({
         fontSize: scaledPx(theme.custom.fontSize.hint),
         fontWeight: 500,
         letterSpacing: '0.01em',
-        color: focused ? theme.palette.accent.main : theme.palette.text.secondary,
+        color: focused
+          ? theme.palette.accent.main
+          : theme.palette.text.secondary,
         background: focused
           ? alpha(theme.palette.accent.main, isDark ? 0.14 : 0.08)
           : theme.palette.glass.field,
@@ -95,7 +97,9 @@ const SheetBadge = ({
           width: '6px',
           height: '6px',
           borderRadius: '50%',
-          background: focused ? theme.palette.accent.main : theme.palette.text.disabled,
+          background: focused
+            ? theme.palette.accent.main
+            : theme.palette.text.disabled,
           flexShrink: 0,
           transition: 'background 0.14s',
         }}
@@ -236,7 +240,9 @@ export const SearchResultItem = ({
           opacity: focused ? 0.85 : active ? 0.35 : 0,
           transition: 'opacity 0.14s',
           paddingTop: '6px',
-          color: focused ? theme.palette.accent.main : theme.palette.text.disabled,
+          color: focused
+            ? theme.palette.accent.main
+            : theme.palette.text.disabled,
           display: 'flex',
           alignItems: 'center',
         }}

--- a/src/components/molecules/SheetSwitchButton.tsx
+++ b/src/components/molecules/SheetSwitchButton.tsx
@@ -117,7 +117,9 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
 
     const dropdownBg = theme.palette.glass.overlay
     const borderColor = isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.10)'
-    const inputBg = isDark ? theme.palette.glass.field : theme.palette.surface.hover
+    const inputBg = isDark
+      ? theme.palette.glass.field
+      : theme.palette.surface.hover
 
     return (
       <Box ref={containerRef} sx={{ position: 'relative' }}>

--- a/src/components/molecules/SheetSwitchButton.tsx
+++ b/src/components/molecules/SheetSwitchButton.tsx
@@ -115,9 +115,9 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
       }
     }
 
-    const dropdownBg = isDark ? 'rgba(12,28,48,0.97)' : 'rgba(240,245,255,0.97)'
+    const dropdownBg = theme.palette.glass.overlay
     const borderColor = isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.10)'
-    const inputBg = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)'
+    const inputBg = isDark ? theme.palette.glass.field : theme.palette.surface.hover
 
     return (
       <Box ref={containerRef} sx={{ position: 'relative' }}>
@@ -128,11 +128,7 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
           aria-haspopup='listbox'
           aria-expanded={open}
           sx={{
-            background: open
-              ? isDark
-                ? 'rgba(255,255,255,0.12)'
-                : 'rgba(0,0,0,0.08)'
-              : 'none',
+            background: open ? theme.palette.surface.hover : 'none',
             border: `0.5px solid ${open ? theme.palette.accent.main : 'transparent'}`,
             borderRadius: '6px',
             cursor: 'pointer',
@@ -244,7 +240,7 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
                     border: 'none',
                     outline: 'none',
                     fontFamily: 'inherit',
-                    fontSize: scaledPx(12),
+                    fontSize: scaledPx(theme.custom.fontSize.body),
                     color: theme.palette.text.primary,
                   }}
                 />
@@ -293,7 +289,7 @@ export const SheetSwitchButton = forwardRef<SheetSwitchButtonHandle, Props>(
                 <Typography
                   sx={{
                     padding: '10px 16px',
-                    fontSize: scaledPx(12),
+                    fontSize: scaledPx(theme.custom.fontSize.body),
                     color: theme.palette.text.disabled,
                     textAlign: 'center',
                   }}
@@ -354,6 +350,7 @@ const SheetDropdownItem = forwardRef<HTMLDivElement, DropdownItemProps>(
     },
     ref,
   ) {
+    const theme = useTheme()
     return (
       <Box
         ref={ref}
@@ -364,16 +361,12 @@ const SheetDropdownItem = forwardRef<HTMLDivElement, DropdownItemProps>(
         sx={{
           padding: '7px 12px',
           cursor: 'pointer',
-          fontSize: scaledPx(13),
+          fontSize: scaledPx(theme.custom.fontSize.label),
           display: 'flex',
           alignItems: 'center',
           gap: '8px',
           color: selected ? accentColor : textPrimary,
-          background: active
-            ? isDark
-              ? 'rgba(255,255,255,0.08)'
-              : 'rgba(0,0,0,0.05)'
-            : 'none',
+          background: active ? theme.palette.surface.hover : 'none',
           transition: 'background 0.08s',
         }}
       >

--- a/src/components/molecules/ShortcutField.tsx
+++ b/src/components/molecules/ShortcutField.tsx
@@ -32,7 +32,7 @@ export const ShortcutField = (props: ShortcutFieldProps) => {
         <Typography
           sx={{
             fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-            fontSize: scaledPx(11.5),
+            fontSize: scaledPx(theme.custom.fontSize.caption),
             color: theme.palette.text.primary,
             whiteSpace: 'nowrap',
             lineHeight: 1.55,
@@ -44,7 +44,7 @@ export const ShortcutField = (props: ShortcutFieldProps) => {
       <TruncatedText
         text={description}
         sx={{
-          fontSize: scaledPx(11),
+          fontSize: scaledPx(theme.custom.fontSize.captionSm),
           color: theme.palette.text.secondary,
         }}
       />

--- a/src/components/molecules/WindowTitleBar.tsx
+++ b/src/components/molecules/WindowTitleBar.tsx
@@ -59,7 +59,7 @@ export const WindowTitleBar = ({ title, rightControls }: Props) => {
         >
           <Typography
             sx={{
-              fontSize: scaledPx(12),
+              fontSize: scaledPx(theme.custom.fontSize.body),
               fontWeight: 600,
               color: theme.palette.text.secondary,
               letterSpacing: '0.02em',

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import PushPin from '@mui/icons-material/PushPin'
 import PushPinOutlined from '@mui/icons-material/PushPinOutlined'
 import { Alert, Box, Grid, IconButton, Stack } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import {
@@ -998,9 +998,7 @@ export const CheatSheet = () => {
               title={editMode ? 'Cancel edit mode (Esc)' : 'Edit mode (e)'}
               sx={{
                 background: editMode
-                  ? theme.palette.mode === 'dark'
-                    ? 'rgba(100,180,255,0.18)'
-                    : 'rgba(0,113,227,0.14)'
+                  ? alpha(theme.palette.accent.main, 0.18)
                   : 'transparent',
                 border: editMode
                   ? `0.5px solid ${theme.palette.accent.main}`
@@ -1016,9 +1014,7 @@ export const CheatSheet = () => {
                 '&.Mui-focusVisible': {
                   outline: 'none',
                   background: editMode
-                    ? theme.palette.mode === 'dark'
-                      ? 'rgba(100,180,255,0.18)'
-                      : 'rgba(0,113,227,0.14)'
+                    ? alpha(theme.palette.accent.main, 0.18)
                     : 'transparent',
                 },
               }}

--- a/src/components/organisms/RcDialog.tsx
+++ b/src/components/organisms/RcDialog.tsx
@@ -25,14 +25,14 @@ const VARIANT_DEFS: Record<DialogVariant, VariantDef> = {
     colorDark: '#64b4ff',
     colorLight: '#0071e3',
     bgAlpha: 0.13,
-    borderAlpha: 0.30,
+    borderAlpha: 0.3,
   },
   warning: {
     Icon: WarningAmberIcon,
     colorDark: '#ffb74d',
     colorLight: '#ed6c02',
     bgAlpha: 0.13,
-    borderAlpha: 0.30,
+    borderAlpha: 0.3,
   },
   error: {
     Icon: ErrorOutlineIcon,
@@ -46,7 +46,7 @@ const VARIANT_DEFS: Record<DialogVariant, VariantDef> = {
     colorDark: '#c084fc',
     colorLight: '#7c3aed',
     bgAlpha: 0.13,
-    borderAlpha: 0.30,
+    borderAlpha: 0.3,
   },
 }
 

--- a/src/components/organisms/RcDialog.tsx
+++ b/src/components/organisms/RcDialog.tsx
@@ -6,7 +6,7 @@ import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 import { Box, Dialog, SvgIconProps } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 import React from 'react'
 
 export type DialogVariant = 'information' | 'warning' | 'error' | 'confirmation'
@@ -15,10 +15,8 @@ type VariantDef = {
   Icon: React.ComponentType<SvgIconProps>
   colorDark: string
   colorLight: string
-  bgDark: string
-  bgLight: string
-  borderDark: string
-  borderLight: string
+  bgAlpha: number
+  borderAlpha: number
 }
 
 const VARIANT_DEFS: Record<DialogVariant, VariantDef> = {
@@ -26,37 +24,29 @@ const VARIANT_DEFS: Record<DialogVariant, VariantDef> = {
     Icon: InfoOutlinedIcon,
     colorDark: '#64b4ff',
     colorLight: '#0071e3',
-    bgDark: 'rgba(100,180,255,0.13)',
-    bgLight: 'rgba(0,113,227,0.08)',
-    borderDark: 'rgba(100,180,255,0.30)',
-    borderLight: 'rgba(0,113,227,0.22)',
+    bgAlpha: 0.13,
+    borderAlpha: 0.30,
   },
   warning: {
     Icon: WarningAmberIcon,
     colorDark: '#ffb74d',
     colorLight: '#ed6c02',
-    bgDark: 'rgba(255,183,77,0.13)',
-    bgLight: 'rgba(237,108,2,0.08)',
-    borderDark: 'rgba(255,183,77,0.30)',
-    borderLight: 'rgba(237,108,2,0.22)',
+    bgAlpha: 0.13,
+    borderAlpha: 0.30,
   },
   error: {
     Icon: ErrorOutlineIcon,
     colorDark: '#ff6b6b',
     colorLight: '#d32f2f',
-    bgDark: 'rgba(255,107,107,0.12)',
-    bgLight: 'rgba(211,47,47,0.08)',
-    borderDark: 'rgba(255,107,107,0.35)',
-    borderLight: 'rgba(211,47,47,0.22)',
+    bgAlpha: 0.12,
+    borderAlpha: 0.35,
   },
   confirmation: {
     Icon: HelpOutlineIcon,
     colorDark: '#c084fc',
     colorLight: '#7c3aed',
-    bgDark: 'rgba(192,132,252,0.13)',
-    bgLight: 'rgba(124,58,237,0.08)',
-    borderDark: 'rgba(192,132,252,0.30)',
-    borderLight: 'rgba(124,58,237,0.22)',
+    bgAlpha: 0.13,
+    borderAlpha: 0.30,
   },
 }
 
@@ -93,7 +83,7 @@ function ActionButton({ variant, onClick, children }: ActionButtonProps) {
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: scaledPx(12),
+        fontSize: scaledPx(theme.custom.fontSize.body),
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: 'pointer',
@@ -132,15 +122,13 @@ function SecondaryButton({ onClick, children }: SecondaryButtonProps) {
       type='button'
       onClick={onClick}
       sx={{
-        background: isDark
-          ? 'rgba(255,255,255,0.06)'
-          : 'rgba(255,255,255,0.75)',
+        background: theme.palette.glass.panel,
         color: theme.palette.text.primary,
-        border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(0,0,0,0.12)'}`,
+        border: `0.5px solid ${theme.palette.divider}`,
         borderRadius: '7px',
         padding: '5px 16px',
         fontFamily: theme.typography.fontFamily,
-        fontSize: scaledPx(12),
+        fontSize: scaledPx(theme.custom.fontSize.body),
         fontWeight: 600,
         letterSpacing: '0.01em',
         cursor: 'pointer',
@@ -148,9 +136,7 @@ function SecondaryButton({ onClick, children }: SecondaryButtonProps) {
         minWidth: '78px',
         boxShadow: !isDark ? 'inset 0 1px 0 rgba(255,255,255,0.5)' : 'none',
         '&:hover': {
-          background: isDark
-            ? 'rgba(255,255,255,0.10)'
-            : 'rgba(255,255,255,0.95)',
+          background: theme.palette.glass.field,
         },
       }}
     >
@@ -179,8 +165,8 @@ function DialogIcon({ variant }: DialogIconProps) {
         height: 40,
         borderRadius: '50%',
         flexShrink: 0,
-        background: isDark ? def.bgDark : def.bgLight,
-        border: `0.5px solid ${isDark ? def.borderDark : def.borderLight}`,
+        background: alpha(color, isDark ? def.bgAlpha : 0.08),
+        border: `0.5px solid ${alpha(color, isDark ? def.borderAlpha : 0.22)}`,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -275,7 +261,7 @@ export function RcDialog({
             <Box
               id='rc-dialog-title'
               sx={{
-                fontSize: scaledPx(14.5),
+                fontSize: scaledPx(theme.custom.fontSize.dialogTitle),
                 fontWeight: 600,
                 color: 'text.primary',
                 mb: '6px',
@@ -288,7 +274,7 @@ export function RcDialog({
             <Box
               id='rc-dialog-description'
               sx={{
-                fontSize: scaledPx(12.5),
+                fontSize: scaledPx(theme.custom.fontSize.dialogMessage),
                 lineHeight: 1.65,
                 color: 'text.secondary',
                 whiteSpace: 'pre-line',
@@ -308,10 +294,8 @@ export function RcDialog({
           alignItems: 'center',
           justifyContent: 'flex-end',
           gap: '8px',
-          background: isDark
-            ? 'rgba(255,255,255,0.018)'
-            : 'rgba(255,255,255,0.40)',
-          borderTop: `0.5px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+          background: theme.palette.glass.panel,
+          borderTop: `0.5px solid ${theme.palette.divider}`,
         }}
       >
         {isYesNo ? (

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -40,7 +40,7 @@ const SearchPlaceholder = ({
           width: '44px',
           height: '44px',
           borderRadius: '50%',
-          background: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+          background: alpha(theme.palette.accent.main, isDark ? 0.1 : 0.07),
           border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.22 : 0.16)}`,
           display: 'flex',
           alignItems: 'center',

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -3,7 +3,7 @@ import { scaledPx } from '@/utils/css'
 import { Fragment, useEffect, useRef } from 'react'
 
 import { Box } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 
 import { SearchResultItem } from '@/components/molecules/SearchResultItem'
 import { CommandSearchResult } from '@/types/api/CheatSheet'
@@ -22,7 +22,6 @@ const SearchPlaceholder = ({
 }) => {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const accentSolid = isDark ? '#64b4ff' : '#0071e3'
   const empty = kind === 'empty'
 
   return (
@@ -41,16 +40,12 @@ const SearchPlaceholder = ({
           width: '44px',
           height: '44px',
           borderRadius: '50%',
-          background: isDark
-            ? 'rgba(100,180,255,0.10)'
-            : 'rgba(0,113,227,0.07)',
-          border: `0.5px solid ${
-            isDark ? 'rgba(100,180,255,0.22)' : 'rgba(0,113,227,0.16)'
-          }`,
+          background: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07),
+          border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.22 : 0.16)}`,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          color: accentSolid,
+          color: theme.palette.accent.main,
         }}
       >
         {empty ? (
@@ -83,7 +78,7 @@ const SearchPlaceholder = ({
       <Box
         sx={{
           fontFamily: FONT_UI,
-          fontSize: scaledPx(13),
+          fontSize: scaledPx(theme.custom.fontSize.label),
           fontWeight: 600,
           color: theme.palette.text.primary,
         }}
@@ -93,7 +88,7 @@ const SearchPlaceholder = ({
       <Box
         sx={{
           fontFamily: FONT_UI,
-          fontSize: scaledPx(11.5),
+          fontSize: scaledPx(theme.custom.fontSize.caption),
           color: theme.palette.text.secondary,
           maxWidth: '340px',
           lineHeight: 1.55,
@@ -147,12 +142,8 @@ const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
               fontSize: scaledPx(10),
               fontWeight: 500,
               color: theme.palette.text.primary,
-              background: isDark
-                ? 'rgba(255,255,255,0.07)'
-                : 'rgba(255,255,255,0.78)',
-              border: `0.5px solid ${
-                isDark ? 'rgba(255,255,255,0.14)' : 'rgba(0,0,0,0.12)'
-              }`,
+              background: theme.palette.glass.field,
+              border: `0.5px solid ${theme.palette.divider}`,
               borderRadius: '4px',
               padding: '1px 5px',
               minWidth: '16px',
@@ -170,7 +161,7 @@ const Hotkey = ({ chips, label }: { chips: string[]; label: string }) => {
         component='span'
         sx={{
           fontFamily: FONT_UI,
-          fontSize: scaledPx(10.5),
+          fontSize: scaledPx(theme.custom.fontSize.hint),
           color: theme.palette.text.secondary,
           letterSpacing: '0.01em',
         }}
@@ -199,7 +190,7 @@ export const SearchResults = ({
 }: Props) => {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const divider = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)'
+  const divider = theme.palette.divider
   const listRef = useRef<HTMLDivElement>(null)
 
   // キーボードで選択行が移動したとき、選択行をリスト表示域内へスクロールする
@@ -249,9 +240,7 @@ export const SearchResults = ({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          background: isDark
-            ? 'rgba(255,255,255,0.018)'
-            : 'rgba(255,255,255,0.30)',
+          background: theme.palette.glass.panel,
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: '14px' }}>

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -8,6 +8,21 @@ import { grey } from '@/theme/color'
 const FONT_UI =
   '"Noto Sans JP", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif'
 
+const FONT_SIZE_SCALE = {
+  numberHint: 9.5,
+  hint: 10.5,
+  commandMultiline: 10,
+  captionSm: 11,
+  caption: 11.5,
+  body: 12,
+  dialogMessage: 12.5,
+  label: 13,
+  sectionHeader: 14,
+  dialogTitle: 14.5,
+  searchInput: 15,
+  hotkeyChar: 16,
+} as const
+
 declare module '@mui/material/styles' {
   interface BreakpointOverrides {
     xs: true
@@ -15,6 +30,29 @@ declare module '@mui/material/styles' {
     md: true
     lg: true
     xl: true
+  }
+  interface Theme {
+    custom: {
+      fontSize: {
+        numberHint: number
+        hint: number
+        commandMultiline: number
+        captionSm: number
+        caption: number
+        body: number
+        dialogMessage: number
+        label: number
+        sectionHeader: number
+        dialogTitle: number
+        searchInput: number
+        hotkeyChar: number
+      }
+    }
+  }
+  interface ThemeOptions {
+    custom?: {
+      fontSize?: Partial<Theme['custom']['fontSize']>
+    }
   }
   interface Palette {
     alert: { main: string }
@@ -34,6 +72,20 @@ declare module '@mui/material/styles' {
       checkedHover: string
       uncheckedHover: string
     }
+    glass: {
+      panel: string
+      field: string
+      overlay: string
+    }
+    surface: {
+      hover: string
+      selected: string
+    }
+    amber: {
+      text: string
+      background: string
+      border: string
+    }
   }
   interface PaletteOptions {
     alert?: { main?: string }
@@ -52,6 +104,20 @@ declare module '@mui/material/styles' {
       trackBackground?: string
       checkedHover?: string
       uncheckedHover?: string
+    }
+    glass?: {
+      panel?: string
+      field?: string
+      overlay?: string
+    }
+    surface?: {
+      hover?: string
+      selected?: string
+    }
+    amber?: {
+      text?: string
+      background?: string
+      border?: string
     }
   }
 }
@@ -79,6 +145,9 @@ const getBaseThemeOptions = (fontScale: number = 1.0) => ({
     h2: { fontSize: 18 * fontScale, fontWeight: 700 },
     h3: { fontSize: 15 * fontScale, fontWeight: 500 },
     h4: { fontSize: 14 * fontScale },
+  },
+  custom: {
+    fontSize: FONT_SIZE_SCALE,
   },
 })
 
@@ -112,6 +181,20 @@ const getLightPalette = () => ({
     trackBackground: 'rgba(0,0,0,0.12)',
     checkedHover: 'rgba(0,113,227,0.08)',
     uncheckedHover: 'rgba(0,0,0,0.08)',
+  },
+  glass: {
+    panel: 'rgba(255,255,255,0.35)',
+    field: 'rgba(255,255,255,0.55)',
+    overlay: 'rgba(240,245,255,0.97)',
+  },
+  surface: {
+    hover: 'rgba(0,0,0,0.04)',
+    selected: 'rgba(0,113,227,0.06)',
+  },
+  amber: {
+    text: '#8a6300',
+    background: 'rgba(180,120,0,0.06)',
+    border: 'rgba(180,120,0,0.22)',
   },
   background: {
     default: '#dce5f2',
@@ -149,6 +232,20 @@ const getDarkPalette = () => ({
     trackBackground: 'rgba(255,255,255,0.15)',
     checkedHover: 'rgba(100,180,255,0.08)',
     uncheckedHover: 'rgba(255,255,255,0.08)',
+  },
+  glass: {
+    panel: 'rgba(255,255,255,0.025)',
+    field: 'rgba(255,255,255,0.055)',
+    overlay: 'rgba(12,28,48,0.97)',
+  },
+  surface: {
+    hover: 'rgba(255,255,255,0.05)',
+    selected: 'rgba(100,180,255,0.10)',
+  },
+  amber: {
+    text: '#f5c46b',
+    background: 'rgba(255,180,80,0.08)',
+    border: 'rgba(255,180,80,0.30)',
   },
   background: {
     default: '#0f2236',


### PR DESCRIPTION
## Summary

- `src/theme/default.ts` に `FONT_SIZE_SCALE` 定数と `glass` / `surface` / `amber` のセマンティックカラートークンを追加し、TypeScript モジュール拡張で `theme.custom.fontSize.*` および `theme.palette.glass/surface/amber/*` として参照可能にした
- 全コンポーネント・ページファイルのハードコーディングされた `scaledPx(N)` を `scaledPx(theme.custom.fontSize.xxx)` に置き換え
- `isDark ? '#64b4ff' : '#0071e3'` のようなアクセントカラーの直書きを `theme.palette.accent.main` に統一
- `isDark ? 'rgba(100,180,255,0.xx)' : 'rgba(0,113,227,0.xx)'` を MUI `alpha(theme.palette.accent.main, x)` で動的生成に変更
- `rgba(255,255,255,0.025/0.35)` などのガラス背景を `theme.palette.glass.panel/field/overlay` に、アンバーの警告チップ色を `theme.palette.amber.*` に置き換え
- 対象ファイル: 24ファイル（theme/default.ts + atoms 2 + molecules 9 + organisms 3 + pages 7 + search/export）

## Test plan

- [x] `npx tsc --noEmit` エラーなし
- [x] `yarn lint:eslint` エラーなし
- [x] `yarn tauri dev` でアプリ起動し、ライト/ダーク両モードで全画面の表示崩れがないことを目視確認
- [x] Preferences画面、Edit Cheatsheets画面、Export画面、Search画面を重点確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)