### PR TITLE
feat: Clipboard Historyを独立ウィンドウ化しグローバルショートカット（^⌘C）で表示切替できるようにする (#198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,9 +186,10 @@ Rust の慣習ではパッケージ名に小文字（`right-cheat`）を推奨�
 - `[useThemeStore]` - `src/hooks/useThemeStore.ts`
 - `[useFontSize]` - `src/hooks/useFontSize.ts`
 - `[useWindowSize]` - `src/hooks/useWindowSize.ts`
+- `[useClipboardHistoryWindowSize]` - `src/hooks/useClipboardHistoryWindowSize.ts`
 - `[useCommandSearch]` - `src/hooks/useCommandSearch.ts`
 - `[useClipboardHistory]` - `src/hooks/useClipboardHistory.ts`
-- `[AddToCheatSheetDialog]` - `src/components/organisms/clipboard-history/AddToCheatSheetDialog.tsx`
+- `[AddToCheatSheet]` - `src/app/add-to-cheatsheet/page.tsx`
 - `[page]` - `src/app/page.tsx`
 - `[search]` - `src/app/search/page.tsx`
 
@@ -354,6 +355,8 @@ backgroundColor: alpha(theme.palette.accent.main, isDark ? 0.10 : 0.07)
 ### ファイル構造
 - `src/`: Next.js フロントエンドコード
   - `src/app/export/`: チートシートエクスポート選択画面
+  - `src/app/clipboard-history/`: クリップボード履歴ウィンドウ（独立ウィンドウ。グローバルショートカット ^⌘C / View メニューでトグル表示）
+  - `src/app/add-to-cheatsheet/`: 履歴エントリをチートシートへ登録する別ウィンドウ
 - `src-tauri/`: Rust バックエンドコードと Tauri 設定
   - `src-tauri/src/db/`: SQLite DB 接続・スキーマ・リポジトリ層
   - `src-tauri/src/api/`: Tauri コマンド（チートシート取得・インポート・エクスポート・検索）

--- a/src-tauri/src/api/global_shortcut.rs
+++ b/src-tauri/src/api/global_shortcut.rs
@@ -257,3 +257,132 @@ pub fn set_toggle_visible_shortcut_settings_with_store<R: tauri::Runtime, S: Set
 
     format!("{{\"status\": {}, \"message\": {}}}", response, message)
 }
+
+pub fn init_clipboard_history_shortcut_settings<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<(), tauri_plugin_store::Error> {
+    let settings_store = TauriSettingsStore;
+    let shortcut_settings =
+        settings_store.get_setting(app, common::config::CLIPBOARD_HISTORY_SHORTCUT);
+
+    match shortcut_settings {
+        Ok(result) => match result {
+            Some(value) => {
+                log::info!(
+                    "[global_shortcut] Clipboard history shortcut settings already exists: {}",
+                    value
+                );
+            }
+            None => {
+                let default_shortcut = ShortcutDef {
+                    ctrl: true,
+                    option: false,
+                    command: true,
+                    hotkey: String::from("C"),
+                };
+                if let Err(err) = settings_store.set_setting(
+                    app,
+                    common::config::CLIPBOARD_HISTORY_SHORTCUT,
+                    json!(default_shortcut),
+                ) {
+                    log::error!(
+                        "[global_shortcut] Failed to set default clipboard history shortcut settings: {}",
+                        err
+                    );
+                    return Err(err);
+                } else {
+                    log::info!(
+                        "[global_shortcut] Default clipboard history shortcut settings initialized."
+                    );
+                }
+            }
+        },
+        Err(err) => {
+            log::error!(
+                "[global_shortcut] Failed to initialize clipboard history shortcut settings: {:?}",
+                err
+            );
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_clipboard_history_shortcut_settings<R: tauri::Runtime>(app: AppHandle<R>) -> String {
+    let settings_store = TauriSettingsStore;
+    get_clipboard_history_shortcut_settings_with_store(&app, &settings_store)
+}
+
+pub fn get_clipboard_history_shortcut_settings_with_store<R: tauri::Runtime, S: SettingsStore>(
+    app: &AppHandle<R>,
+    settings_store: &S,
+) -> String {
+    let shortcut_settings =
+        settings_store.get_setting(app, common::config::CLIPBOARD_HISTORY_SHORTCUT);
+
+    let response;
+    let message;
+    match shortcut_settings {
+        Ok(result) => match result {
+            Some(value) => {
+                response = "\"success\"";
+                message = format!("{}", value);
+            }
+            None => {
+                response = "\"fail\"";
+                message = String::from("\"No settings found for clipboard history shortcut.\"");
+            }
+        },
+        Err(err) => {
+            log::error!(
+                "[global_shortcut] Failed to get clipboard history shortcut settings: {:?}",
+                err
+            );
+            response = "\"fail\"";
+            message = format!("{}", err);
+        }
+    }
+
+    format!("{{\"status\": {}, \"message\": {}}}", response, message)
+}
+
+#[tauri::command]
+pub fn set_clipboard_history_shortcut_settings<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    shortcut: ShortcutDef,
+) -> String {
+    let settings_store = TauriSettingsStore;
+    set_clipboard_history_shortcut_settings_with_store(&app, shortcut, &settings_store)
+}
+
+pub fn set_clipboard_history_shortcut_settings_with_store<R: tauri::Runtime, S: SettingsStore>(
+    app: &AppHandle<R>,
+    shortcut: ShortcutDef,
+    settings_store: &S,
+) -> String {
+    let result = settings_store.set_setting(
+        app,
+        common::config::CLIPBOARD_HISTORY_SHORTCUT,
+        json!(shortcut),
+    );
+
+    let response;
+    let message;
+    match result {
+        Ok(()) => {
+            response = "\"success\"";
+            message = format!("{}", json!(shortcut));
+        }
+        Err(err) => {
+            log::error!(
+                "[global_shortcut] Failed to set clipboard history shortcut settings: {:?}",
+                err
+            );
+            response = "\"fail\"";
+            message = format!("{}", err);
+        }
+    }
+
+    format!("{{\"status\": {}, \"message\": {}}}", response, message)
+}

--- a/src-tauri/src/api/window.rs
+++ b/src-tauri/src/api/window.rs
@@ -1,5 +1,13 @@
+use crate::api::cheatsheet::WindowSize;
 use crate::common;
+use crate::settings_store::{SettingsStore, TauriSettingsStore};
+use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter, EventTarget};
+
+/// Clipboard History ウィンドウの最小サイズ（論理ピクセル）。
+/// ウィンドウ生成時の `min_inner_size` と一致させる。
+const CLIPBOARD_HISTORY_MIN_WIDTH: u32 = 320;
+const CLIPBOARD_HISTORY_MIN_HEIGHT: u32 = 400;
 
 #[tauri::command]
 pub fn notify_theme_changed<R: tauri::Runtime>(app: AppHandle<R>) -> String {
@@ -10,4 +18,45 @@ pub fn notify_theme_changed<R: tauri::Runtime>(app: AppHandle<R>) -> String {
     }
 
     format!("{{\"status\": \"{}\"}}", response)
+}
+
+/// Clipboard History ウィンドウのピン留めサイズを設定ファイルから取得する。
+/// 未設定（キーなし・null）の場合は `None` を返す。
+#[tauri::command]
+pub fn get_clipboard_history_window_size<R: tauri::Runtime>(
+    app: AppHandle<R>,
+) -> Result<Option<WindowSize>, String> {
+    let settings_store = TauriSettingsStore;
+    let value = settings_store
+        .get_setting(&app, common::config::CLIPBOARD_HISTORY_WINDOW_SIZE)
+        .map_err(|e| e.to_string())?;
+
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => serde_json::from_value::<WindowSize>(v)
+            .map(Some)
+            .map_err(|e| e.to_string()),
+    }
+}
+
+/// Clipboard History ウィンドウのピン留めサイズを設定ファイルに保存する。
+/// `None` を渡すとピン留めを解除する（null を保存する）。
+#[tauri::command]
+pub fn save_clipboard_history_window_size<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    window_size: Option<WindowSize>,
+) -> Result<(), String> {
+    let settings_store = TauriSettingsStore;
+    let value = match window_size {
+        Some(ws) => {
+            let clamped =
+                ws.clamp_to_min(CLIPBOARD_HISTORY_MIN_WIDTH, CLIPBOARD_HISTORY_MIN_HEIGHT);
+            json!(clamped)
+        }
+        None => Value::Null,
+    };
+
+    settings_store
+        .set_setting(&app, common::config::CLIPBOARD_HISTORY_WINDOW_SIZE, value)
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/common.rs
+++ b/src-tauri/src/common.rs
@@ -1,6 +1,8 @@
 pub mod config {
     pub const SETTING_FILENAME: &str = "rightcheat-settings.json";
     pub const TOGGLE_VISIBLE_SHORTCUT: &str = "toggle_visibe_shortcut_settings";
+    pub const CLIPBOARD_HISTORY_SHORTCUT: &str = "clipboard_history_shortcut_settings";
+    pub const CLIPBOARD_HISTORY_WINDOW_SIZE: &str = "clipboard_history_window_size";
     pub const LOG_SETTINGS: &str = "log_settings";
     pub const DB_SETTINGS: &str = "db_settings";
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,7 +206,16 @@ fn toggle_clipboard_history_window<R: tauri::Runtime>(handle: &tauri::AppHandle<
                     log::error!("[lib] Failed to hide clipboard history window: {}", e);
                 }
             }
-            _ => {
+            Ok(false) => {
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+            Err(e) => {
+                // 可視状態の取得に失敗した場合は表示側に倒す
+                log::error!(
+                    "[lib] Failed to get clipboard history window visibility: {}",
+                    e
+                );
                 let _ = win.show();
                 let _ = win.set_focus();
             }
@@ -658,6 +667,13 @@ fn global_shortcut_configuration<R: tauri::Runtime>(
                     }
                 }
             }
+        } else {
+            // 通常は init_*_shortcut_settings がデフォルトを書き込むため到達しないが、
+            // 設定ファイルの欠損時にメニュー・グローバルショートカットが無言で無効化
+            // されないよう、原因が追えるようログを残す。
+            log::error!(
+                "[lib] Shortcut settings are missing; menu and global shortcuts were not configured"
+            );
         }
     }
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -152,7 +152,11 @@ pub fn run() {
             api::cheatsheet::save_cheat_sheet_commandlist,
             api::global_shortcut::get_toggle_visible_shortcut_settings,
             api::global_shortcut::set_toggle_visible_shortcut_settings,
+            api::global_shortcut::get_clipboard_history_shortcut_settings,
+            api::global_shortcut::set_clipboard_history_shortcut_settings,
             api::window::notify_theme_changed,
+            api::window::get_clipboard_history_window_size,
+            api::window::save_clipboard_history_window_size,
             api::font_size::get_font_size_settings,
             api::font_size::set_font_size_settings,
             api::font_size::increase_font_size,
@@ -191,9 +195,44 @@ pub fn run() {
         });
 }
 
