### PR TITLE
feat: Preferences画面をv19モックアップのサイドバーナビゲーション型UIデザインに変更する

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -420,9 +420,9 @@ fn on_menu_event_configuration<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, 
                 tauri::WebviewUrl::App("/preferences".into()),
             )
             .title("Preferences")
-            .inner_size(580.0, 680.0)
-            .max_inner_size(800.0, 1100.0)
-            .min_inner_size(580.0, 680.0)
+            .inner_size(760.0, 550.0)
+            .max_inner_size(1000.0, 800.0)
+            .min_inner_size(760.0, 550.0)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .build();

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -61,10 +61,9 @@ import { relaunch } from '@tauri-apps/plugin-process'
 const DEFAULT_MAX_FILE_SIZE_BYTES = 1_048_576
 const DEFAULT_ROTATION_COUNT = 3
 
-const PREF_SECTIONS: {
-  key: 'clipboard' | 'shortcut' | 'ui' | 'other'
-  label: string
-}[] = [
+type PrefSectionKey = 'clipboard' | 'shortcut' | 'ui' | 'other'
+
+const PREF_SECTIONS: { key: PrefSectionKey; label: string }[] = [
   { key: 'clipboard', label: 'Clipboard History' },
   { key: 'shortcut', label: 'Global Shortcut' },
   { key: 'ui', label: 'UI' },
@@ -80,9 +79,16 @@ export default function Page() {
     setClipboardHistoryShortcutDialogOpen,
   ] = useState<boolean>(false)
   const [confirmActions, setConfirmActionsState] = useState<boolean>(true)
-  const [activeSection, setActiveSection] = useState<
-    'clipboard' | 'shortcut' | 'ui' | 'other'
-  >('clipboard')
+  const [activeSection, setActiveSection] =
+    useState<PrefSectionKey>('clipboard')
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  // セクション切り替え時、前セクションのスクロール位置を引き継がないようにする。
+  useEffect(() => {
+    if (contentRef.current) {
+      contentRef.current.scrollTop = 0
+    }
+  }, [activeSection])
 
   const { getConfirmActions, setConfirmActions } = usePreferencesStore()
   const {
@@ -611,6 +617,7 @@ export default function Page() {
 
         {/* Content */}
         <Box
+          ref={contentRef}
           sx={{
             flex: 1,
             minWidth: 0,

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -9,6 +9,7 @@ import {
   ThemedSwitch,
   ThemeToggle,
 } from '@/components/atoms'
+import { PrefNavItem } from '@/components/molecules/PrefNavItem'
 import { WindowHeader } from '@/components/molecules/WindowHeader'
 import { DialogVariant, RcDialog } from '@/components/organisms/RcDialog'
 import { TITLEBAR_HEIGHT } from '@/constants/layout'
@@ -60,6 +61,16 @@ import { relaunch } from '@tauri-apps/plugin-process'
 const DEFAULT_MAX_FILE_SIZE_BYTES = 1_048_576
 const DEFAULT_ROTATION_COUNT = 3
 
+const PREF_SECTIONS: {
+  key: 'clipboard' | 'shortcut' | 'ui' | 'other'
+  label: string
+}[] = [
+  { key: 'clipboard', label: 'Clipboard History' },
+  { key: 'shortcut', label: 'Global Shortcut' },
+  { key: 'ui', label: 'UI' },
+  { key: 'other', label: 'Other Settings' },
+]
+
 export default function Page() {
   const theme = useTheme()
 
@@ -69,6 +80,9 @@ export default function Page() {
     setClipboardHistoryShortcutDialogOpen,
   ] = useState<boolean>(false)
   const [confirmActions, setConfirmActionsState] = useState<boolean>(true)
+  const [activeSection, setActiveSection] = useState<
+    'clipboard' | 'shortcut' | 'ui' | 'other'
+  >('clipboard')
 
   const { getConfirmActions, setConfirmActions } = usePreferencesStore()
   const {
@@ -570,49 +584,50 @@ export default function Page() {
     <>
       <WindowHeader title='Preferences' />
       <Box
-        sx={{
-          p: '4px 20px 16px',
-          display: 'flex',
-          flexDirection: 'column',
-          // body ではなくこの Box をスクロールコンテナにして、
-          // チートシート画面（ネイティブスクロールバー）と同じ見た目に合わせる。
-          // ネイティブのサムは背景より暗い黒系半透明のため同じ色を指定する。
-          height: `calc(100vh - ${TITLEBAR_HEIGHT}px)`,
-          overflowY: 'auto',
-          scrollbarWidth: 'thin',
-          scrollbarColor: isDark
-            ? 'rgba(0,0,0,0.55) transparent'
-            : 'rgba(0,0,0,0.5) transparent',
-        }}
+        sx={{ display: 'flex', height: `calc(100vh - ${TITLEBAR_HEIGHT}px)` }}
       >
-        {/* Clipboard History */}
-        <Box sx={{ py: '12px' }}>
-          <Typography
-            sx={{
-              fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
-              fontWeight: 600,
-              letterSpacing: '0.01em',
-              mb: '10px',
-              color: 'text.primary',
-            }}
-          >
-            Clipboard History
-          </Typography>
-          <Box sx={{ pl: '14px', py: '8px' }}>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '14px',
-                p: '12px 14px',
-                backgroundColor: theme.palette.glass.panel,
-                border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.6)'}`,
-                borderRadius: '10px',
-                boxShadow: isDark
-                  ? 'none'
-                  : 'inset 0 1px 0 rgba(255,255,255,0.5)',
-              }}
-            >
+        {/* Sidebar */}
+        <Box
+          sx={{
+            width: 180,
+            flexShrink: 0,
+            borderRight: `0.5px solid ${theme.palette.divider}`,
+            backgroundColor: theme.palette.ui.sidebarBg,
+            padding: '14px 10px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '2px',
+          }}
+        >
+          {PREF_SECTIONS.map((s) => (
+            <PrefNavItem
+              key={s.key}
+              label={s.label}
+              active={activeSection === s.key}
+              onClick={() => setActiveSection(s.key)}
+            />
+          ))}
+        </Box>
+
+        {/* Content */}
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflowY: 'auto',
+            padding: '18px 22px 20px',
+            // body ではなくこの Box をスクロールコンテナにして、
+            // チートシート画面（ネイティブスクロールバー）と同じ見た目に合わせる。
+            // ネイティブのサムは背景より暗い黒系半透明のため同じ色を指定する。
+            scrollbarWidth: 'thin',
+            scrollbarColor: isDark
+              ? 'rgba(0,0,0,0.55) transparent'
+              : 'rgba(0,0,0,0.5) transparent',
+          }}
+        >
+          {/* Clipboard History */}
+          {activeSection === 'clipboard' && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
               {/* Row: Clipboard monitoring on/off */}
               <Box
                 sx={{
@@ -750,251 +765,220 @@ export default function Page() {
                 </Box>
               </Box>
             </Box>
-          </Box>
-        </Box>
+          )}
 
-        <Divider sx={{ mx: '-20px', borderBottomWidth: '0.5px' }} />
-
-        {/* Global Shortcut */}
-        <Box sx={{ py: '12px' }}>
-          <Typography
-            sx={{
-              fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
-              fontWeight: 600,
-              letterSpacing: '0.01em',
-              mb: '10px',
-              color: 'text.primary',
-            }}
-          >
-            Global Shortcut
-          </Typography>
-          <Box sx={{ pl: '14px', py: '8px' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <Typography
-                sx={{
-                  fontSize: scaledPx(theme.custom.fontSize.label),
-                  fontWeight: 500,
-                  color: 'text.primary',
-                }}
-              >
-                Toggle Visible
-              </Typography>
-              <Typography
-                sx={{
-                  color: 'text.secondary',
-                  fontSize: scaledPx(theme.custom.fontSize.label),
-                }}
-              >
-                :
-              </Typography>
-              {toggleVisibleShortcut && (
-                <Box
+          {/* Global Shortcut */}
+          {activeSection === 'shortcut' && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <Typography
                   sx={{
-                    backgroundColor: isDark
-                      ? 'rgba(255,255,255,0.06)'
-                      : 'rgba(255,255,255,0.9)',
-                    backdropFilter: 'blur(12px)',
-                    border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
-                    borderRadius: '6px',
-                    padding: '4px 11px',
-                    fontFamily: 'monospace',
-                    fontSize: scaledPx(theme.custom.fontSize.body),
+                    fontSize: scaledPx(theme.custom.fontSize.label),
+                    fontWeight: 500,
                     color: 'text.primary',
-                    boxShadow: !isDark
-                      ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
-                      : 'none',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '6px',
                   }}
                 >
-                  {(
-                    [
-                      toggleVisibleShortcut.ctrl && '^',
-                      toggleVisibleShortcut.option && '⌥',
-                      toggleVisibleShortcut.command && '⌘',
-                      toggleVisibleShortcut.hotkey,
-                    ] as (string | false)[]
-                  )
-                    .filter(Boolean)
-                    .map((c, i) => (
-                      <span key={i}>{c}</span>
-                    ))}
-                </Box>
-              )}
-              <Tooltip title='Edit global shortcut…'>
-                <span>
-                  <IconButton
-                    size='small'
-                    disabled={!toggleVisibleShortcut}
-                    onClick={() => setShortcutDialogOpen(true)}
-                    sx={{
-                      width: 28,
-                      height: 28,
-                      borderRadius: '7px',
-                      border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
-                      backgroundColor: alpha(
-                        theme.palette.accent.main,
-                        isDark ? 0.1 : 0.07,
-                      ),
-                      color: theme.palette.text.disabled,
-                      '&:hover': {
-                        borderColor: theme.palette.primary.main,
-                        color: theme.palette.primary.main,
-                      },
-                    }}
-                  >
-                    <SettingsOutlinedIcon sx={{ fontSize: '14px' }} />
-                  </IconButton>
-                </span>
-              </Tooltip>
-            </Box>
-          </Box>
-          <Box sx={{ pl: '14px', py: '8px' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <Typography
-                sx={{
-                  fontSize: scaledPx(theme.custom.fontSize.label),
-                  fontWeight: 500,
-                  color: 'text.primary',
-                }}
-              >
-                Clipboard History
-              </Typography>
-              <Typography
-                sx={{
-                  color: 'text.secondary',
-                  fontSize: scaledPx(theme.custom.fontSize.label),
-                }}
-              >
-                :
-              </Typography>
-              {clipboardHistoryShortcut && (
-                <Box
+                  Toggle Visible
+                </Typography>
+                <Typography
                   sx={{
-                    backgroundColor: isDark
-                      ? 'rgba(255,255,255,0.06)'
-                      : 'rgba(255,255,255,0.9)',
-                    backdropFilter: 'blur(12px)',
-                    border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
-                    borderRadius: '6px',
-                    padding: '4px 11px',
-                    fontFamily: 'monospace',
-                    fontSize: scaledPx(theme.custom.fontSize.body),
-                    color: 'text.primary',
-                    boxShadow: !isDark
-                      ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
-                      : 'none',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '6px',
+                    color: 'text.secondary',
+                    fontSize: scaledPx(theme.custom.fontSize.label),
                   }}
                 >
-                  {(
-                    [
-                      clipboardHistoryShortcut.ctrl && '^',
-                      clipboardHistoryShortcut.option && '⌥',
-                      clipboardHistoryShortcut.command && '⌘',
-                      clipboardHistoryShortcut.hotkey,
-                    ] as (string | false)[]
-                  )
-                    .filter(Boolean)
-                    .map((c, i) => (
-                      <span key={i}>{c}</span>
-                    ))}
-                </Box>
-              )}
-              <Tooltip title='Edit global shortcut…'>
-                <span>
-                  <IconButton
-                    size='small'
-                    disabled={!clipboardHistoryShortcut}
-                    onClick={() => setClipboardHistoryShortcutDialogOpen(true)}
+                  :
+                </Typography>
+                {toggleVisibleShortcut && (
+                  <Box
                     sx={{
-                      width: 28,
-                      height: 28,
-                      borderRadius: '7px',
-                      border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
-                      backgroundColor: alpha(
-                        theme.palette.accent.main,
-                        isDark ? 0.1 : 0.07,
-                      ),
-                      color: theme.palette.text.disabled,
-                      '&:hover': {
-                        borderColor: theme.palette.primary.main,
-                        color: theme.palette.primary.main,
-                      },
+                      backgroundColor: isDark
+                        ? 'rgba(255,255,255,0.06)'
+                        : 'rgba(255,255,255,0.9)',
+                      backdropFilter: 'blur(12px)',
+                      border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
+                      borderRadius: '6px',
+                      padding: '4px 11px',
+                      fontFamily: 'monospace',
+                      fontSize: scaledPx(theme.custom.fontSize.body),
+                      color: 'text.primary',
+                      boxShadow: !isDark
+                        ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
+                        : 'none',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
                     }}
                   >
-                    <SettingsOutlinedIcon sx={{ fontSize: '14px' }} />
-                  </IconButton>
-                </span>
-              </Tooltip>
+                    {(
+                      [
+                        toggleVisibleShortcut.ctrl && '^',
+                        toggleVisibleShortcut.option && '⌥',
+                        toggleVisibleShortcut.command && '⌘',
+                        toggleVisibleShortcut.hotkey,
+                      ] as (string | false)[]
+                    )
+                      .filter(Boolean)
+                      .map((c, i) => (
+                        <span key={i}>{c}</span>
+                      ))}
+                  </Box>
+                )}
+                <Tooltip title='Edit global shortcut…'>
+                  <span>
+                    <IconButton
+                      size='small'
+                      disabled={!toggleVisibleShortcut}
+                      onClick={() => setShortcutDialogOpen(true)}
+                      sx={{
+                        width: 28,
+                        height: 28,
+                        borderRadius: '7px',
+                        border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
+                        backgroundColor: alpha(
+                          theme.palette.accent.main,
+                          isDark ? 0.1 : 0.07,
+                        ),
+                        color: theme.palette.text.disabled,
+                        '&:hover': {
+                          borderColor: theme.palette.primary.main,
+                          color: theme.palette.primary.main,
+                        },
+                      }}
+                    >
+                      <SettingsOutlinedIcon sx={{ fontSize: '14px' }} />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Box>
+
+              <Divider sx={{ borderBottomWidth: '0.5px' }} />
+
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <Typography
+                  sx={{
+                    fontSize: scaledPx(theme.custom.fontSize.label),
+                    fontWeight: 500,
+                    color: 'text.primary',
+                  }}
+                >
+                  Clipboard History
+                </Typography>
+                <Typography
+                  sx={{
+                    color: 'text.secondary',
+                    fontSize: scaledPx(theme.custom.fontSize.label),
+                  }}
+                >
+                  :
+                </Typography>
+                {clipboardHistoryShortcut && (
+                  <Box
+                    sx={{
+                      backgroundColor: isDark
+                        ? 'rgba(255,255,255,0.06)'
+                        : 'rgba(255,255,255,0.9)',
+                      backdropFilter: 'blur(12px)',
+                      border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
+                      borderRadius: '6px',
+                      padding: '4px 11px',
+                      fontFamily: 'monospace',
+                      fontSize: scaledPx(theme.custom.fontSize.body),
+                      color: 'text.primary',
+                      boxShadow: !isDark
+                        ? 'inset 0 1px 0 rgba(255,255,255,0.8)'
+                        : 'none',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                    }}
+                  >
+                    {(
+                      [
+                        clipboardHistoryShortcut.ctrl && '^',
+                        clipboardHistoryShortcut.option && '⌥',
+                        clipboardHistoryShortcut.command && '⌘',
+                        clipboardHistoryShortcut.hotkey,
+                      ] as (string | false)[]
+                    )
+                      .filter(Boolean)
+                      .map((c, i) => (
+                        <span key={i}>{c}</span>
+                      ))}
+                  </Box>
+                )}
+                <Tooltip title='Edit global shortcut…'>
+                  <span>
+                    <IconButton
+                      size='small'
+                      disabled={!clipboardHistoryShortcut}
+                      onClick={() =>
+                        setClipboardHistoryShortcutDialogOpen(true)
+                      }
+                      sx={{
+                        width: 28,
+                        height: 28,
+                        borderRadius: '7px',
+                        border: `0.5px solid ${alpha(theme.palette.accent.main, isDark ? 0.18 : 0.14)}`,
+                        backgroundColor: alpha(
+                          theme.palette.accent.main,
+                          isDark ? 0.1 : 0.07,
+                        ),
+                        color: theme.palette.text.disabled,
+                        '&:hover': {
+                          borderColor: theme.palette.primary.main,
+                          color: theme.palette.primary.main,
+                        },
+                      }}
+                    >
+                      <SettingsOutlinedIcon sx={{ fontSize: '14px' }} />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Box>
             </Box>
-          </Box>
-        </Box>
+          )}
 
-        <Divider sx={{ mx: '-20px', borderBottomWidth: '0.5px' }} />
+          {/* UI */}
+          {activeSection === 'ui' && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+              {/* Row: Theme */}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: '12px',
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <RowDot />
+                  <Typography
+                    sx={{
+                      fontSize: scaledPx(theme.custom.fontSize.label),
+                      color: 'text.primary',
+                    }}
+                  >
+                    Theme
+                  </Typography>
+                </Box>
+                <ThemeToggle
+                  themeMode={themeMode}
+                  onChange={handleThemeChange}
+                  disabled={isLoading}
+                />
+              </Box>
+            </Box>
+          )}
 
-        {/* Theme */}
-        <Box sx={{ py: '12px' }}>
-          <Typography
-            sx={{
-              fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
-              fontWeight: 600,
-              letterSpacing: '0.01em',
-              mb: '10px',
-              color: 'text.primary',
-            }}
-          >
-            Theme
-          </Typography>
-          <Box sx={{ pl: '14px', py: '8px' }}>
-            <ThemeToggle
-              themeMode={themeMode}
-              onChange={handleThemeChange}
-              disabled={isLoading}
-            />
-          </Box>
-        </Box>
-
-        <Divider sx={{ mx: '-20px', borderBottomWidth: '0.5px' }} />
-
-        {/* Other Settings */}
-        <Box sx={{ py: '12px' }}>
-          <Typography
-            sx={{
-              fontSize: scaledPx(theme.custom.fontSize.sectionHeader),
-              fontWeight: 600,
-              letterSpacing: '0.01em',
-              mb: '10px',
-              color: 'text.primary',
-            }}
-          >
-            Other Settings
-          </Typography>
-          <Box sx={{ pl: '14px', py: '8px' }}>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '14px',
-                p: '12px 14px',
-                backgroundColor: theme.palette.glass.panel,
-                border: `0.5px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.6)'}`,
-                borderRadius: '10px',
-                boxShadow: isDark
-                  ? 'none'
-                  : 'inset 0 1px 0 rgba(255,255,255,0.5)',
-              }}
-            >
+          {/* Other Settings */}
+          {activeSection === 'other' && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
               {/* Confirm before actions */}
               <Box
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'space-between',
-                  py: '6px',
                 }}
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
@@ -1017,7 +1001,7 @@ export default function Page() {
               <Divider sx={{ borderBottomWidth: '0.5px' }} />
 
               {/* CheatSheet DB section */}
-              <Box sx={{ py: '6px' }}>
+              <Box>
                 <Box
                   sx={{
                     display: 'flex',
@@ -1104,7 +1088,7 @@ export default function Page() {
               <Divider sx={{ borderBottomWidth: '0.5px' }} />
 
               {/* Log section */}
-              <Box sx={{ py: '6px' }}>
+              <Box>
                 {/* Header row */}
                 <Box
                   sx={{
@@ -1203,7 +1187,7 @@ export default function Page() {
                 </Box>
               </Box>
             </Box>
-          </Box>
+          )}
         </Box>
       </Box>
 

--- a/src/components/atoms/StepperInput.tsx
+++ b/src/components/atoms/StepperInput.tsx
@@ -134,7 +134,8 @@ export function StepperInput({
           alignItems: 'center',
           gap: '4px',
           px: '8px',
-          width: boxWidth,
+          width: scaledPx(boxWidth),
+          flexShrink: 0,
           justifyContent: 'center',
           borderLeft: `0.5px solid ${theme.palette.divider}`,
           borderRight: `0.5px solid ${theme.palette.divider}`,
@@ -153,7 +154,7 @@ export function StepperInput({
             e.currentTarget.select()
           }
           sx={{
-            width: inputWidth,
+            width: scaledPx(inputWidth),
             textAlign: 'right',
             background: 'transparent',
             border: 'none',

--- a/src/components/molecules/PrefNavItem.tsx
+++ b/src/components/molecules/PrefNavItem.tsx
@@ -18,6 +18,7 @@ export function PrefNavItem({ label, active, onClick }: PrefNavItemProps) {
       component='button'
       type='button'
       onClick={onClick}
+      aria-current={active ? 'page' : undefined}
       sx={{
         textAlign: 'left',
         width: '100%',
@@ -26,7 +27,7 @@ export function PrefNavItem({ label, active, onClick }: PrefNavItemProps) {
         padding: '7px 11px',
         borderRadius: '7px',
         fontFamily: 'inherit',
-        fontSize: scaledPx(theme.custom.fontSize.dialogMessage),
+        fontSize: scaledPx(theme.custom.fontSize.label),
         fontWeight: active ? 600 : 500,
         color: active ? 'text.primary' : 'text.secondary',
         backgroundColor: active
@@ -34,6 +35,7 @@ export function PrefNavItem({ label, active, onClick }: PrefNavItemProps) {
           : 'transparent',
         transition: 'background-color 0.12s, color 0.12s',
         outline: 'none',
+        position: 'relative',
         '&:hover': {
           backgroundColor: active
             ? theme.palette.surface.selected
@@ -42,7 +44,9 @@ export function PrefNavItem({ label, active, onClick }: PrefNavItemProps) {
         },
         '&:focus-visible': {
           outline: `2px solid ${theme.palette.primary.main}`,
-          outlineOffset: '-2px',
+          outlineOffset: '1px',
+          borderRadius: '7px',
+          zIndex: 2,
         },
       }}
     >

--- a/src/components/molecules/PrefNavItem.tsx
+++ b/src/components/molecules/PrefNavItem.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { scaledPx } from '@/utils/css'
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+type PrefNavItemProps = {
+  label: string
+  active: boolean
+  onClick: () => void
+}
+
+export function PrefNavItem({ label, active, onClick }: PrefNavItemProps) {
+  const theme = useTheme()
+
+  return (
+    <Box
+      component='button'
+      type='button'
+      onClick={onClick}
+      sx={{
+        textAlign: 'left',
+        width: '100%',
+        border: 'none',
+        cursor: 'pointer',
+        padding: '7px 11px',
+        borderRadius: '7px',
+        fontFamily: 'inherit',
+        fontSize: scaledPx(theme.custom.fontSize.dialogMessage),
+        fontWeight: active ? 600 : 500,
+        color: active ? 'text.primary' : 'text.secondary',
+        backgroundColor: active
+          ? theme.palette.surface.selected
+          : 'transparent',
+        transition: 'background-color 0.12s, color 0.12s',
+        outline: 'none',
+        '&:hover': {
+          backgroundColor: active
+            ? theme.palette.surface.selected
+            : theme.palette.surface.hover,
+          color: 'text.primary',
+        },
+        '&:focus-visible': {
+          outline: `2px solid ${theme.palette.primary.main}`,
+          outlineOffset: '-2px',
+        },
+      }}
+    >
+      {label}
+    </Box>
+  )
+}

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -104,6 +104,7 @@ declare module '@mui/material/styles' {
       footerBg: string
       fieldRowBg: string
       borderSubtle: string
+      sidebarBg: string
     }
   }
   interface PaletteOptions {
@@ -151,6 +152,7 @@ declare module '@mui/material/styles' {
       footerBg: string
       fieldRowBg: string
       borderSubtle: string
+      sidebarBg: string
     }
   }
 }
@@ -260,6 +262,7 @@ const getLightPalette = () => ({
     footerBg: 'rgba(255,255,255,0.30)',
     fieldRowBg: 'rgba(255,255,255,0.48)',
     borderSubtle: 'rgba(0,0,0,0.08)',
+    sidebarBg: 'rgba(0,0,0,0.015)',
   },
   background: {
     default: '#dce5f2',
@@ -343,6 +346,7 @@ const getDarkPalette = () => ({
     footerBg: 'rgba(255,255,255,0.018)',
     fieldRowBg: 'rgba(255,255,255,0.055)',
     borderSubtle: 'rgba(255,255,255,0.08)',
+    sidebarBg: 'rgba(255,255,255,0.02)',
   },
   background: {
     default: '#0f2236',


### PR DESCRIPTION
## Summary
- Preferences画面のレイアウトを、左サイドバー（Clipboard History / Global Shortcut / UI / Other Settings）＋右コンテンツ領域の2ペイン構成に変更（`design/RightCheat-handoff_20260714.zip` 内の v19 モックアップに準拠）
- 各セクションの `glass.panel` カード囲みとセクション見出しを廃止し、フラットな行＋0.5px dividerに統一
- 「Theme」セクションを廃止し、「UI」セクション内の1行（ラベル＋右寄せの LIGHT/DARK/SYSTEM セグメントボタン）に変更
- サイドバー背景色トークン `theme.palette.ui.sidebarBg` を新規追加（既存の `surface.hover` / `surface.selected` はナビ項目のホバー/選択状態にそのまま再利用）
- Preferencesウィンドウのサイズを横長レイアウトに合わせて 760×550 に変更（`src-tauri/src/lib.rs`）

## スコープ外（別issueで対応予定）
- Language 設定（i18n未実装のため #183 で対応）
- Heat bar color 設定（ヒートバー機能未実装のため #195 で対応）

## Test plan
- [x] `yarn lint`（ESLint + Prettier）
- [x] `yarn tsc --noEmit`
- [x] `cargo fmt -- --check` / `cargo build`
- [x] `cargo test --verbose -- --test-threads=1`（355 passed / 既存テストへの影響なし。今回はUIレイアウトのみの変更のため新規Rustテストは追加していない）
- [x] `yarn tauri dev` でライト/ダーク両テーマの4セクション（Clipboard History / Global Shortcut / UI / Other Settings）の表示・切り替えを目視確認

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)