### PR TITLE
feat: クリップボード履歴のDBテーブル・マイグレーション・リポジトリ層を実装

### DIFF
--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -691,6 +691,89 @@ pub fn replace_commandlist_by_title(
     }
 }
 
+#[derive(Debug)]
+pub struct ClipboardHistoryRow {
+    pub id: i64,
+    pub text: String,
+    pub char_count: i64,
+    pub copied_at: String,
+}
+
+/// クリップボード履歴を追加する。
+/// 直前（最新）の履歴と同一テキストの場合は INSERT せず、既存行の id を返す（重複排除）。
+pub fn insert_clipboard_history(conn: &Connection, text: &str) -> Result<i64> {
+    let last: Option<(i64, String)> = match conn.query_row(
+        "SELECT id, text FROM clipboard_history ORDER BY copied_at DESC, id DESC LIMIT 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    ) {
+        Ok(row) => Some(row),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(e) => return Err(e),
+    };
+
+    if let Some((last_id, last_text)) = last {
+        if last_text == text {
+            return Ok(last_id);
+        }
+    }
+
+    let char_count = text.chars().count() as i64;
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count) VALUES (?1, ?2)",
+        params![text, char_count],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// クリップボード履歴を新しい順に取得する。
+pub fn list_clipboard_history(conn: &Connection, limit: u32) -> Result<Vec<ClipboardHistoryRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, text, char_count, copied_at FROM clipboard_history
+         ORDER BY copied_at DESC, id DESC LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(params![limit], |row| {
+            Ok(ClipboardHistoryRow {
+                id: row.get(0)?,
+                text: row.get(1)?,
+                char_count: row.get(2)?,
+                copied_at: row.get(3)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// クリップボード履歴を個別削除する。
+pub fn delete_clipboard_history(conn: &Connection, id: i64) -> Result<()> {
+    conn.execute("DELETE FROM clipboard_history WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+/// クリップボード履歴を全削除する。
+pub fn clear_clipboard_history(conn: &Connection) -> Result<()> {
+    conn.execute("DELETE FROM clipboard_history", [])?;
+    Ok(())
+}
+
+/// クリップボード履歴の件数を取得する（上限管理用）。
+pub fn count_clipboard_history(conn: &Connection) -> Result<i64> {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM clipboard_history", [], |r| r.get(0))?;
+    Ok(count)
+}
+
+/// 新しい順に keep_count 件を残し、それより古いクリップボード履歴を削除する。
+pub fn delete_oldest_clipboard_history(conn: &Connection, keep_count: u32) -> Result<()> {
+    conn.execute(
+        "DELETE FROM clipboard_history WHERE id NOT IN (
+             SELECT id FROM clipboard_history ORDER BY copied_at DESC, id DESC LIMIT ?1
+         )",
+        params![keep_count],
+    )?;
+    Ok(())
+}
+
 /// タイトルごとのコマンド数を返す。将来のエクスポートUI表示用。
 #[allow(dead_code)]
 pub fn count_commands_for_titles(

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -22,8 +22,29 @@ pub fn apply_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     if version < 2 {
         migrate_v2(conn)?;
     }
+    if version < 3 {
+        migrate_v3(conn)?;
+    }
 
     Ok(())
+}
+
+fn migrate_v3(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS clipboard_history (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            text       TEXT NOT NULL,
+            char_count INTEGER NOT NULL,
+            copied_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_clipboard_history_copied_at
+            ON clipboard_history(copied_at DESC);
+
+        INSERT OR REPLACE INTO schema_meta(key, value) VALUES ('schema_version', '3');
+        ",
+    )
 }
 
 fn migrate_v2(conn: &Connection) -> Result<(), rusqlite::Error> {

--- a/src-tauri/tests/db/repository.rs
+++ b/src-tauri/tests/db/repository.rs
@@ -1,11 +1,13 @@
 use app_lib::api::cheatsheet::{CheatSheet, Command, CommandGroup, CommandItem, WindowSize};
 use app_lib::db::repository::{
-    add_command_row, add_group_row, delete_cheatsheet, delete_command_row, delete_group_row,
-    get_all_titles, get_cheatsheet_by_title, get_cheatsheet_id_by_title,
-    get_max_command_in_group_sort_order, get_max_toplevel_sort_order, get_window_size,
-    insert_cheatsheet, insert_commandlist, replace_commandlist_by_title, save_window_size,
-    search_by_fts, search_by_like, search_commands, title_exists, update_cheatsheet,
-    update_command_row, update_group_row,
+    add_command_row, add_group_row, clear_clipboard_history, count_clipboard_history,
+    delete_cheatsheet, delete_clipboard_history, delete_command_row, delete_group_row,
+    delete_oldest_clipboard_history, get_all_titles, get_cheatsheet_by_title,
+    get_cheatsheet_id_by_title, get_max_command_in_group_sort_order, get_max_toplevel_sort_order,
+    get_window_size, insert_cheatsheet, insert_clipboard_history, insert_commandlist,
+    list_clipboard_history, replace_commandlist_by_title, save_window_size, search_by_fts,
+    search_by_like, search_commands, title_exists, update_cheatsheet, update_command_row,
+    update_group_row,
 };
 use app_lib::db::schema::apply_migrations;
 use rusqlite::Connection;
@@ -1232,4 +1234,464 @@ fn replace_commandlist_by_title_old_commands_are_not_searchable_after_replace() 
     // 新しいコマンドは検索できること
     let after_new = search_by_fts(&conn, "new_after_replace", 100).unwrap();
     assert_eq!(after_new.len(), 1);
+}
+
+// ── クリップボード履歴 API テスト ─────────────────────────────
+//
+// テスト対象: 以下の新規 repository.rs 関数（issue #177）
+//   - insert_clipboard_history
+//   - list_clipboard_history
+//   - delete_clipboard_history
+//   - clear_clipboard_history
+//   - count_clipboard_history
+//   - delete_oldest_clipboard_history
+//
+// ブラックボックス テスト設計:
+//   [同値分割]
+//     有効クラス①: 新規テキストの挿入 → 新規行が作成される
+//     有効クラス②: 直前（最新）の履歴と同一テキストの挿入 → 重複排除（INSERT されず既存 id を返す）
+//     有効クラス③: 直前とは異なるが過去に存在したテキストの挿入 → 重複排除されず新規行が作成される
+//     有効クラス④: ASCII テキスト vs マルチバイト（日本語）テキストでの char_count 計算
+//     境界クラス⑤: 空文字列テキスト（NOT NULL だが空文字は許容される）
+//   [境界値分析]
+//     limit = 0（最小値）/ 全件より少ない値 / 全件と同じ値 / 全件より多い値
+//     keep_count = 0（最小値）/ 全件より少ない値 / 全件と同じ値 / 全件より多い値
+//     件数 0 件（空テーブル）時の count / list / clear / delete_oldest
+//
+// ホワイトボックス テスト設計:
+//   - insert_clipboard_history: 「直前の履歴が存在しない（初回挿入）」
+//     「直前と同一テキスト」「直前と異なるテキスト」の3分岐を網羅
+//   - list_clipboard_history / delete_oldest_clipboard_history: copied_at が同一秒の場合の
+//     id によるタイブレーク（ORDER BY copied_at DESC, id DESC）を明示的な copied_at 指定で検証
+
+/// copied_at を明示的に指定してクリップボード履歴行を直接挿入するテスト用ヘルパー。
+/// insert_clipboard_history は copied_at を制御できないため、
+/// 「copied_at DESC」ソート順の検証には SQL を直接発行して固定値を与える。
+fn insert_history_with_timestamp(conn: &Connection, text: &str, copied_at: &str) -> i64 {
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count, copied_at) VALUES (?1, ?2, ?3)",
+        rusqlite::params![text, text.chars().count() as i64, copied_at],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+// ── insert_clipboard_history ──────────────────────────────────
+
+#[test]
+fn insert_clipboard_history_inserts_new_row_and_returns_id() {
+    // Arrange
+    let conn = setup();
+
+    // Act
+    let id = insert_clipboard_history(&conn, "hello").unwrap();
+
+    // Assert: 正のIDが返り、1件だけ登録されること
+    assert!(id > 0);
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 1);
+}
+
+#[test]
+fn insert_clipboard_history_computes_char_count_for_ascii() {
+    // Arrange
+    let conn = setup();
+
+    // Act
+    insert_clipboard_history(&conn, "hello").unwrap();
+
+    // Assert: ASCII文字はバイト数と文字数が一致する
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert_eq!(rows[0].char_count, 5);
+}
+
+#[test]
+fn insert_clipboard_history_computes_char_count_for_multibyte() {
+    // Arrange: "こんにちは" は5文字だが15バイト（UTF-8で日本語は1文字3バイト）
+    let conn = setup();
+
+    // Act
+    insert_clipboard_history(&conn, "こんにちは").unwrap();
+
+    // Assert: char_count はバイト数ではなく chars().count() の文字数であること
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert_eq!(
+        rows[0].char_count, 5,
+        "マルチバイト文字は1文字として数えられること"
+    );
+}
+
+#[test]
+fn insert_clipboard_history_empty_string_is_allowed() {
+    // Arrange: text は NOT NULL だが空文字列は許容される境界値
+    let conn = setup();
+
+    // Act
+    let id = insert_clipboard_history(&conn, "").unwrap();
+
+    // Assert: 挿入が成功し char_count は 0
+    assert!(id > 0);
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert_eq!(rows[0].text, "");
+    assert_eq!(rows[0].char_count, 0);
+}
+
+#[test]
+fn insert_clipboard_history_deduplicates_consecutive_same_text() {
+    // Arrange: 直前の履歴と同一テキストを連続で挿入
+    let conn = setup();
+    let first_id = insert_clipboard_history(&conn, "same text").unwrap();
+
+    // Act
+    let second_id = insert_clipboard_history(&conn, "same text").unwrap();
+
+    // Assert: 新規行は作成されず、同じIDが返り、件数は1件のまま
+    assert_eq!(second_id, first_id, "重複排除により同じIDが返ること");
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 1);
+}
+
+#[test]
+fn insert_clipboard_history_deduplicates_three_consecutive_same_text() {
+    // Arrange: 直前と同一のテキストを3回連続で挿入
+    let conn = setup();
+    let id1 = insert_clipboard_history(&conn, "repeat").unwrap();
+
+    // Act
+    let id2 = insert_clipboard_history(&conn, "repeat").unwrap();
+    let id3 = insert_clipboard_history(&conn, "repeat").unwrap();
+
+    // Assert: すべて同じIDが返り、件数は1件のまま
+    assert_eq!(id1, id2);
+    assert_eq!(id2, id3);
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 1);
+}
+
+#[test]
+fn insert_clipboard_history_does_not_deduplicate_non_consecutive_same_text() {
+    // Arrange: A → B → A の順で挿入（Aが連続していないため重複排除されない）
+    let conn = setup();
+    let id_a1 = insert_clipboard_history(&conn, "A").unwrap();
+    insert_clipboard_history(&conn, "B").unwrap();
+
+    // Act
+    let id_a2 = insert_clipboard_history(&conn, "A").unwrap();
+
+    // Assert: 直前（最新）はBなので、2回目のAは新規行として作成される
+    assert_ne!(
+        id_a1, id_a2,
+        "直前でなければ同じテキストでも重複排除されないこと"
+    );
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 3);
+}
+
+// ── list_clipboard_history ────────────────────────────────────
+
+#[test]
+fn list_clipboard_history_returns_empty_for_empty_table() {
+    // Arrange
+    let conn = setup();
+
+    // Act
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+
+    // Assert
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn list_clipboard_history_limit_zero_returns_empty() {
+    // Arrange: limit の最小境界値 0
+    let conn = setup();
+    insert_clipboard_history(&conn, "x").unwrap();
+
+    // Act
+    let rows = list_clipboard_history(&conn, 0).unwrap();
+
+    // Assert: limit=0 では何も返らないこと
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn list_clipboard_history_respects_limit_less_than_total() {
+    // Arrange: 3件登録し、limit=2 で取得
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "c").unwrap();
+
+    // Act
+    let rows = list_clipboard_history(&conn, 2).unwrap();
+
+    // Assert: 指定した件数のみ返ること
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn list_clipboard_history_limit_equal_to_total_returns_all() {
+    // Arrange: 3件登録し、limit=3（総数と同じ）で取得
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "c").unwrap();
+
+    // Act
+    let rows = list_clipboard_history(&conn, 3).unwrap();
+
+    // Assert
+    assert_eq!(rows.len(), 3);
+}
+
+#[test]
+fn list_clipboard_history_limit_greater_than_total_returns_all() {
+    // Arrange: 2件登録し、limit=100（総数より大きい）で取得
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+
+    // Act
+    let rows = list_clipboard_history(&conn, 100).unwrap();
+
+    // Assert: 総数分のみ返り、エラーにならないこと
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn list_clipboard_history_orders_by_copied_at_desc() {
+    // Arrange: copied_at を明示的に異なる値で3件挿入
+    let conn = setup();
+    insert_history_with_timestamp(&conn, "oldest", "2024-01-01 00:00:00");
+    insert_history_with_timestamp(&conn, "middle", "2024-01-02 00:00:00");
+    insert_history_with_timestamp(&conn, "newest", "2024-01-03 00:00:00");
+
+    // Act
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+
+    // Assert: copied_at の新しい順に並ぶこと
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].text, "newest");
+    assert_eq!(rows[1].text, "middle");
+    assert_eq!(rows[2].text, "oldest");
+}
+
+#[test]
+fn list_clipboard_history_tie_breaks_by_id_desc_when_copied_at_equal() {
+    // Arrange: 同一秒の copied_at で3件挿入（id は昇順で採番される）
+    let conn = setup();
+    let id1 = insert_history_with_timestamp(&conn, "first", "2024-06-01 12:00:00");
+    let id2 = insert_history_with_timestamp(&conn, "second", "2024-06-01 12:00:00");
+    let id3 = insert_history_with_timestamp(&conn, "third", "2024-06-01 12:00:00");
+
+    // Act
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+
+    // Assert: copied_at が同じ場合は id の降順（新しい id が先）になること
+    assert_eq!(
+        rows.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![id3, id2, id1]
+    );
+}
+
+#[test]
+fn list_clipboard_history_returns_correct_fields() {
+    // Arrange
+    let conn = setup();
+    insert_clipboard_history(&conn, "field check").unwrap();
+
+    // Act
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+
+    // Assert: text / char_count / copied_at がすべて取得できること
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].text, "field check");
+    assert_eq!(rows[0].char_count, 11);
+    assert!(!rows[0].copied_at.is_empty());
+}
+
+// ── delete_clipboard_history ──────────────────────────────────
+
+#[test]
+fn delete_clipboard_history_removes_existing_row() {
+    // Arrange
+    let conn = setup();
+    let id = insert_clipboard_history(&conn, "to delete").unwrap();
+
+    // Act
+    delete_clipboard_history(&conn, id).unwrap();
+
+    // Assert
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 0);
+}
+
+#[test]
+fn delete_clipboard_history_on_nonexistent_id_does_not_error() {
+    // Arrange: 存在しない ID への削除はエラーにならない（SQLite は更新行数 0 を返す）
+    let conn = setup();
+
+    // Act & Assert
+    let result = delete_clipboard_history(&conn, 99999);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn delete_clipboard_history_only_removes_target() {
+    // Arrange: 2件登録し、片方だけ削除する
+    let conn = setup();
+    let id1 = insert_clipboard_history(&conn, "keep_me").unwrap();
+    let id2 = insert_clipboard_history(&conn, "delete_me").unwrap();
+
+    // Act: id2 だけ削除
+    delete_clipboard_history(&conn, id2).unwrap();
+
+    // Assert: id1 は残っていること
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, id1);
+    assert_eq!(rows[0].text, "keep_me");
+}
+
+// ── clear_clipboard_history ───────────────────────────────────
+
+#[test]
+fn clear_clipboard_history_removes_all_rows() {
+    // Arrange
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "c").unwrap();
+
+    // Act
+    clear_clipboard_history(&conn).unwrap();
+
+    // Assert
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 0);
+    assert!(list_clipboard_history(&conn, 10).unwrap().is_empty());
+}
+
+#[test]
+fn clear_clipboard_history_on_empty_table_does_not_error() {
+    // Arrange: 空テーブル
+    let conn = setup();
+
+    // Act & Assert
+    let result = clear_clipboard_history(&conn);
+    assert!(result.is_ok());
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 0);
+}
+
+// ── count_clipboard_history ───────────────────────────────────
+
+#[test]
+fn count_clipboard_history_returns_zero_for_empty_table() {
+    // Arrange
+    let conn = setup();
+
+    // Act & Assert
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 0);
+}
+
+#[test]
+fn count_clipboard_history_returns_correct_count() {
+    // Arrange
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+
+    // Act & Assert
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 2);
+}
+
+#[test]
+fn count_clipboard_history_unchanged_after_duplicate_insert() {
+    // Arrange: 直前と同一テキストの挿入は重複排除されカウントが増えない
+    let conn = setup();
+    insert_clipboard_history(&conn, "dup").unwrap();
+
+    // Act
+    insert_clipboard_history(&conn, "dup").unwrap();
+
+    // Assert
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 1);
+}
+
+// ── delete_oldest_clipboard_history ───────────────────────────
+
+#[test]
+fn delete_oldest_clipboard_history_keep_count_zero_deletes_all() {
+    // Arrange: keep_count の最小境界値 0
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+
+    // Act
+    delete_oldest_clipboard_history(&conn, 0).unwrap();
+
+    // Assert: すべて削除されること
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 0);
+}
+
+#[test]
+fn delete_oldest_clipboard_history_keeps_newest_n_rows() {
+    // Arrange: 5件を異なる copied_at で登録し、新しい2件のみ残す
+    let conn = setup();
+    insert_history_with_timestamp(&conn, "t1", "2024-01-01 00:00:00");
+    insert_history_with_timestamp(&conn, "t2", "2024-01-02 00:00:00");
+    insert_history_with_timestamp(&conn, "t3", "2024-01-03 00:00:00");
+    insert_history_with_timestamp(&conn, "t4", "2024-01-04 00:00:00");
+    insert_history_with_timestamp(&conn, "t5", "2024-01-05 00:00:00");
+
+    // Act: 新しい2件（t4, t5）を残す
+    delete_oldest_clipboard_history(&conn, 2).unwrap();
+
+    // Assert
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].text, "t5");
+    assert_eq!(rows[1].text, "t4");
+}
+
+#[test]
+fn delete_oldest_clipboard_history_keep_count_equal_to_total_keeps_all() {
+    // Arrange: keep_count と総件数が一致する境界値
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "c").unwrap();
+
+    // Act
+    delete_oldest_clipboard_history(&conn, 3).unwrap();
+
+    // Assert: 何も削除されないこと
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 3);
+}
+
+#[test]
+fn delete_oldest_clipboard_history_keep_count_greater_than_total_keeps_all() {
+    // Arrange: keep_count が総件数より大きい境界値
+    let conn = setup();
+    insert_clipboard_history(&conn, "a").unwrap();
+    insert_clipboard_history(&conn, "b").unwrap();
+
+    // Act
+    delete_oldest_clipboard_history(&conn, 100).unwrap();
+
+    // Assert: 何も削除されないこと
+    assert_eq!(count_clipboard_history(&conn).unwrap(), 2);
+}
+
+#[test]
+fn delete_oldest_clipboard_history_tie_breaks_by_id_when_copied_at_equal() {
+    // Arrange: 同一秒の copied_at で3件挿入（id は昇順で採番される）
+    let conn = setup();
+    let id1 = insert_history_with_timestamp(&conn, "first", "2024-06-01 12:00:00");
+    let id2 = insert_history_with_timestamp(&conn, "second", "2024-06-01 12:00:00");
+    let id3 = insert_history_with_timestamp(&conn, "third", "2024-06-01 12:00:00");
+
+    // Act: keep_count=1 → copied_at が同じ場合は id の大きい方（新しい方）が残る
+    delete_oldest_clipboard_history(&conn, 1).unwrap();
+
+    // Assert: id3 のみ残ること
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, id3);
+    assert_ne!(rows[0].id, id1);
+    assert_ne!(rows[0].id, id2);
 }