+/// Clipboard History ウィンドウの表示をトグルする。
+/// 未作成なら `/clipboard-history` を開き、表示中なら hide、
+/// 隠れていれば show + フォーカス（メインウィンドウの Toggle Visible と同等の挙動）。
+fn toggle_clipboard_history_window<R: tauri::Runtime>(handle: &tauri::AppHandle<R>) {
+    if let Some(win) = handle.get_webview_window("clipboard_history") {
+        match win.is_visible() {
+            Ok(true) => {
+                if let Err(e) = win.hide() {
+                    log::error!("[lib] Failed to hide clipboard history window: {}", e);
+                }
+            }
+            _ => {
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+        }
+    } else {
+        let result = tauri::webview::WebviewWindowBuilder::new(
+            handle,
+            "clipboard_history",
+            tauri::WebviewUrl::App("/clipboard-history".into()),
+        )
+        .title("Clipboard History")
+        .inner_size(360.0, 620.0)
+        .min_inner_size(320.0, 400.0)
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true)
+        .build();
+        if let Err(e) = result {
+            log::error!("[lib] Failed to create clipboard history window: {}", e);
+        }
+    }
+}
+
 fn menu_configuration<R: tauri::Runtime>(
     handle: &tauri::AppHandle<R>,
     toggle_visible_shortcut: String,
+    clipboard_history_shortcut: String,
 ) -> Result<Menu<R>, tauri::Error> {
     let window_submenu = Submenu::with_id_and_items(
         handle,
@@ -289,6 +328,14 @@ fn menu_configuration<R: tauri::Runtime>(
                 "View ", // NOTE: デフォルトメニューにならないよう、Viewの後にスペースを入れている。
                 true,
                 &[
+                    &MenuItem::with_id(
+                        handle,
+                        "id_clipboard_history",
+                        "Clipboard History",
+                        true,
+                        Some(clipboard_history_shortcut),
+                    )?,
+                    &PredefinedMenuItem::separator(handle)?,
                     &MenuItem::with_id(handle, "id_find", "Find...", true, Some("Cmd+F"))?,
                     &PredefinedMenuItem::separator(handle)?,
                     &MenuItem::with_id(
@@ -512,6 +559,9 @@ fn on_menu_event_configuration<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, 
                 .emit(common::event::WINDOW_VISIABLE_TOGGLE, ())
                 .unwrap();
         }
+        "id_clipboard_history" => {
+            toggle_clipboard_history_window(handle);
+        }
         "id_increase_font_size" => {
             let _ = api::font_size::increase_font_size(handle.clone());
         }
@@ -534,32 +584,54 @@ fn global_shortcut_configuration<R: tauri::Runtime>(
     {
         let settings_store = TauriSettingsStore;
         api::global_shortcut::init_toggle_visible_shortcut_settings(app.handle())?;
-        let shortcut_settings =
+        api::global_shortcut::init_clipboard_history_shortcut_settings(app.handle())?;
+        let toggle_visible_settings_json =
             settings_store.get_setting(app.handle(), common::config::TOGGLE_VISIBLE_SHORTCUT)?;
-        if let Some(ref json) = shortcut_settings {
-            let settings: api::global_shortcut::ShortcutDef = serde_json::from_value(json.clone())?;
-            let window_visible_shortcut = settings.to_shortcut()?;
+        let clipboard_history_settings_json =
+            settings_store.get_setting(app.handle(), common::config::CLIPBOARD_HISTORY_SHORTCUT)?;
+        if let (Some(ref toggle_json), Some(ref clipboard_json)) = (
+            toggle_visible_settings_json,
+            clipboard_history_settings_json,
+        ) {
+            let toggle_settings: api::global_shortcut::ShortcutDef =
+                serde_json::from_value(toggle_json.clone())?;
+            let clipboard_settings: api::global_shortcut::ShortcutDef =
+                serde_json::from_value(clipboard_json.clone())?;
+            let window_visible_shortcut = toggle_settings.to_shortcut()?;
+            let clipboard_history_shortcut = clipboard_settings.to_shortcut()?;
             log::info!(
                 "[lib] Toggle visible shortcut settings : {}",
                 window_visible_shortcut
+            );
+            log::info!(
+                "[lib] Clipboard history shortcut settings : {}",
+                clipboard_history_shortcut
             );
 
             app.handle().plugin(
                 tauri_plugin_global_shortcut::Builder::new()
                     .with_handler(move |_app, shortcut, event| {
-                        if shortcut == &window_visible_shortcut
-                            && event.state() == ShortcutState::Pressed
-                        {
+                        if event.state() != ShortcutState::Pressed {
+                            return;
+                        }
+                        if shortcut == &window_visible_shortcut {
                             _app.emit(common::event::WINDOW_VISIABLE_TOGGLE, ())
                                 .unwrap();
+                        } else if shortcut == &clipboard_history_shortcut {
+                            toggle_clipboard_history_window(_app);
                         }
                     })
                     .build(),
             )?;
 
             app.global_shortcut().register(window_visible_shortcut)?;
+            app.global_shortcut().register(clipboard_history_shortcut)?;
 
-            let menu = menu_configuration(app.handle(), settings.to_shortcut_for_menu()?)?;
+            let menu = menu_configuration(
+                app.handle(),
+                toggle_settings.to_shortcut_for_menu()?,
+                clipboard_settings.to_shortcut_for_menu()?,
+            )?;
             app.set_menu(menu)?;
             #[cfg(target_os = "macos")]
             {

--- a/src-tauri/tests/api/global_shortcut.rs
+++ b/src-tauri/tests/api/global_shortcut.rs
@@ -183,3 +183,192 @@ mod set_toggle_visible_shortcut_settings {
         assert!(result.contains("Mock set error"));
     }
 }
+
+#[cfg(test)]
+mod get_clipboard_history_shortcut_settings {
+    use app_lib::api::global_shortcut::{
+        get_clipboard_history_shortcut_settings, init_clipboard_history_shortcut_settings,
+    };
+    use app_lib::settings_store::{SettingsStore, TauriSettingsStore};
+    use tauri::test::mock_app;
+
+    pub const TEST_SETTING_FILENAME: &str = "unittest-settings.json";
+
+    #[test]
+    fn get_notinitialized() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        let result = get_clipboard_history_shortcut_settings(app.handle().clone());
+        assert_eq!(result, "{\"status\": \"fail\", \"message\": \"No settings found for clipboard history shortcut.\"}");
+    }
+
+    #[test]
+    fn get_default() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        init_clipboard_history_shortcut_settings(&app.handle().clone()).unwrap();
+
+        let result = get_clipboard_history_shortcut_settings(app.handle().clone());
+        assert_eq!(result, "{\"status\": \"success\", \"message\": {\"command\":true,\"ctrl\":true,\"hotkey\":\"C\",\"option\":false}}");
+    }
+
+    // モック用のSettings Store実装
+    struct MockErrorSettingsStore;
+
+    impl app_lib::settings_store::SettingsStore for MockErrorSettingsStore {
+        fn initialize_settings(&self, _filename: &str) {}
+
+        fn clear_settings<R: tauri::Runtime>(
+            &self,
+            _app: &tauri::AppHandle<R>,
+        ) -> Result<(), tauri_plugin_store::Error> {
+            Ok(())
+        }
+
+        fn get_setting<R: tauri::Runtime>(
+            &self,
+            _app: &tauri::AppHandle<R>,
+            _key: impl AsRef<str>,
+        ) -> Result<Option<tauri_plugin_store::JsonValue>, tauri_plugin_store::Error> {
+            Err(tauri_plugin_store::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Mock error",
+            )))
+        }
+
+        fn set_setting<R: tauri::Runtime>(
+            &self,
+            _app: &tauri::AppHandle<R>,
+            _key: impl Into<String>,
+            _value: impl Into<tauri_plugin_store::JsonValue>,
+        ) -> Result<(), tauri_plugin_store::Error> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn get_error() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+
+        let mock_store = MockErrorSettingsStore;
+        let result =
+            app_lib::api::global_shortcut::get_clipboard_history_shortcut_settings_with_store(
+                &app.handle().clone(),
+                &mock_store,
+            );
+
+        // Error時は"fail"ステータスが返されることを確認
+        assert!(result.contains("\"status\": \"fail\""));
+        assert!(result.contains("Mock error"));
+    }
+}
+
+#[cfg(test)]
+mod set_clipboard_history_shortcut_settings {
+    use app_lib::{
+        api::global_shortcut::{
+            get_clipboard_history_shortcut_settings, set_clipboard_history_shortcut_settings,
+            ShortcutDef,
+        },
+        settings_store::{SettingsStore, TauriSettingsStore},
+    };
+    use tauri::test::mock_app;
+
+    pub const TEST_SETTING_FILENAME: &str = "unittest-settings.json";
+
+    #[test]
+    fn set_shortcut() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        let shortcut = ShortcutDef::new(true, false, false, String::from("D"));
+
+        let result = set_clipboard_history_shortcut_settings(app.handle().clone(), shortcut);
+        assert_eq!(result, "{\"status\": \"success\", \"message\": {\"command\":false,\"ctrl\":true,\"hotkey\":\"D\",\"option\":false}}");
+
+        let result = get_clipboard_history_shortcut_settings(app.handle().clone());
+        assert_eq!(result, "{\"status\": \"success\", \"message\": {\"command\":false,\"ctrl\":true,\"hotkey\":\"D\",\"option\":false}}");
+    }
+
+    // モック用のSettings Store実装（set_settingでエラーを返す）
+    struct MockSetErrorSettingsStore;
+
+    impl app_lib::settings_store::SettingsStore for MockSetErrorSettingsStore {
+        fn initialize_settings(&self, _filename: &str) {}
+
+        fn clear_settings<R: tauri::Runtime>(
+            &self,
+            _app: &tauri::AppHandle<R>,
+        ) -> Result<(), tauri_plugin_store::Error> {
+            Ok(())
+        }
+
+        fn get_setting<R: tauri::Runtime>(
+            &self,
+            _app: &tauri::AppHandle<R>,
+            _key: impl AsRef<str>,
+        ) -> Result<Option<tauri_plugin_store::JsonValue>, tauri_plugin_store::Error> {
+            Ok(None)
+        }
+
+        fn set_setting<R: tauri::Runtime>(
+            &self,
+            _app: &tauri::AppHandle<R>,
+            _key: impl Into<String>,
+            _value: impl Into<tauri_plugin_store::JsonValue>,
+        ) -> Result<(), tauri_plugin_store::Error> {
+            Err(tauri_plugin_store::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "Mock set error",
+            )))
+        }
+    }
+
+    #[test]
+    fn set_error() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+
+        let shortcut = ShortcutDef::new(true, false, false, String::from("D"));
+        let mock_store = MockSetErrorSettingsStore;
+
+        let result =
+            app_lib::api::global_shortcut::set_clipboard_history_shortcut_settings_with_store(
+                &app.handle().clone(),
+                shortcut,
+                &mock_store,
+            );
+
+        // Error時は"fail"ステータスが返されることを確認
+        assert!(result.contains("\"status\": \"fail\""));
+        assert!(result.contains("Mock set error"));
+    }
+}

--- a/src-tauri/tests/api/mod.rs
+++ b/src-tauri/tests/api/mod.rs
@@ -9,3 +9,4 @@ mod font_size;
 mod global_shortcut;
 mod log_settings;
 mod visible_on_all_workspaces;
+mod window;

--- a/src-tauri/tests/api/window.rs
+++ b/src-tauri/tests/api/window.rs
@@ -1,0 +1,166 @@
+#[cfg(test)]
+mod get_clipboard_history_window_size {
+    use app_lib::api::window::get_clipboard_history_window_size;
+    use app_lib::settings_store::{SettingsStore, TauriSettingsStore};
+    use tauri::test::mock_app;
+
+    pub const TEST_SETTING_FILENAME: &str = "unittest-window-settings.json";
+
+    #[test]
+    fn get_notinitialized() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 設定キーが存在しない場合は Ok(None) を返す
+        let result = get_clipboard_history_window_size(app.handle().clone()).unwrap();
+        assert!(result.is_none());
+    }
+}
+
+#[cfg(test)]
+mod save_clipboard_history_window_size {
+    use app_lib::api::cheatsheet::WindowSize;
+    use app_lib::api::window::{
+        get_clipboard_history_window_size, save_clipboard_history_window_size,
+    };
+    use app_lib::settings_store::{SettingsStore, TauriSettingsStore};
+    use tauri::test::mock_app;
+
+    pub const TEST_SETTING_FILENAME: &str = "unittest-window-settings.json";
+
+    #[test]
+    fn save_and_get_roundtrip() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 最小サイズ以上の値はそのまま保存される
+        let window_size = WindowSize {
+            width: 500,
+            height: 700,
+        };
+        save_clipboard_history_window_size(app.handle().clone(), Some(window_size)).unwrap();
+
+        let result = get_clipboard_history_window_size(app.handle().clone())
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.width, 500);
+        assert_eq!(result.height, 700);
+    }
+
+    #[test]
+    fn save_clamps_below_minimum() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 最小サイズ (320x400) 未満の値はクランプされる
+        let window_size = WindowSize {
+            width: 100,
+            height: 100,
+        };
+        save_clipboard_history_window_size(app.handle().clone(), Some(window_size)).unwrap();
+
+        let result = get_clipboard_history_window_size(app.handle().clone())
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.width, 320);
+        assert_eq!(result.height, 400);
+    }
+
+    #[test]
+    fn save_clamps_width_only() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 幅のみが最小値未満の境界値ケース（高さは最小値ちょうど）
+        let window_size = WindowSize {
+            width: 319,
+            height: 400,
+        };
+        save_clipboard_history_window_size(app.handle().clone(), Some(window_size)).unwrap();
+
+        let result = get_clipboard_history_window_size(app.handle().clone())
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.width, 320);
+        assert_eq!(result.height, 400);
+    }
+
+    #[test]
+    fn save_at_minimum_boundary_is_not_clamped() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // 最小サイズちょうどの値はクランプされずそのまま保存される
+        let window_size = WindowSize {
+            width: 320,
+            height: 400,
+        };
+        save_clipboard_history_window_size(app.handle().clone(), Some(window_size)).unwrap();
+
+        let result = get_clipboard_history_window_size(app.handle().clone())
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.width, 320);
+        assert_eq!(result.height, 400);
+    }
+
+    #[test]
+    fn save_none_unpins_after_value_saved() {
+        let app = mock_app();
+        let _ = app
+            .handle()
+            .plugin(tauri_plugin_store::Builder::new().build());
+        let settings_store = TauriSettingsStore;
+        settings_store.initialize_settings(TEST_SETTING_FILENAME);
+        settings_store
+            .clear_settings(&app.handle().clone())
+            .unwrap();
+
+        // まず値を保存してからピン解除(None)することで null 保存の挙動を確認
+        let window_size = WindowSize {
+            width: 500,
+            height: 700,
+        };
+        save_clipboard_history_window_size(app.handle().clone(), Some(window_size)).unwrap();
+
+        save_clipboard_history_window_size(app.handle().clone(), None).unwrap();
+
+        let result = get_clipboard_history_window_size(app.handle().clone()).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/src/app/add-to-cheatsheet/page.tsx
+++ b/src/app/add-to-cheatsheet/page.tsx
@@ -1,15 +1,22 @@
 'use client'
 import { scaledPx } from '@/utils/css'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { Box, Dialog, MenuItem, Select, TextField } from '@mui/material'
+import { Box, MenuItem, Select, TextField } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { invoke } from '@tauri-apps/api/core'
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { debug, error as logError } from '@tauri-apps/plugin-log'
 
-import { FooterButton } from '@/components/molecules/FooterButton'
+import { Event } from '@/common'
+import {
+  WINDOW_ACTION_FOOTER_HEIGHT,
+  WindowActionFooter,
+} from '@/components/molecules/WindowActionFooter'
+import { WindowHeader } from '@/components/molecules/WindowHeader'
 import { TYPE_META } from '@/components/organisms/edit-cheatsheets/meta'
 import { useNotificationContext } from '@/context/NotificationContext'
+import { useWindowCloseShortcuts } from '@/hooks/useWindowCloseShortcuts'
 import { FONT_CODE } from '@/theme/fonts'
 import {
   CheatSheetAPI,
@@ -30,29 +37,21 @@ type GroupOption = {
   name: string
 }
 
-type Props = {
-  open: boolean
-  /** 履歴エントリのテキスト（Command フィールドの初期値） */
+/** clipboard_history ウィンドウから受け取る初期化ペイロード */
+type AddToCheatSheetInitPayload = {
   text: string
-  onCancel: () => void
-  /** 追加成功時に対象シートのタイトルを通知する */
-  onAdded: (sheetTitle: string) => void
 }
 
 /**
  * クリップボード履歴のエントリを既存チートシートのコマンドとして登録する
- * ダイアログ。対象は command / application タイプのシートのみ。
+ * 別ウィンドウ（label: add_to_cheatsheet）。対象は command / application タイプの
+ * シートのみ。Add 成功時は clipboard_history ウィンドウへ通知して閉じる。
  */
-export function AddToCheatSheetDialog({
-  open,
-  text,
-  onCancel,
-  onAdded,
-}: Props) {
+export default function AddToCheatSheetPage() {
   const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
   const { showError } = useNotificationContext() ?? {}
 
+  const [initialized, setInitialized] = useState(false)
   const [sheets, setSheets] = useState<CheatSheetSummary[]>([])
   const [sheetTitle, setSheetTitle] = useState('')
   const [groups, setGroups] = useState<GroupOption[]>([])
@@ -64,40 +63,44 @@ export function AddToCheatSheetDialog({
 
   const descRef = useRef<HTMLInputElement>(null)
 
-  // ダイアログを開いたときに状態を初期化し、対象シート一覧を取得する
+  // clipboard_history ウィンドウから履歴テキストを受け取り、対象シート一覧を取得する
   useEffect(() => {
-    if (!open) return
-    let cancelled = false
-    setDescription('')
-    setCommandText(text)
-    setLayout('inherit')
-    setGroupId('')
-    ;(async () => {
-      try {
-        const summaries = await invoke<CheatSheetSummary[]>(
-          CheatSheetAPI.LIST_CHEAT_SHEET_SUMMARIES,
-        )
-        if (cancelled) return
-        // shortcut シートはコピー可能なコマンドを持たないため対象外
-        const targets = summaries.filter((s) => s.sheet_type !== 'shortcut')
-        setSheets(targets)
-        setSheetTitle(targets[0]?.title ?? '')
-        setTimeout(() => descRef.current?.focus(), 80)
-      } catch (err) {
-        logError(
-          `[AddToCheatSheetDialog] Failed to load cheat sheet summaries: ${String(err)}`,
-        )
-        showError?.('Failed to load cheat sheets')
-      }
-    })()
-    return () => {
-      cancelled = true
+    const win = getCurrentWebviewWindow()
+
+    const setup = async () => {
+      await win.once<AddToCheatSheetInitPayload>(
+        Event.ADD_TO_CHEATSHEET_INIT,
+        async (event) => {
+          setCommandText(event.payload.text)
+          try {
+            const summaries = await invoke<CheatSheetSummary[]>(
+              CheatSheetAPI.LIST_CHEAT_SHEET_SUMMARIES,
+            )
+            // shortcut シートはコピー可能なコマンドを持たないため対象外
+            const targets = summaries.filter((s) => s.sheet_type !== 'shortcut')
+            setSheets(targets)
+            setSheetTitle(targets[0]?.title ?? '')
+          } catch (err) {
+            logError(
+              `[AddToCheatSheet] Failed to load cheat sheet summaries: ${String(err)}`,
+            )
+            showError?.('Failed to load cheat sheets')
+          }
+          setInitialized(true)
+          setTimeout(() => descRef.current?.focus(), 80)
+        },
+      )
+      await win.emitTo('clipboard_history', Event.ADD_TO_CHEATSHEET_READY, {})
     }
-  }, [open, text, showError])
+
+    setup()
+    // マウント時のみ実行する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // 対象シートの変更時にグループ一覧を取得する
   useEffect(() => {
-    if (!open || !sheetTitle) {
+    if (!sheetTitle) {
       setGroups([])
       return
     }
@@ -115,20 +118,18 @@ export function AddToCheatSheetDialog({
           .map((g) => ({ id: g.id as number, name: g.group }))
         setGroups(groupOptions)
       } catch (err) {
-        logError(
-          `[AddToCheatSheetDialog] Failed to load groups: ${String(err)}`,
-        )
+        logError(`[AddToCheatSheet] Failed to load groups: ${String(err)}`)
         setGroups([])
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [open, sheetTitle])
+  }, [sheetTitle])
 
   const canAdd = sheetTitle !== '' && commandText.trim().length > 0 && !isAdding
 
-  const handleAdd = async () => {
+  const handleAdd = useCallback(async () => {
     if (!canAdd) return
     setIsAdding(true)
     try {
@@ -142,67 +143,45 @@ export function AddToCheatSheetDialog({
         },
       })
       debug(
-        `[AddToCheatSheetDialog] added command to '${sheetTitle}' (group=${groupId || 'none'})`,
+        `[AddToCheatSheet] added command to '${sheetTitle}' (group=${groupId || 'none'})`,
       )
-      onAdded(sheetTitle)
+      const win = getCurrentWebviewWindow()
+      await win.emitTo('clipboard_history', Event.ADD_TO_CHEATSHEET_ADDED, {
+        sheetTitle,
+      })
+      await win.destroy()
     } catch (err) {
-      logError(`[AddToCheatSheetDialog] Failed to add command: ${String(err)}`)
+      logError(`[AddToCheatSheet] Failed to add command: ${String(err)}`)
       showError?.(
         `Failed to add command: ${err instanceof Error ? err.message : String(err)}`,
       )
-    } finally {
       setIsAdding(false)
     }
+  }, [canAdd, sheetTitle, groupId, description, commandText, layout, showError])
+
+  const handleCancel = useCallback(async () => {
+    await getCurrentWebviewWindow().destroy()
+  }, [])
+
+  // Cmd+S で Add / Esc で Cancel（ウィンドウを閉じる）
+  useWindowCloseShortcuts({
+    onSave: () => void handleAdd(),
+    onCancel: () => void handleCancel(),
+  })
+
+  if (!initialized) {
+    return null
   }
 
   return (
-    <Dialog
-      open={open}
-      onClose={onCancel}
-      aria-labelledby='add-to-cheatsheet-title'
-      slotProps={{
-        backdrop: {
-          sx: {
-            backgroundColor: isDark
-              ? 'rgba(0,0,10,0.45)'
-              : 'rgba(20,30,60,0.28)',
-            backdropFilter: 'blur(3px)',
-            WebkitBackdropFilter: 'blur(3px)',
-          },
-        },
-        paper: {
-          sx: {
-            width: 420,
-            maxWidth: 'calc(100% - 32px)',
-            borderRadius: '14px',
-            border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.10)' : 'rgba(0,0,0,0.12)'}`,
-            boxShadow: isDark
-              ? '0 24px 64px rgba(0,0,0,0.65), 0 0 0 0.5px rgba(255,255,255,0.10)'
-              : '0 24px 64px rgba(0,0,50,0.30), 0 0 0 0.5px rgba(255,255,255,0.7)',
-            overflow: 'hidden',
-            m: 0,
-          },
-        },
-      }}
-    >
-      {/* タイトル */}
-      <Box
-        id='add-to-cheatsheet-title'
-        sx={{
-          p: '16px 18px 0',
-          fontSize: scaledPx(theme.custom.fontSize.dialogTitle),
-          fontWeight: 600,
-          color: 'text.primary',
-          letterSpacing: '0.01em',
-        }}
-      >
-        Add to Cheat Sheet
-      </Box>
+    <>
+      <WindowHeader title='Add to Cheat Sheet' />
 
-      {/* フィールド */}
       <Box
         sx={{
-          p: '14px 18px 16px',
+          px: '18px',
+          pt: '12px',
+          pb: `${WINDOW_ACTION_FOOTER_HEIGHT + 12}px`,
           display: 'flex',
           flexDirection: 'column',
           gap: '14px',
@@ -299,26 +278,13 @@ export function AddToCheatSheetDialog({
         </FieldRow>
       </Box>
 
-      {/* フッター */}
-      <Box
-        sx={{
-          p: '12px 16px 14px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'flex-end',
-          gap: '8px',
-          background: theme.palette.glass.panel,
-          borderTop: `0.5px solid ${theme.palette.divider}`,
-        }}
-      >
-        <FooterButton onClick={onCancel} disabled={isAdding}>
-          Cancel
-        </FooterButton>
-        <FooterButton primary disabled={!canAdd} onClick={handleAdd}>
-          Add
-        </FooterButton>
-      </Box>
-    </Dialog>
+      <WindowActionFooter
+        onCancel={handleCancel}
+        onSave={handleAdd}
+        canSave={canAdd}
+        saveLabel='Add'
+      />
+    </>
   )
 }
 

--- a/src/app/clipboard-history/page.tsx
+++ b/src/app/clipboard-history/page.tsx
@@ -1,0 +1,173 @@
+'use client'
+import { useCallback, useEffect, useRef } from 'react'
+
+import { Box } from '@mui/material'
+import {
+  WebviewWindow,
+  getCurrentWebviewWindow,
+} from '@tauri-apps/api/webviewWindow'
+
+import { Event } from '@/common'
+import { WindowHeader } from '@/components/molecules/WindowHeader'
+import {
+  ClipboardHistorySheet,
+  ClipboardHistoryToolbar,
+} from '@/components/organisms/clipboard-history'
+import { FOCUS_FALLBACK_ID } from '@/constants/focus'
+import { useNotificationContext } from '@/context/NotificationContext'
+import { useClipboardHistory } from '@/hooks/useClipboardHistory'
+import { useClipboardHistoryWindowSize } from '@/hooks/useClipboardHistoryWindowSize'
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
+import { ClipboardHistoryItem } from '@/types/api/ClipboardHistory'
+
+const ADD_WINDOW_LABEL = 'add_to_cheatsheet'
+
+/**
+ * Clipboard History ウィンドウ（独立ウィンドウ）。
+ * 履歴一覧・再コピー・編集モード・ピン留め・Add to Cheat Sheet（別ウィンドウ）を提供する。
+ */
+export default function ClipboardHistoryPage() {
+  const history = useClipboardHistory()
+  const { editMode } = history
+  const { isPinned, togglePin } = useClipboardHistoryWindowSize(editMode)
+  const { showSuccess } = useNotificationContext() ?? {}
+
+  const itemRefs = useRef<Array<HTMLDivElement | null>>([])
+  const pinButtonRef = useRef<HTMLButtonElement>(null)
+
+  // Add to Cheat Sheet ウィンドウを開く（多重起動時は既存へフォーカス）
+  const openAddToCheatSheetWindow = useCallback(
+    async (item: ClipboardHistoryItem) => {
+      const existing = await WebviewWindow.getByLabel(ADD_WINDOW_LABEL)
+      if (existing) {
+        await existing.setFocus()
+        return
+      }
+
+      const win = getCurrentWebviewWindow()
+      await win.once(Event.ADD_TO_CHEATSHEET_READY, async () => {
+        await win.emitTo(ADD_WINDOW_LABEL, Event.ADD_TO_CHEATSHEET_INIT, {
+          text: item.text,
+        })
+      })
+
+      new WebviewWindow(ADD_WINDOW_LABEL, {
+        url: '/add-to-cheatsheet',
+        title: 'Add to Cheat Sheet',
+        width: 460,
+        height: 620,
+        resizable: false,
+        titleBarStyle: 'overlay',
+        hiddenTitle: true,
+        alwaysOnTop: true,
+      })
+    },
+    [],
+  )
+
+  // Add to Cheat Sheet ウィンドウからの登録完了通知で成功トーストを表示する
+  useEffect(() => {
+    let cancelled = false
+    let unlisten: (() => void) | null = null
+    ;(async () => {
+      unlisten = await getCurrentWebviewWindow().listen<{ sheetTitle: string }>(
+        Event.ADD_TO_CHEATSHEET_ADDED,
+        (event) => {
+          showSuccess?.(`Added to "${event.payload.sheetTitle}"`)
+        },
+      )
+      if (cancelled) {
+        unlisten()
+        unlisten = null
+      }
+    })()
+    return () => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [showSuccess])
+
+  // キーボード操作（編集モード中は無効。Esc は useClipboardHistory 側で処理）
+  useKeyboardShortcuts(
+    {
+      onPKey: async () => {
+        await togglePin()
+        pinButtonRef.current?.focus()
+      },
+      onEKey: () => {
+        history.enterEditMode()
+      },
+      onNumberKey: (index) => {
+        if (index < history.items.length) {
+          const targetElement = itemRefs.current[index]
+          if (targetElement) {
+            const enterEvent = new KeyboardEvent('keydown', {
+              key: 'Enter',
+              bubbles: true,
+              cancelable: true,
+            })
+            targetElement.dispatchEvent(enterEvent)
+          }
+        }
+      },
+    },
+    { enabled: !editMode },
+  )
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        paddingX: '4px',
+      }}
+    >
+      {/* ウィンドウ操作後に WKWebView の native first responder を取り戻すための
+          フォールバックフォーカス要素（useClipboardHistoryWindowSize が使用）。 */}
+      <Box
+        id={FOCUS_FALLBACK_ID}
+        tabIndex={-1}
+        aria-hidden
+        sx={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: 0,
+          height: 0,
+          outline: 'none',
+        }}
+      />
+
+      <WindowHeader
+        title='Clipboard History'
+        rightControls={
+          <ClipboardHistoryToolbar
+            editMode={editMode}
+            onToggleEdit={
+              editMode ? history.cancelEditMode : history.enterEditMode
+            }
+            isPinned={isPinned}
+            onTogglePin={togglePin}
+            pinButtonRef={pinButtonRef}
+          />
+        }
+      />
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          overflow: 'hidden',
+        }}
+      >
+        <ClipboardHistorySheet
+          history={history}
+          itemRefs={itemRefs}
+          onAddToSheet={openAddToCheatSheetWindow}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -24,7 +24,11 @@ import {
   ClipboardSettingsAPI,
 } from '@/types/api/ClipboardSettings'
 import { DbSettings, DbSettingsAPI } from '@/types/api/DbSettings'
-import { GlobalShortcutAPI, ShortcutDef } from '@/types/api/GlobalShortcut'
+import {
+  GlobalShortcutAPI,
+  isSameShortcut,
+  ShortcutDef,
+} from '@/types/api/GlobalShortcut'
 import { LogSettings, LogSettingsAPI } from '@/types/api/LogSettings'
 import { VisibleOnAllWorkspacesAPI } from '@/types/api/VisibleOnAllWorkspaces'
 import { WindowAPI } from '@/types/api/Window'
@@ -61,6 +65,10 @@ export default function Page() {
   const theme = useTheme()
 
   const [shortcutDialogOpen, setShortcutDialogOpen] = useState<boolean>(false)
+  const [
+    clipboardHistoryShortcutDialogOpen,
+    setClipboardHistoryShortcutDialogOpen,
+  ] = useState<boolean>(false)
   const [visibleOnAllWorkspaces, setVisibleOnAllWorkspaces] =
     useState<boolean>(true)
   const [confirmActions, setConfirmActionsState] = useState<boolean>(true)
@@ -77,6 +85,8 @@ export default function Page() {
   } = useThemeStore()
 
   const [toggleVisibleShortcut, setToggleVisibleShortcut] =
+    useState<ShortcutDef>()
+  const [clipboardHistoryShortcut, setClipboardHistoryShortcut] =
     useState<ShortcutDef>()
 
   const [logSettings, setLogSettings] = useState<LogSettings>({
@@ -229,6 +239,36 @@ export default function Page() {
       }
 
       try {
+        const response = await invoke<string>(
+          GlobalShortcutAPI.GET_CLIPBOARD_HISTORY_SHORTCUT_SETTINGS,
+        )
+        debug(
+          `[preferences] invoke '${GlobalShortcutAPI.GET_CLIPBOARD_HISTORY_SHORTCUT_SETTINGS}' response=${response}`,
+        )
+        const res_json = JSON.parse(response)
+        if (res_json.status === 'success') {
+          const shortcut: ShortcutDef = res_json.message
+          setClipboardHistoryShortcut(shortcut)
+        } else {
+          error(
+            `[preferences] Failed to get clipboard history shortcut settings: ${res_json.message}`,
+          )
+          await showRcError(
+            'Preferences',
+            'Failed to get global shortcut settings',
+          )
+        }
+      } catch (err) {
+        error(
+          `[preferences] Error getting clipboard history shortcut settings: ${err}`,
+        )
+        await showRcError(
+          'Preferences',
+          'Failed to get global shortcut settings',
+        )
+      }
+
+      try {
         const [settings, logDir] = await Promise.all([
           invoke<LogSettings>(LogSettingsAPI.GET_LOG_SETTINGS),
           invoke<string>(LogSettingsAPI.GET_LOG_DIR),
@@ -332,6 +372,43 @@ export default function Page() {
       }
     } catch (err) {
       error(`[preferences] Error setting shortcut: ${err}`)
+      await showRcError(
+        'Preferences',
+        'Failed to save global shortcut settings',
+      )
+    }
+
+    if (saved) {
+      await showRestartConfirmationDialog()
+    }
+  }
+
+  const handleClipboardHistoryShortcutSave = async (shortcut: ShortcutDef) => {
+    setClipboardHistoryShortcutDialogOpen(false)
+    let saved = false
+    try {
+      const response = await invoke<string>(
+        GlobalShortcutAPI.SET_CLIPBOARD_HISTORY_SHORTCUT_SETTINGS,
+        { shortcut },
+      )
+      debug(
+        `[preferences] invoke '${GlobalShortcutAPI.SET_CLIPBOARD_HISTORY_SHORTCUT_SETTINGS}' response=${response}`,
+      )
+      const res_json = JSON.parse(response)
+      if (res_json.status === 'success') {
+        setClipboardHistoryShortcut(shortcut)
+        saved = true
+      } else {
+        error(
+          `[preferences] Failed to set clipboard history shortcut settings: ${res_json.message}`,
+        )
+        await showRcError(
+          'Preferences',
+          'Failed to save global shortcut settings',
+        )
+      }
+    } catch (err) {
+      error(`[preferences] Error setting clipboard history shortcut: ${err}`)
       await showRcError(
         'Preferences',
         'Failed to save global shortcut settings',
@@ -818,6 +895,88 @@ export default function Page() {
               </Tooltip>
             </Box>
           </Box>
+          <Box sx={{ pl: '14px', py: '8px' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <Typography
+                sx={{
+                  fontSize: scaledPx(theme.custom.fontSize.label),
+                  fontWeight: 500,
+                  color: 'text.primary',
+                }}
+              >
+                Clipboard History
+              </Typography>
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: scaledPx(theme.custom.fontSize.label),
+                }}
+              >
+                :
+              </Typography>
+              {clipboardHistoryShortcut && (
+                <Box
+                  sx={{
+                    backgroundColor: isDark
+                      ? 'rgba(255,255,255,0.06)'
+                      : 'rgba(255,255,255,0.9)',
+                    backdropFilter: 'blur(12px)',
+                    border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
+                    borderRadius: '6px',
+                    padding: '4px 11px',
+                    fontFamily: 'monospace',
+                    fontSize: scaledPx(theme.custom.fontSize.body),
+                    color: 'text.primary',
+                    boxShadow: !isDark
+                      ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
+                      : 'none',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  {(
+                    [
+                      clipboardHistoryShortcut.ctrl && '^',
+                      clipboardHistoryShortcut.option && '⌥',
+                      clipboardHistoryShortcut.command && '⌘',
+                      clipboardHistoryShortcut.hotkey,
+                    ] as (string | false)[]
+                  )
+                    .filter(Boolean)
+                    .map((c, i) => (
+                      <span key={i}>{c}</span>
+                    ))}
+                </Box>
+              )}
+              <Tooltip title='Edit global shortcut…'>
+                <span>
+                  <IconButton
+                    size='small'
+                    disabled={!clipboardHistoryShortcut}
+                    onClick={() => setClipboardHistoryShortcutDialogOpen(true)}
+                    sx={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: '7px',
+                      border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
+                      backgroundColor: alpha(
+                        theme.palette.accent.main,
+                        isDark ? 0.1 : 0.07,
+                      ),
+                      color: theme.palette.text.disabled,
+                      '&:hover': {
+                        borderColor: theme.palette.primary.main,
+                        color: theme.palette.primary.main,
+                      },
+                    }}
+                  >
+                    <SettingsOutlinedIcon sx={{ fontSize: '14px' }} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
+          </Box>
         </Box>
 
         <Divider sx={{ mx: '-20px', borderBottomWidth: '0.5px' }} />
@@ -1131,9 +1290,21 @@ export default function Page() {
       {toggleVisibleShortcut && (
         <ShortcutSettingsDialog
           open={shortcutDialogOpen}
+          label='Toggle Visible'
           shortcut={toggleVisibleShortcut}
+          conflictShortcut={clipboardHistoryShortcut}
           onSave={handleShortcutSave}
           onCancel={() => setShortcutDialogOpen(false)}
+        />
+      )}
+      {clipboardHistoryShortcut && (
+        <ShortcutSettingsDialog
+          open={clipboardHistoryShortcutDialogOpen}
+          label='Clipboard History'
+          shortcut={clipboardHistoryShortcut}
+          conflictShortcut={toggleVisibleShortcut}
+          onSave={handleClipboardHistoryShortcutSave}
+          onCancel={() => setClipboardHistoryShortcutDialogOpen(false)}
         />
       )}
       {rcDialog.isYesNo ? (
@@ -1588,14 +1759,20 @@ function HotkeyInput({ value, onChange, invalid }: HotkeyInputProps) {
 
 type ShortcutSettingsDialogProps = {
   open: boolean
+  /** ダイアログタイトルに表示する対象名（例: "Toggle Visible"） */
+  label: string
   shortcut: ShortcutDef
+  /** 重複を禁止するもう一方のショートカット（同一の組み合わせは保存不可） */
+  conflictShortcut?: ShortcutDef
   onSave: (shortcut: ShortcutDef) => void
   onCancel: () => void
 }
 
 function ShortcutSettingsDialog({
   open: dialogOpen,
+  label,
   shortcut,
+  conflictShortcut,
   onSave,
   onCancel,
 }: ShortcutSettingsDialogProps) {
@@ -1627,7 +1804,12 @@ function ShortcutSettingsDialog({
     option !== shortcut.option ||
     command !== shortcut.command ||
     hotkey !== shortcut.hotkey
-  const canSave = hasModifier && hasHotkey && dirty
+  const isConflict =
+    hasModifier &&
+    hasHotkey &&
+    conflictShortcut !== undefined &&
+    isSameShortcut({ ctrl, option, command, hotkey }, conflictShortcut)
+  const canSave = hasModifier && hasHotkey && dirty && !isConflict
 
   const handleSave = () => {
     if (!canSave) {
@@ -1659,7 +1841,7 @@ function ShortcutSettingsDialog({
           borderBottom: `0.5px solid ${theme.palette.divider}`,
         }}
       >
-        Global Shortcut — Toggle Visible
+        Global Shortcut — {label}
       </DialogTitle>
       <DialogContent
         sx={{
@@ -1863,6 +2045,17 @@ function ShortcutSettingsDialog({
               }}
             >
               Please enter a hotkey character.
+            </Typography>
+          )}
+          {isConflict && (
+            <Typography
+              sx={{
+                fontSize: scaledPx(theme.custom.fontSize.hint),
+                color: theme.palette.error.main,
+                mt: '2px',
+              }}
+            >
+              This shortcut is already used by another action.
             </Typography>
           )}
         </Box>

--- a/src/common.ts
+++ b/src/common.ts
@@ -9,4 +9,7 @@ export class Event {
   static readonly EDIT_GROUP_READY = 'edit-group-ready'
   static readonly EDIT_GROUP_INIT = 'edit-group-init'
   static readonly EDIT_GROUP_SAVE = 'edit-group-save'
+  static readonly ADD_TO_CHEATSHEET_READY = 'add-to-cheatsheet-ready'
+  static readonly ADD_TO_CHEATSHEET_INIT = 'add-to-cheatsheet-init'
+  static readonly ADD_TO_CHEATSHEET_ADDED = 'add-to-cheatsheet-added'
 }

--- a/src/components/organisms/CheatSheet.tsx
+++ b/src/components/organisms/CheatSheet.tsx
@@ -13,7 +13,6 @@ import {
   EditBlockList,
   NormalCommandList,
 } from '@/components/organisms/cheat-sheet'
-import { ClipboardHistorySheet } from '@/components/organisms/clipboard-history'
 import { RcDialog } from '@/components/organisms/RcDialog'
 import { FOCUS_FALLBACK_ID } from '@/constants/focus'
 import { useNotificationContext } from '@/context/NotificationContext'
@@ -23,12 +22,10 @@ import { useEditBlockActions } from '@/hooks/cheat-sheet/useEditBlockActions'
 import { useEditBlockDnd } from '@/hooks/cheat-sheet/useEditBlockDnd'
 import { useEditWindows } from '@/hooks/cheat-sheet/useEditWindows'
 import { useScrollToCommand } from '@/hooks/cheat-sheet/useScrollToCommand'
-import { useClipboardHistory } from '@/hooks/useClipboardHistory'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
 import { useWindowSize } from '@/hooks/useWindowSize'
 import { isCommandGroupData } from '@/types/api/CheatSheet'
-import { CLIPBOARD_HISTORY_SHEET_TITLE } from '@/types/api/ClipboardHistory'
 import { EditBlock, getGroupOptions, isEditGroup } from '@/types/edit/EditBlock'
 
 // ─── メインコンポーネント ─────────────────────────────────────
@@ -40,10 +37,6 @@ export const CheatSheet = () => {
     editModeRef.current = editMode
   }, [editMode])
 
-  // クリップボード履歴シートの編集モードを RELOAD_CHEAT_SHEET リスナーから
-  // 参照するための ref（値の更新は useClipboardHistory 呼び出し後の effect で行う）
-  const historyEditModeRef = useRef(false)
-
   // ─── チートシートデータ ───────────────────────────────────
   const {
     cheatSheetTitles,
@@ -54,31 +47,11 @@ export const CheatSheet = () => {
     errorMessage,
     reloading,
     loadCheatSheetData,
-  } = useCheatSheetData({ editModeRef, historyEditModeRef })
-
-  // ─── クリップボード履歴（擬似シート） ─────────────────────
-  const isHistorySheet = selectCheatSheet === CLIPBOARD_HISTORY_SHEET_TITLE
-  const history = useClipboardHistory({ active: isHistorySheet })
-  useEffect(() => {
-    historyEditModeRef.current = history.editMode
-  }, [history.editMode])
-
-  // 履歴シートから離れたら編集モードを解除する（インポート等による
-  // シート再読み込みで選択が切り替わるケース）
-  useEffect(() => {
-    if (!isHistorySheet && history.editMode) {
-      history.cancelEditMode()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isHistorySheet, history.editMode])
+  } = useCheatSheetData({ editModeRef })
 
   const theme = useTheme()
   // 編集モード中はピン留めでもウィンドウサイズを変更できるようにする
-  // 履歴シートは DB 上のチートシートではないためピン留め（サイズ保存）非対応
-  const { isPinned, togglePin } = useWindowSize(
-    isHistorySheet ? '' : selectCheatSheet,
-    editMode,
-  )
+  const { isPinned, togglePin } = useWindowSize(selectCheatSheet, editMode)
   const { showError } = useNotificationContext() ?? {}
   const { getConfirmActions } = usePreferencesStore()
 
@@ -164,7 +137,7 @@ export const CheatSheet = () => {
 
   // ─── 通常モード計算 ───────────────────────────────────────
   const isKeyboardShortcutEnabled =
-    !editMode && !history.editMode && cheatSheetData?.type !== 'shortcut'
+    !editMode && cheatSheetData?.type !== 'shortcut'
 
   const flatCommandCount = useMemo(() => {
     if (!cheatSheetData || cheatSheetData.type === 'shortcut') return 0
@@ -196,27 +169,21 @@ export const CheatSheet = () => {
     })
   }, [editBlocks])
 
-  const numberKeyTargetCount = isHistorySheet
-    ? history.items.length
-    : flatCommandCount
-
   useKeyboardShortcuts(
     {
       onPKey: async () => {
-        if (selectCheatSheet && !isHistorySheet) {
+        if (selectCheatSheet) {
           await togglePin()
           pinButtonRef.current?.focus()
         }
       },
       onEKey: () => {
-        if (isHistorySheet) {
-          history.enterEditMode()
-        } else if (selectCheatSheet) {
+        if (selectCheatSheet) {
           void enterEditMode()
         }
       },
       onNumberKey: (index) => {
-        if (isKeyboardShortcutEnabled && index < numberKeyTargetCount) {
+        if (isKeyboardShortcutEnabled && index < flatCommandCount) {
           const targetElement = commandFieldRefs.current[index]
           if (targetElement) {
             const enterEvent = new KeyboardEvent('keydown', {
@@ -233,7 +200,7 @@ export const CheatSheet = () => {
         debug('[CheatSheet] 0 key: opened sheet switch dropdown')
       },
     },
-    { enabled: !editMode && !history.editMode && !isEditWindowOpen },
+    { enabled: !editMode && !isEditWindowOpen },
   )
 
   // ─── レンダリング ─────────────────────────────────────────
@@ -268,25 +235,13 @@ export const CheatSheet = () => {
         title={selectCheatSheet || 'RightCheat'}
         rightControls={
           <CheatSheetToolbar
-            titles={[
-              ...(cheatSheetTitles?.title ?? []),
-              CLIPBOARD_HISTORY_SHEET_TITLE,
-            ]}
+            titles={cheatSheetTitles?.title ?? []}
             selected={selectCheatSheet}
             onSelect={(value) => setCheatSheet(value)}
-            editMode={isHistorySheet ? history.editMode : editMode}
-            onToggleEdit={
-              isHistorySheet
-                ? history.editMode
-                  ? history.cancelEditMode
-                  : history.enterEditMode
-                : editMode
-                  ? cancelEditMode
-                  : enterEditMode
-            }
+            editMode={editMode}
+            onToggleEdit={editMode ? cancelEditMode : enterEditMode}
             isPinned={isPinned}
             onTogglePin={togglePin}
-            pinDisabled={isHistorySheet}
             sheetSwitchRef={sheetSwitchRef}
             pinButtonRef={pinButtonRef}
           />
@@ -302,77 +257,67 @@ export const CheatSheet = () => {
           overflow: 'hidden',
         }}
       >
-        {isHistorySheet ? (
-          // ─── クリップボード履歴シート ─────────────────────────
-          <ClipboardHistorySheet
-            history={history}
-            itemRefs={commandFieldRefs}
-          />
-        ) : (
-          <>
-            <Box
-              ref={scrollContainerRef}
-              sx={{ flex: 1, overflow: 'auto', px: 1.5, py: 1 }}
+        <Box
+          ref={scrollContainerRef}
+          sx={{ flex: 1, overflow: 'auto', px: 1.5, py: 1 }}
+        >
+          {errorMessage ? (
+            <Alert
+              severity='error'
+              style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
             >
-              {errorMessage ? (
-                <Alert
-                  severity='error'
-                  style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-                >
-                  {errorMessage}
-                </Alert>
-              ) : reloading === false &&
-                cheatSheetTitles !== undefined &&
-                cheatSheetTitles.title.length === 0 ? (
-                <Alert severity='info'>
-                  No cheat sheets registered.
-                  <br />
-                  Use [File] - [Import from JSON...] to import a cheat sheet.
-                </Alert>
-              ) : editMode ? (
-                // ─── 編集モード ───────────────────────────────────
-                <EditBlockList
-                  editBlocks={editBlocks}
-                  isShortcuts={isShortcuts}
-                  cheatSheetLayout={cheatSheetData?.layout}
-                  dragInfo={dragInfo}
-                  dropMark={dropMark}
-                  editFlatStartIndices={editFlatStartIndices}
-                  onPointerDown={handlePointerDown}
-                  onPointerMove={handlePointerMove}
-                  onPointerUp={handlePointerUp}
-                  onPointerCancel={handlePointerCancel}
-                  blockRefsMap={blockRefsMap}
-                  groupBodyRefsMap={groupBodyRefsMap}
-                  itemRefsMap={itemRefsMap}
-                  onEditCommand={openCmdEditWindow}
-                  onDeleteCommand={deleteCommand}
-                  onRenameGroup={(group) => openGroupEditWindow(group, false)}
-                  onDeleteGroup={deleteGroup}
-                />
-              ) : (
-                // ─── 通常モード ───────────────────────────────────
-                <NormalCommandList
-                  cheatSheetData={cheatSheetData}
-                  flatStartIndices={flatStartIndices}
-                  commandFieldRefs={commandFieldRefs}
-                />
-              )}
-            </Box>
+              {errorMessage}
+            </Alert>
+          ) : reloading === false &&
+            cheatSheetTitles !== undefined &&
+            cheatSheetTitles.title.length === 0 ? (
+            <Alert severity='info'>
+              No cheat sheets registered.
+              <br />
+              Use [File] - [Import from JSON...] to import a cheat sheet.
+            </Alert>
+          ) : editMode ? (
+            // ─── 編集モード ───────────────────────────────────
+            <EditBlockList
+              editBlocks={editBlocks}
+              isShortcuts={isShortcuts}
+              cheatSheetLayout={cheatSheetData?.layout}
+              dragInfo={dragInfo}
+              dropMark={dropMark}
+              editFlatStartIndices={editFlatStartIndices}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerCancel}
+              blockRefsMap={blockRefsMap}
+              groupBodyRefsMap={groupBodyRefsMap}
+              itemRefsMap={itemRefsMap}
+              onEditCommand={openCmdEditWindow}
+              onDeleteCommand={deleteCommand}
+              onRenameGroup={(group) => openGroupEditWindow(group, false)}
+              onDeleteGroup={deleteGroup}
+            />
+          ) : (
+            // ─── 通常モード ───────────────────────────────────
+            <NormalCommandList
+              cheatSheetData={cheatSheetData}
+              flatStartIndices={flatStartIndices}
+              commandFieldRefs={commandFieldRefs}
+            />
+          )}
+        </Box>
 
-            {/* 編集モードフッター */}
-            {editMode && (
-              <EditModeFooter
-                isShortcuts={isShortcuts ?? false}
-                editDirty={editDirty}
-                isSaving={isSaving}
-                onAddCommand={() => openCmdEditWindow(null, null, true)}
-                onAddGroup={() => openGroupEditWindow(null, true)}
-                onCancel={cancelEditMode}
-                onSave={saveEditMode}
-              />
-            )}
-          </>
+        {/* 編集モードフッター */}
+        {editMode && (
+          <EditModeFooter
+            isShortcuts={isShortcuts ?? false}
+            editDirty={editDirty}
+            isSaving={isSaving}
+            onAddCommand={() => openCmdEditWindow(null, null, true)}
+            onAddGroup={() => openGroupEditWindow(null, true)}
+            onCancel={cancelEditMode}
+            onSave={saveEditMode}
+          />
         )}
       </Box>
 

--- a/src/components/organisms/clipboard-history/ClipboardHistorySheet.tsx
+++ b/src/components/organisms/clipboard-history/ClipboardHistorySheet.tsx
@@ -8,25 +8,29 @@ import { useTheme } from '@mui/material/styles'
 import { CopyIcon } from '@/components/atoms/icons'
 import { ClipboardHistoryFooter } from '@/components/molecules/ClipboardHistoryFooter'
 import { HistoryItemRow } from '@/components/molecules/HistoryItemRow'
-import { AddToCheatSheetDialog } from '@/components/organisms/clipboard-history/AddToCheatSheetDialog'
 import { RcDialog } from '@/components/organisms/RcDialog'
-import { useNotificationContext } from '@/context/NotificationContext'
 import { ClipboardHistoryState } from '@/hooks/useClipboardHistory'
+import { ClipboardHistoryItem } from '@/types/api/ClipboardHistory'
 
 type Props = {
   history: ClipboardHistoryState
   /** 数字キー（1〜9）での再コピー用に各行の要素を登録する */
   itemRefs: RefObject<Array<HTMLDivElement | null>>
+  /** 編集モードの行アクション「Add to Cheat Sheet」で別ウィンドウを開く */
+  onAddToSheet: (item: ClipboardHistoryItem) => void
 }
 
 /**
- * クリップボード履歴シートの本体。
+ * クリップボード履歴ウィンドウの本体。
  * 履歴一覧（空の場合はプレースホルダー）・固定フッター・
- * 全クリア確認ダイアログ・Add to Cheat Sheet ダイアログを描画する。
+ * 全クリア確認ダイアログを描画する。
  */
-export function ClipboardHistorySheet({ history, itemRefs }: Props) {
+export function ClipboardHistorySheet({
+  history,
+  itemRefs,
+  onAddToSheet,
+}: Props) {
   const theme = useTheme()
-  const { showSuccess } = useNotificationContext() ?? {}
 
   const {
     items,
@@ -39,8 +43,6 @@ export function ClipboardHistorySheet({ history, itemRefs }: Props) {
     clearAll,
     confirmClearOpen,
     setConfirmClearOpen,
-    addDialogItem,
-    setAddDialogItem,
   } = history
 
   return (
@@ -64,7 +66,7 @@ export function ClipboardHistorySheet({ history, itemRefs }: Props) {
                 text={item.text}
                 numberHint={(index + 1).toString()}
                 editMode={editMode}
-                onAddToSheet={() => setAddDialogItem(item)}
+                onAddToSheet={() => onAddToSheet(item)}
                 onDelete={() => deleteItem(item.id)}
               />
             ))}
@@ -138,17 +140,6 @@ export function ClipboardHistorySheet({ history, itemRefs }: Props) {
         yesLabel='Clear All'
         onNo={() => setConfirmClearOpen(false)}
         noLabel='Cancel'
-      />
-
-      {/* チートシートへの追加ダイアログ */}
-      <AddToCheatSheetDialog
-        open={addDialogItem !== null}
-        text={addDialogItem?.text ?? ''}
-        onCancel={() => setAddDialogItem(null)}
-        onAdded={(sheetTitle) => {
-          setAddDialogItem(null)
-          showSuccess?.(`Added to "${sheetTitle}"`)
-        }}
       />
     </>
   )

--- a/src/components/organisms/clipboard-history/ClipboardHistoryToolbar.tsx
+++ b/src/components/organisms/clipboard-history/ClipboardHistoryToolbar.tsx
@@ -7,65 +7,37 @@ import { Box, IconButton } from '@mui/material'
 import { alpha, useTheme } from '@mui/material/styles'
 
 import { PencilIcon } from '@/components/atoms/icons'
-import {
-  SheetSwitchButton,
-  SheetSwitchButtonHandle,
-} from '@/components/molecules/SheetSwitchButton'
 
 type Props = {
-  titles: string[]
-  selected: string
-  onSelect: (value: string) => void
   editMode: boolean
   onToggleEdit: () => void
   isPinned: boolean
   onTogglePin: () => void
-  sheetSwitchRef: Ref<SheetSwitchButtonHandle>
-  pinButtonRef: Ref<HTMLButtonElement>
+  pinButtonRef?: Ref<HTMLButtonElement>
 }
 
 /**
- * ウィンドウヘッダー右側の操作群。
- * シート切り替え・編集モードトグル・ウィンドウサイズのピン留めを提供する。
+ * Clipboard History ウィンドウのヘッダー右側の操作群。
+ * 編集モードトグル（鉛筆）とウィンドウサイズのピン留めを提供する。
+ * チートシートと異なりシート切り替えは持たない。
  */
-export function CheatSheetToolbar({
-  titles,
-  selected,
-  onSelect,
+export function ClipboardHistoryToolbar({
   editMode,
   onToggleEdit,
   isPinned,
   onTogglePin,
-  sheetSwitchRef,
   pinButtonRef,
 }: Props) {
   const theme = useTheme()
-  const hasSelection = !!selected
-  const canPin = hasSelection && !editMode
+  // 編集モード中はサイズ変更を許容するためピン操作を無効化する
+  const canPin = !editMode
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-      {/* シート切り替え（編集モード中は無効化） */}
-      <Box
-        sx={{
-          opacity: editMode ? 0.35 : 1,
-          pointerEvents: editMode ? 'none' : 'auto',
-          transition: 'opacity 0.14s',
-        }}
-      >
-        <SheetSwitchButton
-          ref={sheetSwitchRef}
-          titles={titles}
-          selected={selected}
-          onSelect={onSelect}
-        />
-      </Box>
-
       {/* 編集モードトグル（鉛筆アイコン） */}
       <IconButton
         onClick={onToggleEdit}
         size='small'
-        disabled={!hasSelection}
         title={editMode ? 'Cancel edit mode (Esc)' : 'Edit mode (e)'}
         sx={{
           background: editMode
@@ -79,7 +51,6 @@ export function CheatSheetToolbar({
           color: editMode
             ? theme.palette.accent.main
             : theme.palette.text.disabled,
-          opacity: !hasSelection ? 0.3 : 1,
           transition: 'all 0.15s',
           ml: '2px',
           '&.Mui-focusVisible': {

--- a/src/components/organisms/clipboard-history/index.ts
+++ b/src/components/organisms/clipboard-history/index.ts
@@ -1,2 +1,2 @@
-export { AddToCheatSheetDialog } from '@/components/organisms/clipboard-history/AddToCheatSheetDialog'
 export { ClipboardHistorySheet } from '@/components/organisms/clipboard-history/ClipboardHistorySheet'
+export { ClipboardHistoryToolbar } from '@/components/organisms/clipboard-history/ClipboardHistoryToolbar'

--- a/src/hooks/cheat-sheet/useCheatSheetData.ts
+++ b/src/hooks/cheat-sheet/useCheatSheetData.ts
@@ -11,19 +11,16 @@ import {
   CheatSheetData,
   CheatSheetTitleData,
 } from '@/types/api/CheatSheet'
-import { CLIPBOARD_HISTORY_SHEET_TITLE } from '@/types/api/ClipboardHistory'
 
 type Params = {
   editModeRef: RefObject<boolean>
-  /** クリップボード履歴シートの編集モード中かどうか */
-  historyEditModeRef: RefObject<boolean>
 }
 
 /**
  * チートシートのタイトル一覧・選択中シートのデータのロードを管理するフック。
  * 起動時のリロード、`RELOAD_CHEAT_SHEET` イベントの購読、選択変更時のデータ取得を担う。
  */
-export function useCheatSheetData({ editModeRef, historyEditModeRef }: Params) {
+export function useCheatSheetData({ editModeRef }: Params) {
   const [cheatSheetTitles, setCheatSheetTitles] = useState<
     CheatSheetTitleData | undefined
   >()
@@ -43,11 +40,9 @@ export function useCheatSheetData({ editModeRef, historyEditModeRef }: Params) {
     let unlisten: (() => void) | undefined
     ;(async () => {
       unlisten = await listen<{}>(Event.RELOAD_CHEAT_SHEET, () => {
-        // 編集モード中はリロードしない。クリップボード履歴シートの編集モード中も
-        // 同様（Add to Cheat Sheet の add_command が RELOAD_CHEAT_SHEET を emit
-        // するため、リロードすると選択が先頭シートへ切り替わり編集セッションが
-        // 破棄されてしまう）
-        if (editModeRef.current || historyEditModeRef.current) return
+        // 編集モード中はリロードしない（リロードすると選択が先頭シートへ
+        // 切り替わり編集セッションが破棄されてしまう）
+        if (editModeRef.current) return
         ;(async () => {
           setReloading(true)
           setCheatSheet('')
@@ -76,12 +71,7 @@ export function useCheatSheetData({ editModeRef, historyEditModeRef }: Params) {
 
   useEffect(() => {
     ;(async () => {
-      // クリップボード履歴は DB 上のチートシートではない擬似シートのため
-      // チートシートデータの取得は行わない
-      if (
-        selectCheatSheet !== '' &&
-        selectCheatSheet !== CLIPBOARD_HISTORY_SHEET_TITLE
-      ) {
+      if (selectCheatSheet !== '') {
         const data = await loadCheatSheetData(selectCheatSheet)
         setCheatSheetData(data)
       } else {

--- a/src/hooks/useClipboardHistory.ts
+++ b/src/hooks/useClipboardHistory.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { debug, error as logError } from '@tauri-apps/plugin-log'
 
-import { Event } from '@/common'
 import { useNotificationContext } from '@/context/NotificationContext'
 import {
   CLIPBOARD_HISTORY_LIST_LIMIT,
@@ -12,25 +11,21 @@ import {
   ClipboardHistoryItem,
 } from '@/types/api/ClipboardHistory'
 
-type Params = {
-  /** クリップボード履歴シートが選択されているかどうか */
-  active: boolean
-}
-
 /**
- * クリップボード履歴シートの状態を管理するフック。
- * - 履歴一覧の取得（シート選択時・ウィンドウフォーカス時に再取得）
+ * クリップボード履歴ウィンドウの状態を管理するフック。
+ * - 履歴一覧の取得（マウント時・ウィンドウフォーカス時に再取得）
  * - 編集モード（スナップショット方式: Delete はローカル削除、Save で確定、
  *   Cancel / Esc キーでロールバック）
  * - 全クリア（確認ダイアログ経由）
+ *
+ * Clipboard History は独立ウィンドウのため、常時アクティブとして扱い、
+ * 再取得は自ウィンドウの `onFocusChanged` で行う。
  */
-export function useClipboardHistory({ active }: Params) {
+export function useClipboardHistory() {
   const [items, setItems] = useState<ClipboardHistoryItem[]>([])
   const [editMode, setEditMode] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [confirmClearOpen, setConfirmClearOpen] = useState(false)
-  const [addDialogItem, setAddDialogItem] =
-    useState<ClipboardHistoryItem | null>(null)
   const snapshotRef = useRef<ClipboardHistoryItem[] | null>(null)
   const pendingDeleteIdsRef = useRef<number[]>([])
   const [dirty, setDirty] = useState(false)
@@ -55,23 +50,24 @@ export function useClipboardHistory({ active }: Params) {
     }
   }, [showError])
 
-  // シート選択時に一覧を取得する
+  // マウント時に一覧を取得する
   useEffect(() => {
-    if (!active) return
     void reload()
-  }, [active, reload])
+  }, [reload])
 
   // ウィンドウフォーカス時に一覧を再取得する（編集モード中はスナップショットを
   // 壊さないようスキップ）
   useEffect(() => {
-    if (!active) return
     let cancelled = false
     let unlisten: (() => void) | null = null
     ;(async () => {
-      unlisten = await listen<{}>(Event.WINDOW_FOCUSED, () => {
-        if (editModeRef.current) return
-        void reload()
-      })
+      unlisten = await getCurrentWebviewWindow().onFocusChanged(
+        ({ payload: focused }) => {
+          if (!focused) return
+          if (editModeRef.current) return
+          void reload()
+        },
+      )
       if (cancelled) {
         unlisten()
         unlisten = null
@@ -81,7 +77,7 @@ export function useClipboardHistory({ active }: Params) {
       cancelled = true
       unlisten?.()
     }
-  }, [active, reload])
+  }, [reload])
 
   // ─── 編集モード ─────────────────────────────────────────────
   const enterEditMode = useCallback(() => {
@@ -135,17 +131,17 @@ export function useClipboardHistory({ active }: Params) {
     setDirty(true)
   }, [])
 
-  // Esc キーで編集モードをキャンセル（ダイアログ表示中は除く）
+  // Esc キーで編集モードをキャンセル（確認ダイアログ表示中は除く）
   useEffect(() => {
     if (!editMode) return
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
-      if (confirmClearOpen || addDialogItem !== null) return
+      if (confirmClearOpen) return
       cancelEditMode()
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [editMode, confirmClearOpen, addDialogItem, cancelEditMode])
+  }, [editMode, confirmClearOpen, cancelEditMode])
 
   // ─── 全クリア ───────────────────────────────────────────────
   const clearAll = useCallback(async () => {
@@ -172,8 +168,6 @@ export function useClipboardHistory({ active }: Params) {
     clearAll,
     confirmClearOpen,
     setConfirmClearOpen,
-    addDialogItem,
-    setAddDialogItem,
     reload,
   }
 }

--- a/src/hooks/useClipboardHistoryWindowSize.ts
+++ b/src/hooks/useClipboardHistoryWindowSize.ts
@@ -13,38 +13,32 @@ import { useNotificationContext } from '@/context/NotificationContext'
 import { WindowSizeAPI, WindowSizeSettings } from '@/types/api/WindowSize'
 import { restoreFocusAfterWindowOp } from '@/utils/windowFocus'
 
-export const useWindowSize = (selectedTitle: string, editMode = false) => {
+/**
+ * Clipboard History ウィンドウのサイズのピン留め（保存・復元）を管理するフック。
+ *
+ * チートシートウィンドウの {@link useWindowSize} と同等だが、保存先は
+ * チートシートの DB ではなく設定ファイル（tauri-plugin-store）で、単一ウィンドウの
+ * ため対象タイトルを持たない。
+ *
+ * - マウント時: 保存済みサイズがあれば適用してリサイズ不可にする
+ * - ピン留め時: 現在のウィンドウサイズ（論理ピクセル）を保存し `setResizable(false)`
+ * - ピン留め解除時: 保存値を削除し `setResizable(true)`
+ * - 編集モード中はピン留めでもサイズ変更を許容し、終了時にピン留めサイズへ戻す
+ */
+export const useClipboardHistoryWindowSize = (editMode = false) => {
   const [isPinned, setIsPinned] = useState(false)
   const { showError } = useNotificationContext() ?? {}
   const savedSizeRef = useRef<WindowSizeSettings | null>(null)
   const isResizableRef = useRef<boolean | null>(null)
 
+  // マウント時に保存済みサイズを読み込み、あれば適用する
   useEffect(() => {
-    if (!selectedTitle) {
-      setIsPinned(false)
-      savedSizeRef.current = null
-      if (isResizableRef.current !== true) {
-        getCurrentWindow()
-          .setResizable(true)
-          .then(() => {
-            isResizableRef.current = true
-            return restoreFocusAfterWindowOp()
-          })
-          .catch((e) => logError(`Failed to call setResizable: ${e}`))
-      }
-      return
-    }
-
     let cancelled = false
 
     const loadAndApply = async () => {
-      debug(
-        `[useWindowSize] loadAndApply started: title="${selectedTitle}", activeElement=${document.activeElement?.tagName}`,
-      )
       try {
         const savedSize = await invoke<WindowSizeSettings | null>(
-          WindowSizeAPI.GET_CHEAT_SHEET_WINDOW_SIZE,
-          { title: selectedTitle },
+          WindowSizeAPI.GET_CLIPBOARD_HISTORY_WINDOW_SIZE,
         )
         if (cancelled) return
 
@@ -52,46 +46,23 @@ export const useWindowSize = (selectedTitle: string, editMode = false) => {
         setIsPinned(savedSize !== null)
 
         const win = getCurrentWindow()
-        let windowOpPerformed = false
         if (savedSize) {
           debug(
-            `[useWindowSize] setSize: ${savedSize.width}x${savedSize.height} for "${selectedTitle}"`,
+            `[useClipboardHistoryWindowSize] setSize: ${savedSize.width}x${savedSize.height}`,
           )
           await win.setSize(new LogicalSize(savedSize.width, savedSize.height))
-          windowOpPerformed = true
-          if (isResizableRef.current !== false) {
-            debug(
-              `[useWindowSize] Setting window non-resizable: "${selectedTitle}"`,
-            )
-            await win.setResizable(false)
-            isResizableRef.current = false
-          }
+          await win.setResizable(false)
+          isResizableRef.current = false
         } else {
-          if (isResizableRef.current !== true) {
-            debug(
-              `[useWindowSize] Setting window resizable: "${selectedTitle}"`,
-            )
-            await win.setResizable(true)
-            isResizableRef.current = true
-            windowOpPerformed = true
-          }
+          await win.setResizable(true)
+          isResizableRef.current = true
         }
-
-        if (windowOpPerformed) {
-          debug(
-            `[useWindowSize] Restoring focus, starting: activeElement=${document.activeElement?.tagName}`,
-          )
-          await restoreFocusAfterWindowOp()
-          debug(
-            `[useWindowSize] Focus restored: activeElement=${document.activeElement?.tagName}`,
-          )
-        } else {
-          await restoreFocusAfterWindowOp()
-        }
-        debug(`[useWindowSize] loadAndApply complete: title="${selectedTitle}"`)
+        await restoreFocusAfterWindowOp()
       } catch (e) {
         if (!cancelled) {
-          logError(`Failed to load window size: ${e}`)
+          logError(
+            `[useClipboardHistoryWindowSize] Failed to load window size: ${e}`,
+          )
           showError?.('Failed to load window size')
         }
       }
@@ -101,27 +72,19 @@ export const useWindowSize = (selectedTitle: string, editMode = false) => {
 
     return () => {
       cancelled = true
-      savedSizeRef.current = null
-      setIsPinned(false)
     }
-  }, [selectedTitle, showError])
+  }, [showError])
 
   // 編集モードの切り替えに応じてリサイズ可否を制御する。
-  // 編集モード中はピン留め（非リサイズ）でもウィンドウサイズを変更できるようにし、
-  // 編集モード終了時はピン留め状態に応じてリサイズ可否を元に戻す。
+  // 編集モード中は常にリサイズ可、終了時はピン留め状態へ戻す。
   const prevEditModeRef = useRef(editMode)
   useEffect(() => {
     if (prevEditModeRef.current === editMode) return
     prevEditModeRef.current = editMode
-    if (!selectedTitle) return
 
     const win = getCurrentWindow()
-    // 編集モード中は常にリサイズ可。終了時はピン留めなら非リサイズに戻す。
     const savedSize = savedSizeRef.current
     const shouldBeResizable = editMode ? true : savedSize === null
-
-    // 編集モード終了時にピン留めされている場合は、編集中に変更された
-    // ウィンドウサイズをピン留め時のサイズに戻す。
     const shouldRestoreSize = !editMode && savedSize !== null
 
     if (isResizableRef.current === shouldBeResizable && !shouldRestoreSize)
@@ -130,42 +93,37 @@ export const useWindowSize = (selectedTitle: string, editMode = false) => {
       try {
         if (shouldRestoreSize && savedSize) {
           debug(
-            `[useWindowSize] editMode end: restore pinned size ${savedSize.width}x${savedSize.height}`,
+            `[useClipboardHistoryWindowSize] editMode end: restore pinned size ${savedSize.width}x${savedSize.height}`,
           )
           await win.setSize(new LogicalSize(savedSize.width, savedSize.height))
         }
         if (isResizableRef.current !== shouldBeResizable) {
           debug(
-            `[useWindowSize] editMode=${editMode}: setResizable(${shouldBeResizable})`,
+            `[useClipboardHistoryWindowSize] editMode=${editMode}: setResizable(${shouldBeResizable})`,
           )
           await win.setResizable(shouldBeResizable)
           isResizableRef.current = shouldBeResizable
         }
         await restoreFocusAfterWindowOp()
       } catch (e) {
-        logError(`[useWindowSize] Failed to toggle resizable: ${e}`)
+        logError(
+          `[useClipboardHistoryWindowSize] Failed to toggle resizable: ${e}`,
+        )
       }
     })()
-  }, [editMode, selectedTitle])
+  }, [editMode])
 
   const togglePin = useCallback(async () => {
-    if (!selectedTitle) return
-
-    debug(
-      `[useWindowSize] togglePin started: activeElement=${document.activeElement?.tagName}`,
-    )
     const win = getCurrentWindow()
 
     if (savedSizeRef.current) {
-      debug(`[useWindowSize] Unpinning: title="${selectedTitle}"`)
-
+      debug('[useClipboardHistoryWindowSize] Unpinning')
       try {
-        await invoke(WindowSizeAPI.SAVE_CHEAT_SHEET_WINDOW_SIZE, {
-          title: selectedTitle,
+        await invoke(WindowSizeAPI.SAVE_CLIPBOARD_HISTORY_WINDOW_SIZE, {
           windowSize: null,
         })
       } catch (e) {
-        logError(`Failed to delete window size: ${e}`)
+        logError(`[useClipboardHistoryWindowSize] Failed to unpin: ${e}`)
         showError?.('Failed to unpin')
         return
       }
@@ -179,15 +137,14 @@ export const useWindowSize = (selectedTitle: string, editMode = false) => {
       } catch (e) {
         savedSizeRef.current = prevSavedSize
         setIsPinned(true)
-        logError(`Failed to call setResizable: ${e}`)
+        logError(`[useClipboardHistoryWindowSize] Failed to unpin: ${e}`)
         showError?.('Failed to unpin')
         return
       }
 
       await restoreFocusAfterWindowOp()
-      debug(`[useWindowSize] Unpin complete: title="${selectedTitle}"`)
     } else {
-      debug(`[useWindowSize] Pinning: title="${selectedTitle}"`)
+      debug('[useClipboardHistoryWindowSize] Pinning')
 
       let logicalWidth: number
       let logicalHeight: number
@@ -199,22 +156,18 @@ export const useWindowSize = (selectedTitle: string, editMode = false) => {
         const scaleFactor = monitor?.scaleFactor ?? 1.0
         logicalWidth = Math.round(size.width / scaleFactor)
         logicalHeight = Math.round(size.height / scaleFactor)
-        debug(
-          `[useWindowSize] Pin size: ${logicalWidth}x${logicalHeight} (physical: ${size.width}x${size.height}, scaleFactor: ${scaleFactor})`,
-        )
       } catch (e) {
-        logError(`Failed to get window size: ${e}`)
+        logError(`[useClipboardHistoryWindowSize] Failed to get size: ${e}`)
         showError?.('Failed to get window size')
         return
       }
 
       try {
-        await invoke(WindowSizeAPI.SAVE_CHEAT_SHEET_WINDOW_SIZE, {
-          title: selectedTitle,
+        await invoke(WindowSizeAPI.SAVE_CLIPBOARD_HISTORY_WINDOW_SIZE, {
           windowSize: { width: logicalWidth, height: logicalHeight },
         })
       } catch (e) {
-        logError(`Failed to save window size: ${e}`)
+        logError(`[useClipboardHistoryWindowSize] Failed to save size: ${e}`)
         showError?.('Failed to save window size')
         return
       }
@@ -227,15 +180,14 @@ export const useWindowSize = (selectedTitle: string, editMode = false) => {
       } catch (e) {
         savedSizeRef.current = null
         setIsPinned(false)
-        logError(`Failed to call setResizable: ${e}`)
+        logError(`[useClipboardHistoryWindowSize] Failed to save pin: ${e}`)
         showError?.('Failed to save pin')
         return
       }
 
       await restoreFocusAfterWindowOp()
-      debug(`[useWindowSize] Pin complete: title="${selectedTitle}"`)
     }
-  }, [selectedTitle, showError])
+  }, [showError])
 
   return { isPinned, togglePin }
 }

--- a/src/types/api/ClipboardHistory.ts
+++ b/src/types/api/ClipboardHistory.ts
@@ -12,10 +12,5 @@ export type ClipboardHistoryItem = {
   copied_at: string
 }
 
-// シート切り替えに表示する擬似シートのタイトル。
-// DB 上のチートシートではないため、選択時はチートシートデータの取得や
-// ウィンドウサイズのピン留めを行わない。
-export const CLIPBOARD_HISTORY_SHEET_TITLE = 'Clipboard History'
-
 // 一覧取得時の上限件数。設定の「Max history entries」上限（1000）に合わせる。
 export const CLIPBOARD_HISTORY_LIST_LIMIT = 1000

--- a/src/types/api/GlobalShortcut.ts
+++ b/src/types/api/GlobalShortcut.ts
@@ -3,7 +3,21 @@ export class GlobalShortcutAPI {
     'get_toggle_visible_shortcut_settings'
   static readonly SET_TOGGLE_VISIBLE_SHORTCUT_SETTINGS =
     'set_toggle_visible_shortcut_settings'
+  static readonly GET_CLIPBOARD_HISTORY_SHORTCUT_SETTINGS =
+    'get_clipboard_history_shortcut_settings'
+  static readonly SET_CLIPBOARD_HISTORY_SHORTCUT_SETTINGS =
+    'set_clipboard_history_shortcut_settings'
   static readonly RESTART_APP = 'restart_app'
+}
+
+/** 2つのショートカット定義が同一の組み合わせかどうかを判定する（ホットキーは大文字小文字を区別しない）。 */
+export function isSameShortcut(a: ShortcutDef, b: ShortcutDef): boolean {
+  return (
+    a.ctrl === b.ctrl &&
+    a.option === b.option &&
+    a.command === b.command &&
+    a.hotkey.toLowerCase() === b.hotkey.toLowerCase()
+  )
 }
 
 export type ShortcutDef = {

--- a/src/types/api/WindowSize.ts
+++ b/src/types/api/WindowSize.ts
@@ -1,6 +1,10 @@
 export class WindowSizeAPI {
   static readonly GET_CHEAT_SHEET_WINDOW_SIZE = 'get_cheat_sheet_window_size'
   static readonly SAVE_CHEAT_SHEET_WINDOW_SIZE = 'save_cheat_sheet_window_size'
+  static readonly GET_CLIPBOARD_HISTORY_WINDOW_SIZE =
+    'get_clipboard_history_window_size'
+  static readonly SAVE_CLIPBOARD_HISTORY_WINDOW_SIZE =
+    'save_clipboard_history_window_size'
 }
 
 export type WindowSizeSettings = {

--- a/src/utils/windowFocus.ts
+++ b/src/utils/windowFocus.ts
@@ -1,0 +1,41 @@
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+import { FOCUS_FALLBACK_ID } from '@/constants/focus'
+
+// setSize/setResizable は macOS の NSWindow 状態を変更するため WKWebView が
+// first responder を失うことがある。
+// 1. native イベント（styleMask 変更通知など）が処理されるまで 50ms 待機する
+// 2. setFocus() でウィンドウのキーステータスを復元する
+// 3. blur() → focus() で WKWebView の native first responder を強制的に再取得する
+//    focus() 単独では document.activeElement がすでに対象要素の場合 no-op になり
+//    WKWebView の native first responder が復元されないため blur() が必要
+// 4. document.activeElement は 50ms 待機後に読む。
+//    呼び出し側が事前に取得した値を渡すと、その後の DOM 変化（dropdown input
+//    アンマウントなど）で body に戻り target=null になる race condition が生じる。
+//    50ms 待機中に SheetSwitchButton の restoreFocusAfterClose（setTimeout=0）が
+//    先に完了してトリガーボタンにフォーカスを移すため、その後に読めば正しい要素が得られる。
+export const restoreFocusAfterWindowOp = async (): Promise<void> => {
+  await new Promise<void>((resolve) => setTimeout(resolve, 50))
+  await getCurrentWindow().setFocus()
+
+  const currentActive = document.activeElement as HTMLElement | null
+  const target =
+    currentActive &&
+    currentActive !== document.body &&
+    document.body.contains(currentActive)
+      ? currentActive
+      : null
+
+  if (target) {
+    target.blur()
+    target.focus()
+  } else {
+    // フォーカス可能な要素が無い場合（通常表示や編集モード突入直後は
+    // activeElement が body に戻る）でも、ルートに常設したフォールバック要素へ
+    // フォーカスして WKWebView の native first responder を取り戻す。
+    // setFocus() 単独では first responder が復元されず、以降のキーイベント
+    // （Esc など）が document に届かずネイティブのビープ音だけ鳴るため。
+    const fallback = document.getElementById(FOCUS_FALLBACK_ID)
+    fallback?.focus()
+  }
+}


### PR DESCRIPTION
Closes #198

## 概要

Clipboard History を、チートシートウィンドウ内の擬似シートから **独立したウィンドウ** へ仕様変更し、グローバルショートカット（デフォルト ^⌘C）や View メニューから表示をトグルできるようにしました。

## 変更内容

### Phase 1: バックエンド（ショートカット・メニュー・ウィンドウ生成）
- `global_shortcut.rs`: `CLIPBOARD_HISTORY_SHORTCUT` の init/get/set を Toggle Visible と同構成で追加（デフォルト `^⌘C`）
- `lib.rs`: `global_shortcut_configuration` を複数ショートカット対応にし、両ショートカットを register。ハンドラで判定して処理を分岐
- View メニュー **先頭** に「Clipboard History」+ separator を追加（アクセラレータは設定中のショートカット）
- `clipboard_history` ウィンドウのトグル処理（未作成なら `/clipboard-history` を作成、表示中は hide、非表示なら show + focus）

### Phase 2: Preferences
- Global Shortcut セクションに「Clipboard History」行を追加（歯車ボタン → ショートカット編集ダイアログ）
- Toggle Visible との**重複チェック**を双方向に追加（同一の組み合わせは保存不可・インラインエラー表示）
- 保存成功時に再起動確認ダイアログを表示

### Phase 3: 履歴のページ化と擬似シート撤去
- `src/app/clipboard-history/page.tsx` を新規作成
- `useClipboardHistory` の `active` 引数を廃止し、再取得を自ウィンドウの `onFocusChanged` に変更
- `CheatSheet.tsx` / `useCheatSheetData.ts` / `CheatSheetToolbar.tsx` から擬似シート関連コードを撤去
- `CLIPBOARD_HISTORY_SHEET_TITLE` を削除

### Phase 4: ウィンドウサイズのピン留め
- `window.rs`: 設定ファイル（tauri-plugin-store）に保存する `get/save_clipboard_history_window_size` コマンドを追加（最小サイズ 320×400 にクランプ）
- `useClipboardHistoryWindowSize` フックを新設（`useWindowSize` と同等。`restoreFocusAfterWindowOp` は `utils/windowFocus.ts` へ共通化）
- タイトルバー右のピンアイコン / `p` キーでトグル

### Phase 5: Add to Cheat Sheet のウィンドウ化
- `src/app/add-to-cheatsheet/page.tsx` を新規作成（`edit-command` の READY/INIT パターン踏襲、⌘S で Add / Esc で Cancel）
- 登録成功時に `clipboard_history` ウィンドウへ emit → Snackbar で「Added to "{sheet}"」表示
- in-window の `AddToCheatSheetDialog.tsx` を削除

## テスト

- `src-tauri/tests/api/global_shortcut.rs`: Clipboard History ショートカットの get/set テストを追加
- `src-tauri/tests/api/window.rs`（新規）: ウィンドウサイズの get/save・クランプ・ピン解除テストを追加
- `cargo test -- --test-threads=1`: **314 passed**
- `yarn lint` / `yarn build` / `cargo fmt --check`: 通過

## 確認事項

- [ ] グローバルショートカット（^⌘C）でトグル（非フォーカス時も動作）
- [ ] View メニュー先頭から開ける
- [ ] Preferences でショートカット変更・重複禁止
- [ ] チートシート選択に Clipboard History が出ない
- [ ] 一覧・再コピー・編集・全クリア・空状態・キーボード操作
- [ ] ピン留めの保存・再起動後復元
- [ ] Add to Cheat Sheet 別ウィンドウ＋登録通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)