### PR TITLE
fix: リロード時に各チートシートウィンドウの表示中シートを維持する

### DIFF
--- a/src/hooks/cheat-sheet/useCheatSheetData.ts
+++ b/src/hooks/cheat-sheet/useCheatSheetData.ts
@@ -10,6 +10,9 @@ type Params = {
   editModeRef: RefObject<boolean>
 }
 
+const firstTitleOf = (titles: CheatSheetTitleData): string =>
+  titles.title.length > 0 ? titles.title[0] : ''
+
 /**
  * チートシートのタイトル一覧・選択中シートのデータのロードを管理するフック。
  * 起動時のリロード、`RELOAD_CHEAT_SHEET` イベントの購読、選択変更時のデータ取得を担う。
@@ -51,13 +54,18 @@ export function useCheatSheetData({ editModeRef }: Params) {
             if (currentTitle !== '' && titles.title.includes(currentTitle)) {
               // 表示中のチートシートを維持したまま、コマンドデータのみ再取得する
               // （selectCheatSheet 自体は変化しないため、下の useEffect には
-              // 任せられず明示的に呼び出す必要がある）
+              // 任せられず明示的に呼び出す必要がある）。
+              // この await 中にユーザーが手動でシートを切り替える可能性があるため、
+              // 完了後に selectCheatSheetRef が currentTitle のままかを再確認してから
+              // 反映する（切り替え後のシートを古いデータで上書きしないためのガード）。
               const data = await loadCheatSheetData(currentTitle)
-              setCheatSheetData(data)
+              if (selectCheatSheetRef.current === currentTitle) {
+                setCheatSheetData(data)
+              }
             } else {
               // 表示中のチートシートがリロード後の一覧に存在しない場合のみ
               // 先頭のチートシートへフォールバックする
-              setCheatSheet(titles.title.length > 0 ? titles.title[0] : '')
+              setCheatSheet(firstTitleOf(titles))
             }
           }
           setReloading(false)
@@ -76,7 +84,7 @@ export function useCheatSheetData({ editModeRef }: Params) {
       // Cmd+R メニューや編集後の同期ブロードキャストは別経路で継続する。
       const titles = await loadCheatSheetTitles()
       if (titles) {
-        setCheatSheet(titles.title.length > 0 ? titles.title[0] : '')
+        setCheatSheet(firstTitleOf(titles))
       }
     })()
     return () => {

--- a/src/hooks/cheat-sheet/useCheatSheetData.ts
+++ b/src/hooks/cheat-sheet/useCheatSheetData.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useState } from 'react'
+import { RefObject, useEffect, useRef, useState } from 'react'
 
 import { listen } from '@tauri-apps/api/event'
 
@@ -23,9 +23,15 @@ export function useCheatSheetData({ editModeRef }: Params) {
   const [errorMessage, setErrorMessage] = useState<string>()
   const [reloading, setReloading] = useState<boolean>(false)
 
+  // RELOAD_CHEAT_SHEET リスナーはマウント時に一度だけ登録されるため、
+  // 内部のクロージャが selectCheatSheet の古い値を参照しないよう ref で保持する
+  const selectCheatSheetRef = useRef<string>('')
+  useEffect(() => {
+    selectCheatSheetRef.current = selectCheatSheet
+  }, [selectCheatSheet])
+
   const { loadCheatSheetTitles, loadCheatSheetData } = useCheatSheetLoader({
     setCheatSheetTitles,
-    setCheatSheet,
     setErrorMessage,
   })
 
@@ -39,8 +45,21 @@ export function useCheatSheetData({ editModeRef }: Params) {
         if (editModeRef.current) return
         ;(async () => {
           setReloading(true)
-          setCheatSheet('')
-          await loadCheatSheetTitles()
+          const currentTitle = selectCheatSheetRef.current
+          const titles = await loadCheatSheetTitles()
+          if (titles) {
+            if (currentTitle !== '' && titles.title.includes(currentTitle)) {
+              // 表示中のチートシートを維持したまま、コマンドデータのみ再取得する
+              // （selectCheatSheet 自体は変化しないため、下の useEffect には
+              // 任せられず明示的に呼び出す必要がある）
+              const data = await loadCheatSheetData(currentTitle)
+              setCheatSheetData(data)
+            } else {
+              // 表示中のチートシートがリロード後の一覧に存在しない場合のみ
+              // 先頭のチートシートへフォールバックする
+              setCheatSheet(titles.title.length > 0 ? titles.title[0] : '')
+            }
+          }
           setReloading(false)
         })()
       })
@@ -55,7 +74,10 @@ export function useCheatSheetData({ editModeRef }: Params) {
       // 新規チートシートウィンドウを開くたびに既存の全ウィンドウが
       // 先頭シートへリセットされてしまう（複数ウィンドウ対応で顕在化）。
       // Cmd+R メニューや編集後の同期ブロードキャストは別経路で継続する。
-      await loadCheatSheetTitles()
+      const titles = await loadCheatSheetTitles()
+      if (titles) {
+        setCheatSheet(titles.title.length > 0 ? titles.title[0] : '')
+      }
     })()
     return () => {
       cancelled = true

--- a/src/hooks/useCheatSheetLoader.ts
+++ b/src/hooks/useCheatSheetLoader.ts
@@ -10,16 +10,16 @@ import {
 
 interface UseCheatSheetLoaderProps {
   setCheatSheetTitles: (titles: CheatSheetTitleData | undefined) => void
-  setCheatSheet: (title: string) => void
   setErrorMessage: (message: string | undefined) => void
 }
 
 export const useCheatSheetLoader = ({
   setCheatSheetTitles,
-  setCheatSheet,
   setErrorMessage,
 }: UseCheatSheetLoaderProps) => {
-  const loadCheatSheetTitles = useCallback(async () => {
+  const loadCheatSheetTitles = useCallback(async (): Promise<
+    CheatSheetTitleData | undefined
+  > => {
     try {
       setErrorMessage(undefined)
       const response = await invoke<string>(CheatSheetAPI.GET_CHEAT_TITLES)
@@ -32,11 +32,12 @@ export const useCheatSheetLoader = ({
       if (parsedResponse.success === false && parsedResponse.error) {
         setErrorMessage(parsedResponse.error)
         setCheatSheetTitles(undefined)
+        return undefined
       } else {
         const titles: CheatSheetTitleData = parsedResponse
         setCheatSheetTitles(titles)
-        setCheatSheet(titles.title.length > 0 ? titles.title[0] : '')
         setErrorMessage(undefined)
+        return titles
       }
     } catch (error) {
       const errorMessage =
@@ -46,8 +47,9 @@ export const useCheatSheetLoader = ({
       )
       setErrorMessage(errorMessage)
       setCheatSheetTitles(undefined)
+      return undefined
     }
-  }, [setCheatSheetTitles, setCheatSheet, setErrorMessage])
+  }, [setCheatSheetTitles, setErrorMessage])
 
   const loadCheatSheetData = useCallback(
     async (title: string) => {


### PR DESCRIPTION
## Summary
- 複数チートシートウィンドウ環境でリロード（Cmd+R / File メニュー > Reload）を実行すると、全ウィンドウが先頭のチートシートへ強制的に切り替わっていた問題を修正
- `useCheatSheetLoader.ts` の `loadCheatSheetTitles()` から「タイトル一覧の先頭を自動選択する」責務を分離し、タイトル一覧の取得・返却のみを行うようにした
- `useCheatSheetData.ts` の `RELOAD_CHEAT_SHEET` イベントハンドラで、表示中のタイトルが新しい一覧に存在する場合はそのまま維持しつつコマンドデータのみ再取得し、存在しない場合のみ先頭タイトルへフォールバックするようにした
- 初回マウント時の挙動（先頭シートを表示する）は維持

Closes #204

## Test plan
- [x] `yarn lint` が通過することを確認
- [x] `yarn build` が通過することを確認
- [x] `cargo test --verbose -- --test-threads=1` が通過することを確認（Rustコードの変更はなし、既存テストに影響なし）
- [x] 実機で2つ以上のチートシートウィンドウで異なるチートシートを表示した状態からリロードを実行し、それぞれのウィンドウが自分の表示していたチートシートを維持しつつ、JSON側の変更が反映されることを確認
- [x] 表示中のチートシート自体がリロード後に存在しなくなっているケース（フォールバック動作）を確認
- [x] 編集モード中はリロードをスキップする既存の挙動に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)