--- a/src-tauri/tests/db/schema.rs
+++ b/src-tauri/tests/db/schema.rs
@@ -52,7 +52,7 @@ fn schema_version_is_set() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
 }
 
 #[test]
@@ -68,5 +68,134 @@ fn apply_migrations_is_idempotent() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
+}
+
+// ── v3: clipboard_history テーブルのテスト ─────────────────────
+//
+// テスト対象: migrate_v3 で追加される clipboard_history テーブルと
+// idx_clipboard_history_copied_at インデックス
+//
+// ブラックボックス テスト設計:
+//   [同値分割]
+//     有効クラス①: text / char_count を指定した INSERT → 成功
+//     無効クラス②: text が NULL → NOT NULL 制約違反でエラー
+//     無効クラス③: char_count が NULL → NOT NULL 制約違反でエラー
+//   [境界値分析]
+//     copied_at を明示指定しない INSERT → DEFAULT (datetime('now')) が適用される
+//
+// ホワイトボックス テスト設計:
+//   - id が AUTOINCREMENT のため、削除後の再挿入で id が再利用されないこと
+
+#[test]
+fn apply_migrations_creates_clipboard_history_table() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='clipboard_history'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1, "clipboard_history テーブルが作成されること");
+}
+
+#[test]
+fn apply_migrations_creates_clipboard_history_index() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_clipboard_history_copied_at'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        count, 1,
+        "idx_clipboard_history_copied_at インデックスが作成されること"
+    );
+}
+
+#[test]
+fn clipboard_history_copied_at_defaults_to_now_when_omitted() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    // copied_at を指定せずに INSERT → DEFAULT (datetime('now')) が適用される
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count) VALUES ('abc', 3)",
+        [],
+    )
+    .unwrap();
+
+    let copied_at: String = conn
+        .query_row(
+            "SELECT copied_at FROM clipboard_history WHERE text = 'abc'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        !copied_at.is_empty(),
+        "copied_at にデフォルト値が設定されること"
+    );
+}
+
+#[test]
+fn clipboard_history_text_not_null_constraint_rejects_null() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    let result = conn.execute(
+        "INSERT INTO clipboard_history (text, char_count) VALUES (NULL, 0)",
+        [],
+    );
+    assert!(result.is_err(), "text が NULL の INSERT はエラーになること");
+}
+
+#[test]
+fn clipboard_history_char_count_not_null_constraint_rejects_null() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    let result = conn.execute(
+        "INSERT INTO clipboard_history (text, char_count) VALUES ('abc', NULL)",
+        [],
+    );
+    assert!(
+        result.is_err(),
+        "char_count が NULL の INSERT はエラーになること"
+    );
+}
+
+#[test]
+fn clipboard_history_id_autoincrement_does_not_reuse_deleted_id() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count) VALUES ('first', 5)",
+        [],
+    )
+    .unwrap();
+    let first_id = conn.last_insert_rowid();
+
+    conn.execute("DELETE FROM clipboard_history WHERE id = ?1", [first_id])
+        .unwrap();
+
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count) VALUES ('second', 6)",
+        [],
+    )
+    .unwrap();
+    let second_id = conn.last_insert_rowid();
+
+    assert!(
+        second_id > first_id,
+        "AUTOINCREMENT により削除済み id が再利用されないこと"
+    );
 }


### PR DESCRIPTION
## 概要

クリップボード履歴機能のデータ永続化レイヤーを実装しました。

Closes #177

## 変更内容

### スキーマ（v3マイグレーション）
- `src-tauri/src/db/schema.rs` に `migrate_v3` を追加
  - `clipboard_history` テーブル（id / text / char_count / copied_at）
  - `idx_clipboard_history_copied_at` インデックス（copied_at DESC）
  - `schema_version` を 3 に更新

### リポジトリ層
- `src-tauri/src/db/repository.rs` に `ClipboardHistoryRow` 構造体と以下の6関数を追加
  - `insert_clipboard_history(conn, text) -> Result<i64>` — 履歴追加。直前（最新）の履歴と同一テキストの場合は INSERT せず既存 id を返す（重複排除）。`char_count` は `chars().count()` で算出（マルチバイト文字は1文字）
  - `list_clipboard_history(conn, limit)` — `copied_at DESC, id DESC` 順で取得
  - `delete_clipboard_history(conn, id)` — 個別削除
  - `clear_clipboard_history(conn)` — 全削除
  - `count_clipboard_history(conn)` — 件数取得（上限管理用）
  - `delete_oldest_clipboard_history(conn, keep_count)` — 新しい順 keep_count 件を残して削除

### テスト
- `tests/db/schema.rs` — v3 スキーマの検証テスト6件を追加（既存の schema_version 期待値を 2→3 に更新）
- `tests/db/repository.rs` — 6関数の CRUD テスト28件を追加（境界値: limit/keep_count の 0・総数一致・総数超過、マルチバイト char_count、同一秒タイブレークなど）

## テスト結果

`cargo test -- --test-threads=1`: 225 passed / 0 failed

## 関連

- PoC参照: PR #176（`research/clipboard-history-poc` ブランチ）
- 次: バックエンド② ClipboardMonitor統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)