### PR TITLE
feat: クリップボード履歴で最大文字数により切り詰められたエントリを画面上で識別できるようにする

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -29,7 +29,8 @@
       "Bash(gh pr *)",
       "Bash(cargo doc *)",
       "Bash(osascript -e ' *)",
-      "Bash(git commit -m ' *k)"
+      "Bash(git commit -m ' *k)",
+      "Bash(git reset *)"
     ],
     "deny": [],
     "ask": []

--- a/src-tauri/src/api/clipboard_history.rs
+++ b/src-tauri/src/api/clipboard_history.rs
@@ -12,6 +12,8 @@ pub struct ClipboardHistoryItem {
     pub copied_at: String,
     pub copy_count: i64,
     pub first_copied_at: String,
+    pub truncated: bool,
+    pub original_char_count: Option<i64>,
 }
 
 impl From<repository::ClipboardHistoryRow> for ClipboardHistoryItem {
@@ -23,6 +25,8 @@ impl From<repository::ClipboardHistoryRow> for ClipboardHistoryItem {
             copied_at: row.copied_at,
             copy_count: row.copy_count,
             first_copied_at: row.first_copied_at,
+            truncated: row.truncated,
+            original_char_count: row.original_char_count,
         }
     }
 }
@@ -56,7 +60,7 @@ pub fn record_clipboard_history_recopy<R: Runtime>(
 ) -> Result<(), String> {
     let db = app.state::<DbConnection>();
     let conn = db.0.lock().map_err(|e| e.to_string())?;
-    repository::insert_clipboard_history(&conn, &text).map_err(|e| e.to_string())?;
+    repository::insert_clipboard_history(&conn, &text, None).map_err(|e| e.to_string())?;
     log::debug!(
         "[clipboard_history] record_clipboard_history_recopy: {} char(s)",
         text.chars().count()

--- a/src-tauri/src/api/clipboard_monitor.rs
+++ b/src-tauri/src/api/clipboard_monitor.rs
@@ -278,9 +278,16 @@ pub fn save_clipboard_text<R: Runtime>(
         text.to_string()
     };
 
+    let original_char_count = if truncated {
+        Some(char_count as i64)
+    } else {
+        None
+    };
+
     let db = app.state::<DbConnection>();
     let conn = db.0.lock().map_err(|e| e.to_string())?;
-    repository::insert_clipboard_history(&conn, &text_to_save).map_err(|e| e.to_string())?;
+    repository::insert_clipboard_history(&conn, &text_to_save, original_char_count)
+        .map_err(|e| e.to_string())?;
     repository::delete_oldest_clipboard_history(&conn, settings.max_items)
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -699,6 +699,8 @@ pub struct ClipboardHistoryRow {
     pub copied_at: String,
     pub copy_count: i64,
     pub first_copied_at: String,
+    pub truncated: bool,
+    pub original_char_count: Option<i64>,
 }
 
 /// SQLite の `datetime('now')` は秒精度のため、同一秒内に複数回のコピー操作
@@ -715,8 +717,16 @@ pub const MAX_COPY_COUNT: i64 = 5;
 /// クリップボード履歴を追加する。
 /// 同一テキストが履歴全体に既に存在する場合は INSERT せず、既存行の `copied_at` を
 /// 現在時刻に更新して先頭（最新）へ移動し、`copy_count` を `MAX_COPY_COUNT` を上限に
-/// インクリメントして既存行の id を返す（move-to-top）。
-pub fn insert_clipboard_history(conn: &Connection, text: &str) -> Result<i64> {
+/// インクリメントして既存行の id を返す（move-to-top）。この場合 `original_char_count`
+/// は既存行の値のまま変更しない（切り詰めは初回保存時にのみ発生するため）。
+///
+/// `original_char_count` は切り詰めが発生した場合のみ `Some(元テキストの文字数)` を渡す。
+/// `None` の場合は `truncated = false` として保存する。
+pub fn insert_clipboard_history(
+    conn: &Connection,
+    text: &str,
+    original_char_count: Option<i64>,
+) -> Result<i64> {
     let existing: Option<i64> = match conn.query_row(
         "SELECT id FROM clipboard_history WHERE text = ?1 ORDER BY copied_at DESC, id DESC LIMIT 1",
         params![text],
@@ -738,12 +748,13 @@ pub fn insert_clipboard_history(conn: &Connection, text: &str) -> Result<i64> {
     }
 
     let char_count = text.chars().count() as i64;
+    let truncated = original_char_count.is_some();
     conn.execute(
         &format!(
-            "INSERT INTO clipboard_history (text, char_count, copied_at, first_copied_at, copy_count)
-             VALUES (?1, ?2, {COPIED_AT_NOW_EXPR}, {COPIED_AT_NOW_EXPR}, 1)"
+            "INSERT INTO clipboard_history (text, char_count, copied_at, first_copied_at, copy_count, truncated, original_char_count)
+             VALUES (?1, ?2, {COPIED_AT_NOW_EXPR}, {COPIED_AT_NOW_EXPR}, 1, ?3, ?4)"
         ),
-        params![text, char_count],
+        params![text, char_count, truncated, original_char_count],
     )?;
     Ok(conn.last_insert_rowid())
 }
@@ -751,7 +762,8 @@ pub fn insert_clipboard_history(conn: &Connection, text: &str) -> Result<i64> {
 /// クリップボード履歴を新しい順に取得する。
 pub fn list_clipboard_history(conn: &Connection, limit: u32) -> Result<Vec<ClipboardHistoryRow>> {
     let mut stmt = conn.prepare(
-        "SELECT id, text, char_count, copied_at, copy_count, first_copied_at FROM clipboard_history
+        "SELECT id, text, char_count, copied_at, copy_count, first_copied_at, truncated, original_char_count
+         FROM clipboard_history
          ORDER BY copied_at DESC, id DESC LIMIT ?1",
     )?;
     let rows = stmt
@@ -763,6 +775,8 @@ pub fn list_clipboard_history(conn: &Connection, limit: u32) -> Result<Vec<Clipb
                 copied_at: row.get(3)?,
                 copy_count: row.get(4)?,
                 first_copied_at: row.get(5)?,
+                truncated: row.get(6)?,
+                original_char_count: row.get(7)?,
             })
         })?
         .collect::<Result<Vec<_>>>()?;

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -28,8 +28,24 @@ pub fn apply_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     if version < 4 {
         migrate_v4(conn)?;
     }
+    if version < 5 {
+        migrate_v5(conn)?;
+    }
 
     Ok(())
+}
+
+/// クリップボード履歴に切り詰め情報（truncated / original_char_count）を追加する。
+/// 既存行は truncated = 0（過去分は切り詰めの有無を判別できないため通常表示）のまま。
+fn migrate_v5(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "
+        ALTER TABLE clipboard_history ADD COLUMN truncated INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE clipboard_history ADD COLUMN original_char_count INTEGER;
+
+        INSERT OR REPLACE INTO schema_meta(key, value) VALUES ('schema_version', '5');
+        ",
+    )
 }
 
 /// クリップボード履歴にコピー回数（copy_count）と初回コピー日時（first_copied_at）を追加する。

--- a/src-tauri/tests/api/clipboard_history.rs
+++ b/src-tauri/tests/api/clipboard_history.rs
@@ -23,9 +23,14 @@
 //     id: 存在しない最小値相当（0） / 負値 / 存在しない大きな値
 //
 // ホワイトボックス テスト設計:
-//   - ClipboardHistoryItem::from の全フィールド（id, text, char_count, copied_at）が
-//     ClipboardHistoryRow から漏れなくコピーされることを検証
+//   - ClipboardHistoryItem::from の全フィールド（id, text, char_count, copied_at,
+//     truncated, original_char_count）が ClipboardHistoryRow から漏れなく
+//     コピーされることを検証（issue #196）
 //   - list_clipboard_history はリポジトリの新しい順ソートをそのまま維持して返す
+//   - record_clipboard_history_recopy は insert_clipboard_history に常に
+//     original_char_count = None を渡すため、新規行では truncated = false 固定、
+//     既存行の move-to-top では既存の truncated / original_char_count を
+//     上書きしないことを検証（issue #196）
 
 #[cfg(test)]
 mod test_support {
@@ -63,6 +68,8 @@ mod clipboard_history_item_from {
             copied_at: "2026-07-14 12:00:00".to_string(),
             copy_count: 3,
             first_copied_at: "2026-07-01 09:00:00".to_string(),
+            truncated: false,
+            original_char_count: None,
         };
 
         let item: ClipboardHistoryItem = row.into();
@@ -73,6 +80,34 @@ mod clipboard_history_item_from {
         assert_eq!(item.copied_at, "2026-07-14 12:00:00");
         assert_eq!(item.copy_count, 3);
         assert_eq!(item.first_copied_at, "2026-07-01 09:00:00");
+        assert!(!item.truncated);
+        assert_eq!(item.original_char_count, None);
+    }
+
+    /// 同値クラス: truncated = true / original_char_count = Some(n) の行（issue #196）
+    /// truncated / original_char_count が漏れなくコピーされることを検証する
+    #[test]
+    fn maps_truncated_row_with_original_char_count() {
+        let row = ClipboardHistoryRow {
+            id: 43,
+            text: "truncated conte".to_string(),
+            char_count: 16,
+            copied_at: "2026-07-14 12:00:00".to_string(),
+            copy_count: 1,
+            first_copied_at: "2026-07-14 12:00:00".to_string(),
+            truncated: true,
+            original_char_count: Some(500),
+        };
+
+        let item: ClipboardHistoryItem = row.into();
+
+        assert_eq!(item.id, 43);
+        assert!(item.truncated, "truncated = true が正しくコピーされること");
+        assert_eq!(
+            item.original_char_count,
+            Some(500),
+            "original_char_count が正しくコピーされること"
+        );
     }
 
     /// 境界値: 空文字列・char_count = 0 の行も正しく変換される
@@ -85,6 +120,8 @@ mod clipboard_history_item_from {
             copied_at: "2026-07-14 00:00:00".to_string(),
             copy_count: 1,
             first_copied_at: "2026-07-14 00:00:00".to_string(),
+            truncated: false,
+            original_char_count: None,
         };
 
         let item: ClipboardHistoryItem = row.into();
@@ -93,6 +130,8 @@ mod clipboard_history_item_from {
         assert_eq!(item.char_count, 0);
         assert_eq!(item.copy_count, 1);
         assert_eq!(item.first_copied_at, "2026-07-14 00:00:00");
+        assert!(!item.truncated);
+        assert_eq!(item.original_char_count, None);
     }
 
     /// マルチバイト文字を含む行も文字列がそのまま保持される
@@ -105,6 +144,8 @@ mod clipboard_history_item_from {
             copied_at: "2026-07-14 09:30:00".to_string(),
             copy_count: 1,
             first_copied_at: "2026-07-14 09:30:00".to_string(),
+            truncated: false,
+            original_char_count: None,
         };
 
         let item: ClipboardHistoryItem = row.into();
@@ -113,6 +154,8 @@ mod clipboard_history_item_from {
         assert_eq!(item.char_count, 6);
         assert_eq!(item.copy_count, 1);
         assert_eq!(item.first_copied_at, "2026-07-14 09:30:00");
+        assert!(!item.truncated);
+        assert_eq!(item.original_char_count, None);
     }
 }
 
@@ -146,7 +189,7 @@ mod list_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "only one").unwrap();
+            insert_clipboard_history(&conn, "only one", None).unwrap();
         }
 
         let result = list_clipboard_history(app.handle().clone(), 10).unwrap();
@@ -164,9 +207,9 @@ mod list_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
-            insert_clipboard_history(&conn, "b").unwrap();
-            insert_clipboard_history(&conn, "c").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
+            insert_clipboard_history(&conn, "b", None).unwrap();
+            insert_clipboard_history(&conn, "c", None).unwrap();
         }
 
         let result = list_clipboard_history(app.handle().clone(), 10).unwrap();
@@ -184,7 +227,7 @@ mod list_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "x").unwrap();
+            insert_clipboard_history(&conn, "x", None).unwrap();
         }
 
         let result = list_clipboard_history(app.handle().clone(), 0).unwrap();
@@ -199,9 +242,9 @@ mod list_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
-            insert_clipboard_history(&conn, "b").unwrap();
-            insert_clipboard_history(&conn, "c").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
+            insert_clipboard_history(&conn, "b", None).unwrap();
+            insert_clipboard_history(&conn, "c", None).unwrap();
         }
 
         let result = list_clipboard_history(app.handle().clone(), 2).unwrap();
@@ -217,8 +260,8 @@ mod list_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
-            insert_clipboard_history(&conn, "b").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
+            insert_clipboard_history(&conn, "b", None).unwrap();
         }
 
         let result = list_clipboard_history(app.handle().clone(), 2).unwrap();
@@ -233,7 +276,7 @@ mod list_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
         }
 
         let result = list_clipboard_history(app.handle().clone(), 100).unwrap();
@@ -262,8 +305,8 @@ mod delete_clipboard_history_item {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "keep me").unwrap();
-            target_id = insert_clipboard_history(&conn, "delete me").unwrap();
+            insert_clipboard_history(&conn, "keep me", None).unwrap();
+            target_id = insert_clipboard_history(&conn, "delete me", None).unwrap();
         }
 
         delete_clipboard_history_item(app.handle().clone(), target_id).unwrap();
@@ -281,9 +324,9 @@ mod delete_clipboard_history_item {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            target_id = insert_clipboard_history(&conn, "a").unwrap();
-            insert_clipboard_history(&conn, "b").unwrap();
-            insert_clipboard_history(&conn, "c").unwrap();
+            target_id = insert_clipboard_history(&conn, "a", None).unwrap();
+            insert_clipboard_history(&conn, "b", None).unwrap();
+            insert_clipboard_history(&conn, "c", None).unwrap();
         }
 
         delete_clipboard_history_item(app.handle().clone(), target_id).unwrap();
@@ -311,7 +354,7 @@ mod delete_clipboard_history_item {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "untouched").unwrap();
+            insert_clipboard_history(&conn, "untouched", None).unwrap();
         }
 
         let result = delete_clipboard_history_item(app.handle().clone(), 0);
@@ -328,7 +371,7 @@ mod delete_clipboard_history_item {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "untouched").unwrap();
+            insert_clipboard_history(&conn, "untouched", None).unwrap();
         }
 
         let result = delete_clipboard_history_item(app.handle().clone(), -1);
@@ -358,9 +401,9 @@ mod clear_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
-            insert_clipboard_history(&conn, "b").unwrap();
-            insert_clipboard_history(&conn, "c").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
+            insert_clipboard_history(&conn, "b", None).unwrap();
+            insert_clipboard_history(&conn, "c", None).unwrap();
         }
 
         clear_clipboard_history(app.handle().clone()).unwrap();
@@ -390,7 +433,7 @@ mod clear_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "old").unwrap();
+            insert_clipboard_history(&conn, "old", None).unwrap();
         }
 
         clear_clipboard_history(app.handle().clone()).unwrap();
@@ -398,7 +441,7 @@ mod clear_clipboard_history {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "new").unwrap();
+            insert_clipboard_history(&conn, "new", None).unwrap();
         }
 
         let result = list_clipboard_history(app.handle().clone(), 10).unwrap();
@@ -419,6 +462,14 @@ mod clear_clipboard_history {
 //     既存テキストの再コピー（move-to-top 分岐） / 未知テキストの再コピー（新規 INSERT 分岐）
 //   [境界値分析]
 //     同一テキストを複数回連続で再コピー → copy_count が呼び出し回数分インクリメントされる
+//
+// （issue #196 追記）
+//   record_clipboard_history_recopy は insert_clipboard_history に常に
+//   original_char_count = None を渡す。そのため:
+//     - 新規 INSERT 分岐: 常に truncated = false, original_char_count = None で保存される
+//     - move-to-top 分岐: 引数の None は無視され、既存行の truncated /
+//       original_char_count がそのまま保持される（切り詰め済みエントリの再コピーで
+//       truncated フラグが誤って false にリセットされないこと）
 // ─────────────────────────────────────────────────────────────
 #[cfg(test)]
 mod record_clipboard_history_recopy {
@@ -438,7 +489,7 @@ mod record_clipboard_history_recopy {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "hello").unwrap();
+            insert_clipboard_history(&conn, "hello", None).unwrap();
         }
 
         record_clipboard_history_recopy(app.handle().clone(), "hello".to_string()).unwrap();
@@ -456,7 +507,7 @@ mod record_clipboard_history_recopy {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "repeat").unwrap();
+            insert_clipboard_history(&conn, "repeat", None).unwrap();
         }
 
         for _ in 0..3 {
@@ -481,6 +532,34 @@ mod record_clipboard_history_recopy {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].text, "brand new");
         assert_eq!(result[0].copy_count, 1);
+        assert!(
+            !result[0].truncated,
+            "新規行作成時、truncated は常に false であること"
+        );
+        assert_eq!(result[0].original_char_count, None);
+    }
+
+    /// 同値クラス: 既に truncated = true として保存されているエントリを再コピー
+    /// 期待値: record_clipboard_history_recopy が None を渡しても move-to-top では
+    /// 既存行の truncated / original_char_count が上書きされず、そのまま保持される
+    #[test]
+    fn recopy_of_already_truncated_entry_preserves_truncated_flag() {
+        let app = setup_mock_app_with_db();
+        {
+            let state = app.state::<DbConnection>();
+            let conn = state.0.lock().unwrap();
+            insert_clipboard_history(&conn, "was truncated", Some(999)).unwrap();
+        }
+
+        record_clipboard_history_recopy(app.handle().clone(), "was truncated".to_string()).unwrap();
+
+        let result = list_clipboard_history(app.handle().clone(), 10).unwrap();
+        assert_eq!(result.len(), 1, "行が増えず既存行が更新されること");
+        assert!(
+            result[0].truncated,
+            "recopy が None を渡しても、既存の truncated=true は move-to-top で保持されること"
+        );
+        assert_eq!(result[0].original_char_count, Some(999));
     }
 }
 

--- a/src-tauri/tests/api/clipboard_monitor.rs
+++ b/src-tauri/tests/api/clipboard_monitor.rs
@@ -31,6 +31,9 @@
 //     ② char_count <= max_chars → truncated=false（text.to_string() 経路）
 //     ③ char_count > max_chars → truncated=true（text.chars().take() 経路）
 //   - delete_oldest_clipboard_history が保存の都度呼ばれること（max_items 超過時に反映される）
+//   - （issue #196）truncated=true の場合のみ original_char_count = Some(切り詰め前の文字数)
+//     を repository::insert_clipboard_history に渡す分岐。SaveOutcome の戻り値だけでなく、
+//     DB に永続化された行の truncated / original_char_count も併せて検証する
 
 #[cfg(target_os = "macos")]
 mod save_clipboard_text {
@@ -174,6 +177,14 @@ mod save_clipboard_text {
         let conn = state.0.lock().unwrap();
         let rows = list_clipboard_history(&conn, 10).unwrap();
         assert_eq!(rows[0].text, text);
+        assert!(
+            !rows[0].truncated,
+            "max_chars ちょうどの場合、DB行の truncated は false であること"
+        );
+        assert_eq!(
+            rows[0].original_char_count, None,
+            "切り詰めが発生しない場合、DB行の original_char_count は None であること"
+        );
     }
 
     /// 文字数 = max_chars + 1（上限の直上）は先頭 max_chars 文字に切り詰めて保存される
@@ -198,6 +209,15 @@ mod save_clipboard_text {
         let rows = list_clipboard_history(&conn, 10).unwrap();
         assert_eq!(rows[0].text, "a".repeat(10));
         assert_eq!(rows[0].char_count, 10);
+        assert!(
+            rows[0].truncated,
+            "max_chars を超える場合、DB行の truncated は true であること"
+        );
+        assert_eq!(
+            rows[0].original_char_count,
+            Some(11),
+            "DB行の original_char_count は切り詰め前の文字数（11）であること"
+        );
     }
 
     // ── マルチバイト文字での「文字数」基準の切り詰め ────────
@@ -226,6 +246,12 @@ mod save_clipboard_text {
         let rows = list_clipboard_history(&conn, 10).unwrap();
         assert_eq!(rows[0].text, "あいう");
         assert_eq!(rows[0].text.chars().count(), 3);
+        assert!(rows[0].truncated);
+        assert_eq!(
+            rows[0].original_char_count,
+            Some(5),
+            "DB行の original_char_count は切り詰め前の文字数（5文字）であること"
+        );
     }
 
     /// 絵文字（4バイト/文字の Unicode スカラー値）テキストの切り詰めも文字数基準で
@@ -250,6 +276,12 @@ mod save_clipboard_text {
         let conn = state.0.lock().unwrap();
         let rows = list_clipboard_history(&conn, 10).unwrap();
         assert_eq!(rows[0].text, "🎉🎊");
+        assert!(rows[0].truncated);
+        assert_eq!(
+            rows[0].original_char_count,
+            Some(4),
+            "DB行の original_char_count は切り詰め前の文字数（4文字）であること"
+        );
     }
 
     /// 日本語テキストが max_chars 以内であれば切り詰められず、文字数もそのまま。
@@ -268,6 +300,15 @@ mod save_clipboard_text {
                 truncated: false,
             }
         );
+
+        let state = app.state::<DbConnection>();
+        let conn = state.0.lock().unwrap();
+        let rows = list_clipboard_history(&conn, 10).unwrap();
+        assert!(
+            !rows[0].truncated,
+            "max_chars 以内の場合、DB行の truncated は false であること"
+        );
+        assert_eq!(rows[0].original_char_count, None);
     }
 
     // ── 重複排除（リポジトリ層との統合） ─────────────────

--- a/src-tauri/tests/api/clipboard_settings.rs
+++ b/src-tauri/tests/api/clipboard_settings.rs
@@ -907,9 +907,9 @@ mod clear_history_on_quit_if_enabled {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
-            insert_clipboard_history(&conn, "b").unwrap();
-            insert_clipboard_history(&conn, "c").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
+            insert_clipboard_history(&conn, "b", None).unwrap();
+            insert_clipboard_history(&conn, "c", None).unwrap();
             assert_eq!(count_clipboard_history(&conn).unwrap(), 3);
         }
 
@@ -935,8 +935,8 @@ mod clear_history_on_quit_if_enabled {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
-            insert_clipboard_history(&conn, "b").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
+            insert_clipboard_history(&conn, "b", None).unwrap();
             assert_eq!(count_clipboard_history(&conn).unwrap(), 2);
         }
 
@@ -957,7 +957,7 @@ mod clear_history_on_quit_if_enabled {
         {
             let state = app.state::<DbConnection>();
             let conn = state.0.lock().unwrap();
-            insert_clipboard_history(&conn, "a").unwrap();
+            insert_clipboard_history(&conn, "a", None).unwrap();
         }
 
         let settings = ClipboardSettings {

--- a/src-tauri/tests/db/repository.rs
+++ b/src-tauri/tests/db/repository.rs
@@ -1293,7 +1293,7 @@ fn insert_clipboard_history_inserts_new_row_and_returns_id() {
     let conn = setup();
 
     // Act
-    let id = insert_clipboard_history(&conn, "hello").unwrap();
+    let id = insert_clipboard_history(&conn, "hello", None).unwrap();
 
     // Assert: 正のIDが返り、1件だけ登録されること
     assert!(id > 0);
@@ -1306,7 +1306,7 @@ fn insert_clipboard_history_computes_char_count_for_ascii() {
     let conn = setup();
 
     // Act
-    insert_clipboard_history(&conn, "hello").unwrap();
+    insert_clipboard_history(&conn, "hello", None).unwrap();
 
     // Assert: ASCII文字はバイト数と文字数が一致する
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1319,7 +1319,7 @@ fn insert_clipboard_history_computes_char_count_for_multibyte() {
     let conn = setup();
 
     // Act
-    insert_clipboard_history(&conn, "こんにちは").unwrap();
+    insert_clipboard_history(&conn, "こんにちは", None).unwrap();
 
     // Assert: char_count はバイト数ではなく chars().count() の文字数であること
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1335,7 +1335,7 @@ fn insert_clipboard_history_empty_string_is_allowed() {
     let conn = setup();
 
     // Act
-    let id = insert_clipboard_history(&conn, "").unwrap();
+    let id = insert_clipboard_history(&conn, "", None).unwrap();
 
     // Assert: 挿入が成功し char_count は 0
     assert!(id > 0);
@@ -1348,10 +1348,10 @@ fn insert_clipboard_history_empty_string_is_allowed() {
 fn insert_clipboard_history_deduplicates_consecutive_same_text() {
     // Arrange: 直前の履歴と同一テキストを連続で挿入
     let conn = setup();
-    let first_id = insert_clipboard_history(&conn, "same text").unwrap();
+    let first_id = insert_clipboard_history(&conn, "same text", None).unwrap();
 
     // Act
-    let second_id = insert_clipboard_history(&conn, "same text").unwrap();
+    let second_id = insert_clipboard_history(&conn, "same text", None).unwrap();
 
     // Assert: 新規行は作成されず、同じIDが返り、件数は1件のまま
     assert_eq!(second_id, first_id, "重複排除により同じIDが返ること");
@@ -1362,11 +1362,11 @@ fn insert_clipboard_history_deduplicates_consecutive_same_text() {
 fn insert_clipboard_history_deduplicates_three_consecutive_same_text() {
     // Arrange: 直前と同一のテキストを3回連続で挿入
     let conn = setup();
-    let id1 = insert_clipboard_history(&conn, "repeat").unwrap();
+    let id1 = insert_clipboard_history(&conn, "repeat", None).unwrap();
 
     // Act
-    let id2 = insert_clipboard_history(&conn, "repeat").unwrap();
-    let id3 = insert_clipboard_history(&conn, "repeat").unwrap();
+    let id2 = insert_clipboard_history(&conn, "repeat", None).unwrap();
+    let id3 = insert_clipboard_history(&conn, "repeat", None).unwrap();
 
     // Assert: すべて同じIDが返り、件数は1件のまま
     assert_eq!(id1, id2);
@@ -1394,7 +1394,7 @@ fn insert_clipboard_history_moves_non_consecutive_same_text_to_top() {
     insert_history_with_timestamp(&conn, "B", "2024-01-02 00:00:00");
 
     // Act
-    let id_a2 = insert_clipboard_history(&conn, "A").unwrap();
+    let id_a2 = insert_clipboard_history(&conn, "A", None).unwrap();
 
     // Assert: 新規行は作成されず、1回目のAと同じIDが返り、件数は2件（A, B）のまま
     assert_eq!(
@@ -1422,7 +1422,7 @@ fn insert_clipboard_history_moves_middle_entry_to_top() {
     assert_eq!(count_clipboard_history(&conn).unwrap(), 3);
 
     // Act: 中間に位置する "A" を再度挿入
-    let id_a_again = insert_clipboard_history(&conn, "A").unwrap();
+    let id_a_again = insert_clipboard_history(&conn, "A", None).unwrap();
 
     // Assert: 新規行は作成されず、中間にあったAの行がそのまま move-to-top されること
     assert_eq!(
@@ -1466,13 +1466,13 @@ fn insert_clipboard_history_repeated_reinsert_keeps_same_id_across_timings() {
     // insert_clipboard_history_moves_middle_entry_to_top（insert_history_with_timestamp で
     // 明示的な過去日時を与えて決定論的に検証）に譲り、本テストでは行わない。
     let conn = setup();
-    let id_x1 = insert_clipboard_history(&conn, "X").unwrap();
-    insert_clipboard_history(&conn, "Y").unwrap();
+    let id_x1 = insert_clipboard_history(&conn, "X", None).unwrap();
+    insert_clipboard_history(&conn, "Y", None).unwrap();
 
     // Act: X を再挿入（move-to-top） → 別テキスト挿入 → X を再々挿入
-    let id_x2 = insert_clipboard_history(&conn, "X").unwrap();
-    insert_clipboard_history(&conn, "Z").unwrap();
-    let id_x3 = insert_clipboard_history(&conn, "X").unwrap();
+    let id_x2 = insert_clipboard_history(&conn, "X", None).unwrap();
+    insert_clipboard_history(&conn, "Z", None).unwrap();
+    let id_x3 = insert_clipboard_history(&conn, "X", None).unwrap();
 
     // Assert: X の id は常に不変
     assert_eq!(id_x1, id_x2);
@@ -1486,7 +1486,7 @@ fn insert_clipboard_history_repeated_reinsert_keeps_same_id_across_timings() {
 fn insert_clipboard_history_new_row_uses_millisecond_precision_copied_at() {
     // Arrange & Act: 新規 INSERT 経路
     let conn = setup();
-    insert_clipboard_history(&conn, "precision check").unwrap();
+    insert_clipboard_history(&conn, "precision check", None).unwrap();
 
     // Assert: copied_at はミリ秒精度（小数点以下を含む）で記録されること。
     // SQLite の datetime('now') は秒精度のため、これに依存すると同一秒内の
@@ -1504,10 +1504,10 @@ fn insert_clipboard_history_new_row_uses_millisecond_precision_copied_at() {
 fn insert_clipboard_history_move_to_top_uses_millisecond_precision_copied_at() {
     // Arrange: 既存行を用意し、move-to-top（UPDATE）経路を実行する
     let conn = setup();
-    insert_clipboard_history(&conn, "A").unwrap();
+    insert_clipboard_history(&conn, "A", None).unwrap();
 
     // Act: 同一テキストの再挿入（既存行の copied_at を UPDATE）
-    insert_clipboard_history(&conn, "A").unwrap();
+    insert_clipboard_history(&conn, "A", None).unwrap();
 
     // Assert: move-to-top による UPDATE 後の copied_at もミリ秒精度であること
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1536,7 +1536,7 @@ fn insert_clipboard_history_move_to_top_uses_millisecond_precision_copied_at() {
 fn insert_clipboard_history_new_row_sets_copy_count_to_one() {
     // Arrange & Act: 新規テキストの挿入
     let conn = setup();
-    insert_clipboard_history(&conn, "new item").unwrap();
+    insert_clipboard_history(&conn, "new item", None).unwrap();
 
     // Assert: 新規挿入時は copy_count が 1 であること
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1547,7 +1547,7 @@ fn insert_clipboard_history_new_row_sets_copy_count_to_one() {
 fn insert_clipboard_history_new_row_first_copied_at_equals_copied_at() {
     // Arrange & Act: 新規テキストの挿入
     let conn = setup();
-    insert_clipboard_history(&conn, "new item").unwrap();
+    insert_clipboard_history(&conn, "new item", None).unwrap();
 
     // Assert: 新規挿入時は first_copied_at が copied_at と一致すること
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1561,9 +1561,9 @@ fn insert_clipboard_history_new_row_first_copied_at_equals_copied_at() {
 fn insert_clipboard_history_repeated_insert_increments_copy_count_by_insertion_count() {
     // Arrange & Act: 同一テキストを3回挿入（1回目は新規、2・3回目は move-to-top）
     let conn = setup();
-    insert_clipboard_history(&conn, "repeat").unwrap();
-    insert_clipboard_history(&conn, "repeat").unwrap();
-    insert_clipboard_history(&conn, "repeat").unwrap();
+    insert_clipboard_history(&conn, "repeat", None).unwrap();
+    insert_clipboard_history(&conn, "repeat", None).unwrap();
+    insert_clipboard_history(&conn, "repeat", None).unwrap();
 
     // Assert: 挿入回数分 copy_count がインクリメントされること（3回挿入で copy_count=3）
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1575,7 +1575,7 @@ fn insert_clipboard_history_repeated_insert_increments_copy_count_by_insertion_c
 fn insert_clipboard_history_move_to_top_keeps_first_copied_at_but_updates_copied_at() {
     // Arrange: 初回挿入後、copied_at / first_copied_at を過去日時に固定する
     let conn = setup();
-    let id = insert_clipboard_history(&conn, "history item").unwrap();
+    let id = insert_clipboard_history(&conn, "history item", None).unwrap();
     conn.execute(
         "UPDATE clipboard_history SET copied_at = '2020-01-01 00:00:00.000', \
          first_copied_at = '2020-01-01 00:00:00.000' WHERE id = ?1",
@@ -1585,7 +1585,7 @@ fn insert_clipboard_history_move_to_top_keeps_first_copied_at_but_updates_copied
 
     // Act: move-to-top（copy_count のみインクリメントされ、first_copied_at は
     // 更新されない実装であることを検証する）
-    insert_clipboard_history(&conn, "history item").unwrap();
+    insert_clipboard_history(&conn, "history item", None).unwrap();
 
     // Assert: first_copied_at は固定した過去日時のまま変化しないこと
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1613,7 +1613,7 @@ fn insert_clipboard_history_move_to_top_keeps_first_copied_at_but_updates_copied
 fn insert_clipboard_history_copy_count_reaches_cap_at_five_insertions() {
     let conn = setup();
     for _ in 0..5 {
-        insert_clipboard_history(&conn, "capped").unwrap();
+        insert_clipboard_history(&conn, "capped", None).unwrap();
     }
 
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1627,7 +1627,7 @@ fn insert_clipboard_history_copy_count_reaches_cap_at_five_insertions() {
 fn insert_clipboard_history_copy_count_does_not_exceed_cap_beyond_five_insertions() {
     let conn = setup();
     for _ in 0..10 {
-        insert_clipboard_history(&conn, "capped").unwrap();
+        insert_clipboard_history(&conn, "capped", None).unwrap();
     }
 
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1645,7 +1645,7 @@ fn insert_clipboard_history_copy_count_does_not_exceed_cap_beyond_five_insertion
 fn insert_clipboard_history_still_updates_copied_at_after_copy_count_capped() {
     let conn = setup();
     for _ in 0..5 {
-        insert_clipboard_history(&conn, "capped and fresh").unwrap();
+        insert_clipboard_history(&conn, "capped and fresh", None).unwrap();
     }
     let rows = list_clipboard_history(&conn, 10).unwrap();
     assert_eq!(rows[0].copy_count, 5);
@@ -1657,7 +1657,7 @@ fn insert_clipboard_history_still_updates_copied_at_after_copy_count_capped() {
         [],
     )
     .unwrap();
-    insert_clipboard_history(&conn, "capped and fresh").unwrap();
+    insert_clipboard_history(&conn, "capped and fresh", None).unwrap();
 
     let rows = list_clipboard_history(&conn, 10).unwrap();
     assert_eq!(
@@ -1668,6 +1668,132 @@ fn insert_clipboard_history_still_updates_copied_at_after_copy_count_capped() {
         rows[0].copied_at, "2020-01-01 00:00:00.000",
         "copy_count が上限でも copied_at は move-to-top で更新され続けること"
     );
+}
+
+// ── truncated / original_char_count（issue #196: 切り詰められたエントリの識別）──
+//
+// ブラックボックス テスト設計:
+//   [同値分割]
+//     有効クラス①: original_char_count = Some(n) を渡す新規挿入 →
+//                   truncated = true, original_char_count = Some(n)
+//     有効クラス②: original_char_count = None を渡す新規挿入 →
+//                   truncated = false, original_char_count = None
+//     有効クラス③: 既存テキストへの move-to-top 時に渡された original_char_count
+//                   引数は無視され、初回 INSERT 時点の値がそのまま保持される
+//   [境界値分析]
+//     original_char_count = Some(0)（Option の内部値としての境界値）
+//
+// ホワイトボックス テスト設計:
+//   - insert_clipboard_history の新規 INSERT 分岐で
+//     `truncated = original_char_count.is_some()` の計算式どおりに動作することを検証
+//   - move-to-top（既存行 UPDATE）分岐では、引数で渡された original_char_count を
+//     一切参照せず既存行の値を保持することを検証（true→true, false→false の両方）
+
+#[test]
+fn insert_clipboard_history_with_original_char_count_sets_truncated_true() {
+    // Arrange & Act: 切り詰め発生を示す original_char_count を渡して新規挿入
+    let conn = setup();
+    insert_clipboard_history(&conn, "truncated text", Some(500)).unwrap();
+
+    // Assert
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert!(
+        rows[0].truncated,
+        "original_char_count を渡した新規挿入は truncated = true になること"
+    );
+    assert_eq!(rows[0].original_char_count, Some(500));
+}
+
+#[test]
+fn insert_clipboard_history_without_original_char_count_sets_truncated_false() {
+    // Arrange & Act: original_char_count = None（切り詰めなし）で新規挿入
+    let conn = setup();
+    insert_clipboard_history(&conn, "not truncated", None).unwrap();
+
+    // Assert
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert!(
+        !rows[0].truncated,
+        "original_char_count を渡さない新規挿入は truncated = false になること"
+    );
+    assert_eq!(rows[0].original_char_count, None);
+}
+
+#[test]
+fn insert_clipboard_history_original_char_count_zero_is_allowed() {
+    // 境界値: original_char_count = Some(0)。実運用では発生しにくいが、
+    // Option<i64> の内部値として 0 も正しく Some として扱われることを確認する
+    let conn = setup();
+    insert_clipboard_history(&conn, "edge", Some(0)).unwrap();
+
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert!(
+        rows[0].truncated,
+        "Some(0) でも Some である以上 truncated = true になること"
+    );
+    assert_eq!(rows[0].original_char_count, Some(0));
+}
+
+#[test]
+fn insert_clipboard_history_move_to_top_preserves_truncated_state() {
+    // Arrange: 初回は切り詰めあり（Some(500)）で保存
+    let conn = setup();
+    let first_id = insert_clipboard_history(&conn, "preserved", Some(500)).unwrap();
+
+    // Act: 2回目は再コピー相当で None を渡す
+    // （record_clipboard_history_recopy が常に None を渡すのと同じ呼び出し方）
+    let second_id = insert_clipboard_history(&conn, "preserved", None).unwrap();
+
+    // Assert: move-to-top のため同じ行が更新され、初回の truncated /
+    // original_char_count が変更されずに保持されること（2回目に渡した None は無視される）
+    assert_eq!(second_id, first_id, "move-to-top のため同じIDが返ること");
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0].truncated,
+        "move-to-top では引数の original_char_count を無視し、既存行の値が保持されること"
+    );
+    assert_eq!(rows[0].original_char_count, Some(500));
+}
+
+#[test]
+fn insert_clipboard_history_move_to_top_preserves_untruncated_state() {
+    // Arrange: 初回は切り詰めなし（None）で保存
+    let conn = setup();
+    let first_id = insert_clipboard_history(&conn, "still not truncated", None).unwrap();
+
+    // Act: 2回目に Some を渡しても、move-to-top では無視される
+    let second_id = insert_clipboard_history(&conn, "still not truncated", Some(999)).unwrap();
+
+    // Assert
+    assert_eq!(second_id, first_id, "move-to-top のため同じIDが返ること");
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+    assert!(
+        !rows[0].truncated,
+        "move-to-top では2回目に Some を渡しても既存行の truncated=false が保持されること"
+    );
+    assert_eq!(rows[0].original_char_count, None);
+}
+
+#[test]
+fn list_clipboard_history_returns_truncated_and_original_char_count_fields() {
+    // Arrange: 切り詰めあり/なしの2行を挿入
+    let conn = setup();
+    insert_history_with_timestamp(&conn, "not truncated", "2024-01-01 00:00:00");
+    insert_clipboard_history(&conn, "truncated", Some(1000)).unwrap();
+
+    // Act
+    let rows = list_clipboard_history(&conn, 10).unwrap();
+
+    // Assert
+    assert_eq!(rows.len(), 2);
+    let truncated_row = rows.iter().find(|r| r.text == "truncated").unwrap();
+    assert!(truncated_row.truncated);
+    assert_eq!(truncated_row.original_char_count, Some(1000));
+
+    let not_truncated_row = rows.iter().find(|r| r.text == "not truncated").unwrap();
+    assert!(!not_truncated_row.truncated);
+    assert_eq!(not_truncated_row.original_char_count, None);
 }
 
 // ── list_clipboard_history ────────────────────────────────────
@@ -1688,7 +1814,7 @@ fn list_clipboard_history_returns_empty_for_empty_table() {
 fn list_clipboard_history_limit_zero_returns_empty() {
     // Arrange: limit の最小境界値 0
     let conn = setup();
-    insert_clipboard_history(&conn, "x").unwrap();
+    insert_clipboard_history(&conn, "x", None).unwrap();
 
     // Act
     let rows = list_clipboard_history(&conn, 0).unwrap();
@@ -1701,9 +1827,9 @@ fn list_clipboard_history_limit_zero_returns_empty() {
 fn list_clipboard_history_respects_limit_less_than_total() {
     // Arrange: 3件登録し、limit=2 で取得
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
-    insert_clipboard_history(&conn, "c").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
+    insert_clipboard_history(&conn, "c", None).unwrap();
 
     // Act
     let rows = list_clipboard_history(&conn, 2).unwrap();
@@ -1716,9 +1842,9 @@ fn list_clipboard_history_respects_limit_less_than_total() {
 fn list_clipboard_history_limit_equal_to_total_returns_all() {
     // Arrange: 3件登録し、limit=3（総数と同じ）で取得
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
-    insert_clipboard_history(&conn, "c").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
+    insert_clipboard_history(&conn, "c", None).unwrap();
 
     // Act
     let rows = list_clipboard_history(&conn, 3).unwrap();
@@ -1731,8 +1857,8 @@ fn list_clipboard_history_limit_equal_to_total_returns_all() {
 fn list_clipboard_history_limit_greater_than_total_returns_all() {
     // Arrange: 2件登録し、limit=100（総数より大きい）で取得
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
 
     // Act
     let rows = list_clipboard_history(&conn, 100).unwrap();
@@ -1781,7 +1907,7 @@ fn list_clipboard_history_tie_breaks_by_id_desc_when_copied_at_equal() {
 fn list_clipboard_history_returns_correct_fields() {
     // Arrange
     let conn = setup();
-    insert_clipboard_history(&conn, "field check").unwrap();
+    insert_clipboard_history(&conn, "field check", None).unwrap();
 
     // Act
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1797,7 +1923,7 @@ fn list_clipboard_history_returns_correct_fields() {
 fn list_clipboard_history_returns_copy_count_and_first_copied_at() {
     // Arrange: 新規挿入行（issue #195 で追加された copy_count / first_copied_at）
     let conn = setup();
-    insert_clipboard_history(&conn, "heat bar field check").unwrap();
+    insert_clipboard_history(&conn, "heat bar field check", None).unwrap();
 
     // Act
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1812,8 +1938,8 @@ fn list_clipboard_history_returns_copy_count_and_first_copied_at() {
 fn list_clipboard_history_returns_incremented_copy_count_after_move_to_top() {
     // Arrange: move-to-top を経由して copy_count がインクリメントされた行
     let conn = setup();
-    insert_clipboard_history(&conn, "incremented").unwrap();
-    insert_clipboard_history(&conn, "incremented").unwrap();
+    insert_clipboard_history(&conn, "incremented", None).unwrap();
+    insert_clipboard_history(&conn, "incremented", None).unwrap();
 
     // Act
     let rows = list_clipboard_history(&conn, 10).unwrap();
@@ -1829,7 +1955,7 @@ fn list_clipboard_history_returns_incremented_copy_count_after_move_to_top() {
 fn delete_clipboard_history_removes_existing_row() {
     // Arrange
     let conn = setup();
-    let id = insert_clipboard_history(&conn, "to delete").unwrap();
+    let id = insert_clipboard_history(&conn, "to delete", None).unwrap();
 
     // Act
     delete_clipboard_history(&conn, id).unwrap();
@@ -1852,8 +1978,8 @@ fn delete_clipboard_history_on_nonexistent_id_does_not_error() {
 fn delete_clipboard_history_only_removes_target() {
     // Arrange: 2件登録し、片方だけ削除する
     let conn = setup();
-    let id1 = insert_clipboard_history(&conn, "keep_me").unwrap();
-    let id2 = insert_clipboard_history(&conn, "delete_me").unwrap();
+    let id1 = insert_clipboard_history(&conn, "keep_me", None).unwrap();
+    let id2 = insert_clipboard_history(&conn, "delete_me", None).unwrap();
 
     // Act: id2 だけ削除
     delete_clipboard_history(&conn, id2).unwrap();
@@ -1871,9 +1997,9 @@ fn delete_clipboard_history_only_removes_target() {
 fn clear_clipboard_history_removes_all_rows() {
     // Arrange
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
-    insert_clipboard_history(&conn, "c").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
+    insert_clipboard_history(&conn, "c", None).unwrap();
 
     // Act
     clear_clipboard_history(&conn).unwrap();
@@ -1909,8 +2035,8 @@ fn count_clipboard_history_returns_zero_for_empty_table() {
 fn count_clipboard_history_returns_correct_count() {
     // Arrange
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
 
     // Act & Assert
     assert_eq!(count_clipboard_history(&conn).unwrap(), 2);
@@ -1920,10 +2046,10 @@ fn count_clipboard_history_returns_correct_count() {
 fn count_clipboard_history_unchanged_after_duplicate_insert() {
     // Arrange: 直前と同一テキストの挿入は重複排除されカウントが増えない
     let conn = setup();
-    insert_clipboard_history(&conn, "dup").unwrap();
+    insert_clipboard_history(&conn, "dup", None).unwrap();
 
     // Act
-    insert_clipboard_history(&conn, "dup").unwrap();
+    insert_clipboard_history(&conn, "dup", None).unwrap();
 
     // Assert
     assert_eq!(count_clipboard_history(&conn).unwrap(), 1);
@@ -1935,8 +2061,8 @@ fn count_clipboard_history_unchanged_after_duplicate_insert() {
 fn delete_oldest_clipboard_history_keep_count_zero_deletes_all() {
     // Arrange: keep_count の最小境界値 0
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
 
     // Act
     delete_oldest_clipboard_history(&conn, 0).unwrap();
@@ -1969,9 +2095,9 @@ fn delete_oldest_clipboard_history_keeps_newest_n_rows() {
 fn delete_oldest_clipboard_history_keep_count_equal_to_total_keeps_all() {
     // Arrange: keep_count と総件数が一致する境界値
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
-    insert_clipboard_history(&conn, "c").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
+    insert_clipboard_history(&conn, "c", None).unwrap();
 
     // Act
     delete_oldest_clipboard_history(&conn, 3).unwrap();
@@ -1984,8 +2110,8 @@ fn delete_oldest_clipboard_history_keep_count_equal_to_total_keeps_all() {
 fn delete_oldest_clipboard_history_keep_count_greater_than_total_keeps_all() {
     // Arrange: keep_count が総件数より大きい境界値
     let conn = setup();
-    insert_clipboard_history(&conn, "a").unwrap();
-    insert_clipboard_history(&conn, "b").unwrap();
+    insert_clipboard_history(&conn, "a", None).unwrap();
+    insert_clipboard_history(&conn, "b", None).unwrap();
 
     // Act
     delete_oldest_clipboard_history(&conn, 100).unwrap();

--- a/src-tauri/tests/db/schema.rs
+++ b/src-tauri/tests/db/schema.rs
@@ -52,7 +52,7 @@ fn schema_version_is_set() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn apply_migrations_is_idempotent() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 }
 
 // ── v3: clipboard_history テーブルのテスト ─────────────────────
@@ -402,8 +402,10 @@ fn migrate_v4_multiple_existing_rows_are_all_backfilled() {
 }
 
 #[test]
-fn migrate_v4_applied_from_v3_updates_schema_version_to_4() {
+fn apply_migrations_from_v3_updates_schema_version_to_5() {
     // Arrange: schema_version = 3（境界値: 0件のbackfill対象ではなく1件のみ）
+    // apply_migrations は version を1回だけ読み取り、それ以降の全マイグレーション
+    // （v4, v5）を1回の呼び出しでまとめて適用するため、最終的に最新版（5）になる
     let conn = v3_conn_with_row("v", 1, "2025-01-01 00:00:00.000");
 
     // Act
@@ -417,13 +419,14 @@ fn migrate_v4_applied_from_v3_updates_schema_version_to_4() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 }
 
 #[test]
 fn apply_migrations_from_v3_is_idempotent() {
     // v3 相当の状態から apply_migrations を複数回呼んでもエラーにならないこと
-    // （migrate_v4 の ALTER TABLE がスキーマバージョンガードにより再実行されないこと）
+    // （migrate_v4 / migrate_v5 の ALTER TABLE がスキーマバージョンガードにより
+    // 再実行されないこと）
     let conn = v3_conn_with_row("idem", 4, "2025-01-01 00:00:00.000");
 
     apply_migrations(&conn).unwrap();
@@ -441,5 +444,301 @@ fn apply_migrations_from_v3_is_idempotent() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
+}
+
+// ── v5: clipboard_history への truncated / original_char_count 追加マイグレーションのテスト
+//    （issue #196: 切り詰められたエントリの識別）───────────────────
+//
+// テスト対象: migrate_v5 で追加される truncated（DEFAULT 0）/ original_char_count
+// （NULL可）カラムと、既存データ（v4 スキーマ相当）に対する truncated の backfill 処理
+//
+// ブラックボックス テスト設計:
+//   [同値分割]
+//     有効クラス①: truncated / original_char_count を指定しない INSERT →
+//                   DEFAULT 0 / NULL が適用される
+//     有効クラス②: truncated / original_char_count を明示指定した INSERT →
+//                   指定値がそのまま入る
+//     有効クラス③: マイグレーション適用前（v4 相当）に存在した行 → truncated が
+//                   0 で backfill され、original_char_count は NULL のまま
+//   [境界値分析]
+//     backfill 対象行が 1 件 / 複数件
+//
+// ホワイトボックス テスト設計:
+//   - apply_migrations を schema_version = 4 の状態から呼び出すと migrate_v5 のみが
+//     実行される分岐を通ることを検証する
+//   - apply_migrations は v4 → v5 の部分適用後も冪等であること（重複 ALTER TABLE で
+//     エラーにならないこと）
+
+/// v4 スキーマ相当（truncated / original_char_count カラムがまだ存在しない状態）を
+/// 手動で構築し、1行だけ登録した Connection を返す。
+/// migrate_v1〜v4 は private のため直接呼べず、apply_migrations 経由では一気に
+/// 最新版まで進んでしまうため、ここでは v4 相当のテーブル定義を直接実行して
+/// schema_version を 4 に設定する。
+fn v4_conn_with_row(
+    text: &str,
+    char_count: i64,
+    copied_at: &str,
+    copy_count: i64,
+    first_copied_at: &str,
+) -> Connection {
+    let conn = in_memory_conn();
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS schema_meta (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE clipboard_history (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            text            TEXT NOT NULL,
+            char_count      INTEGER NOT NULL,
+            copied_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+            copy_count      INTEGER NOT NULL DEFAULT 1,
+            first_copied_at TEXT
+        );
+        INSERT OR REPLACE INTO schema_meta(key, value) VALUES ('schema_version', '4');
+        ",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count, copied_at, copy_count, first_copied_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![text, char_count, copied_at, copy_count, first_copied_at],
+    )
+    .unwrap();
+    conn
+}
+
+#[test]
+fn apply_migrations_adds_truncated_and_original_char_count_columns() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(clipboard_history)")
+        .unwrap();
+    let columns: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert!(
+        columns.contains(&"truncated".to_string()),
+        "truncated カラムが追加されること"
+    );
+    assert!(
+        columns.contains(&"original_char_count".to_string()),
+        "original_char_count カラムが追加されること"
+    );
+}
+
+#[test]
+fn clipboard_history_truncated_defaults_to_zero_when_omitted() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count, first_copied_at) \
+         VALUES ('abc', 3, '2026-01-01 00:00:00.000')",
+        [],
+    )
+    .unwrap();
+
+    let truncated: i64 = conn
+        .query_row(
+            "SELECT truncated FROM clipboard_history WHERE text = 'abc'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        truncated, 0,
+        "truncated を指定しない INSERT では DEFAULT 0 が適用されること"
+    );
+}
+
+#[test]
+fn clipboard_history_original_char_count_defaults_to_null_when_omitted() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count, first_copied_at) \
+         VALUES ('abc', 3, '2026-01-01 00:00:00.000')",
+        [],
+    )
+    .unwrap();
+
+    let original_char_count: Option<i64> = conn
+        .query_row(
+            "SELECT original_char_count FROM clipboard_history WHERE text = 'abc'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        original_char_count.is_none(),
+        "original_char_count は NULL 許容でありデフォルト値が設定されないこと"
+    );
+}
+
+#[test]
+fn clipboard_history_truncated_and_original_char_count_can_be_set_explicitly() {
+    let conn = in_memory_conn();
+    apply_migrations(&conn).unwrap();
+
+    conn.execute(
+        "INSERT INTO clipboard_history \
+         (text, char_count, first_copied_at, truncated, original_char_count) \
+         VALUES ('xyz', 200, '2026-01-01 00:00:00.000', 1, 500)",
+        [],
+    )
+    .unwrap();
+
+    let (truncated, original_char_count): (i64, i64) = conn
+        .query_row(
+            "SELECT truncated, original_char_count FROM clipboard_history WHERE text = 'xyz'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        truncated, 1,
+        "truncated を明示指定した場合はその値が入ること"
+    );
+    assert_eq!(
+        original_char_count, 500,
+        "original_char_count を明示指定した場合はその値が入ること"
+    );
+}
+
+#[test]
+fn migrate_v5_backfills_truncated_zero_for_existing_row() {
+    // Arrange: v4 相当のスキーマ・データ（truncated / original_char_count カラムが
+    // まだ存在しない状態）
+    let conn = v4_conn_with_row(
+        "legacy",
+        6,
+        "2025-06-01 10:00:00.000",
+        1,
+        "2025-06-01 10:00:00.000",
+    );
+
+    // Act: schema_version=4 から apply_migrations を呼ぶと migrate_v5 のみが実行される
+    apply_migrations(&conn).unwrap();
+
+    // Assert: 既存行の truncated は 0 で backfill され、original_char_count は
+    // 過去の切り詰め有無が判別できないため NULL のままであること
+    let (truncated, original_char_count): (i64, Option<i64>) = conn
+        .query_row(
+            "SELECT truncated, original_char_count FROM clipboard_history WHERE text = 'legacy'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        truncated, 0,
+        "既存行の truncated は 0 で backfill されること"
+    );
+    assert!(
+        original_char_count.is_none(),
+        "既存行の original_char_count は NULL のままであること"
+    );
+}
+
+#[test]
+fn migrate_v5_multiple_existing_rows_are_all_backfilled_with_truncated_zero() {
+    // Arrange: 複数行が存在する v4 相当データ（境界値: 1件 → 複数件）
+    let conn = v4_conn_with_row(
+        "row1",
+        4,
+        "2025-01-01 00:00:00.000",
+        1,
+        "2025-01-01 00:00:00.000",
+    );
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count, copied_at, copy_count, first_copied_at) \
+         VALUES ('row2', 4, '2025-01-02 00:00:00.000', 1, '2025-01-02 00:00:00.000')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clipboard_history (text, char_count, copied_at, copy_count, first_copied_at) \
+         VALUES ('row3', 4, '2025-01-03 00:00:00.000', 1, '2025-01-03 00:00:00.000')",
+        [],
+    )
+    .unwrap();
+
+    // Act
+    apply_migrations(&conn).unwrap();
+
+    // Assert: 全行が truncated = 0 で backfill されること（0 以外の行が残らない）
+    let non_zero_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM clipboard_history WHERE truncated != 0",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        non_zero_count, 0,
+        "全ての既存行の truncated が 0 で backfill されること"
+    );
+}
+
+#[test]
+fn apply_migrations_from_v4_updates_schema_version_to_5() {
+    // Arrange: schema_version = 4
+    let conn = v4_conn_with_row(
+        "v",
+        1,
+        "2025-01-01 00:00:00.000",
+        1,
+        "2025-01-01 00:00:00.000",
+    );
+
+    // Act
+    apply_migrations(&conn).unwrap();
+
+    // Assert
+    let version: i64 = conn
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM schema_meta WHERE key = 'schema_version'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(version, 5);
+}
+
+#[test]
+fn apply_migrations_from_v4_is_idempotent() {
+    // v4 相当の状態から apply_migrations を複数回呼んでもエラーにならないこと
+    // （migrate_v5 の ALTER TABLE がスキーマバージョンガードにより再実行されないこと）
+    let conn = v4_conn_with_row(
+        "idem",
+        4,
+        "2025-01-01 00:00:00.000",
+        1,
+        "2025-01-01 00:00:00.000",
+    );
+
+    apply_migrations(&conn).unwrap();
+    let result = apply_migrations(&conn);
+
+    assert!(
+        result.is_ok(),
+        "v4 から適用後、再度 apply_migrations を呼んでもエラーにならないこと"
+    );
+
+    let version: i64 = conn
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM schema_meta WHERE key = 'schema_version'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(version, 5);
 }

--- a/src/components/atoms/icons/index.tsx
+++ b/src/components/atoms/icons/index.tsx
@@ -117,6 +117,17 @@ export const MinusIcon = (p: IconProps) => (
   </StrokeIcon>
 )
 
+/** ハサミ（切り詰め表示用） */
+export const ScissorsIcon = (p: IconProps) => (
+  <StrokeIcon size={9} {...p}>
+    <circle cx='6' cy='6' r='3' />
+    <circle cx='6' cy='18' r='3' />
+    <line x1='20' y1='4' x2='8.12' y2='15.88' />
+    <line x1='14.47' y1='14.48' x2='20' y2='20' />
+    <line x1='8.12' y1='8.12' x2='12' y2='12' />
+  </StrokeIcon>
+)
+
 /** ロック（施錠） */
 export const LockIcon = (p: IconProps) => (
   <StrokeIcon size={9} strokeWidth={2.4} {...p}>

--- a/src/components/molecules/HistoryItemRow.tsx
+++ b/src/components/molecules/HistoryItemRow.tsx
@@ -9,6 +9,7 @@ import {
   CheckIcon,
   CopyIcon,
   PencilIcon,
+  ScissorsIcon,
   TrashIcon,
 } from '@/components/atoms/icons'
 import {
@@ -16,6 +17,8 @@ import {
   getCommandBoxSx,
   getCommandTextSx,
   getNumberHintTextSx,
+  getTruncatedInfoRowSx,
+  getTruncatedInfoTextSx,
   numberHintBoxSx,
 } from '@/components/molecules/commandFieldStyles'
 import { HeatBarColorId, historyHeat } from '@/constants/heatPalette'
@@ -39,6 +42,12 @@ export type HistoryItemRowProps = {
   lastCopiedAt?: string
   /** Preferences → Clipboard History の Heat bar color 設定 */
   heatColor?: HeatBarColorId
+  /** 保存時に Maximum characters to save で切り詰められたか（DB の truncated） */
+  truncated?: boolean
+  /** 保存済みの文字数（DB の char_count。切り詰め表示の分子に使う） */
+  charCount?: number
+  /** 切り詰め前の元テキストの文字数（DB の original_char_count） */
+  originalCharCount?: number
 }
 
 /**
@@ -49,6 +58,8 @@ export type HistoryItemRowProps = {
  * 見た目のスタイルは commandFieldStyles で CommandField と共有している。
  * コピー回数に応じたヒートバー（左端の inset shadow + 行背景ティント）を描画し、
  * ホバー時にコピー回数・初回/最終コピー日時を表示するツールチップを出す（issue #195）。
+ * 保存時に Maximum characters to save で切り詰められた行には、テキスト本文の下に
+ * 「保存文字数 / 元の文字数」を常時表示する（issue #196）。
  */
 export const HistoryItemRow = forwardRef<HTMLDivElement, HistoryItemRowProps>(
   (
@@ -63,6 +74,9 @@ export const HistoryItemRow = forwardRef<HTMLDivElement, HistoryItemRowProps>(
       firstCopiedAt,
       lastCopiedAt,
       heatColor = 'none',
+      truncated = false,
+      charCount,
+      originalCharCount,
     },
     ref,
   ) => {
@@ -132,9 +146,8 @@ export const HistoryItemRow = forwardRef<HTMLDivElement, HistoryItemRowProps>(
               cursor: editMode ? 'default' : 'pointer',
               transition: 'all 0.14s ease',
               display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              gap: 1,
+              flexDirection: 'column',
+              gap: '4px',
               outline: 'none',
               flex: 1,
               minWidth: 0,
@@ -152,24 +165,53 @@ export const HistoryItemRow = forwardRef<HTMLDivElement, HistoryItemRowProps>(
               }
             }}
           >
-            <Typography
-              sx={getCommandTextSx(theme, { isMultiLine, hasDone: hasCopied })}
-            >
-              {text}
-            </Typography>
             <Box
-              sx={getActionIconBoxSx(theme, {
-                hasDone: hasCopied,
-                isFocused,
-                isHovered,
-              })}
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
+                gap: 1,
+              }}
             >
-              {hasCopied ? (
-                <CheckIcon size={11} strokeWidth={2.5} />
-              ) : (
-                <CopyIcon size={11} strokeWidth={2} />
-              )}
+              <Typography
+                sx={getCommandTextSx(theme, {
+                  isMultiLine,
+                  hasDone: hasCopied,
+                })}
+              >
+                {text}
+              </Typography>
+              <Box
+                sx={getActionIconBoxSx(theme, {
+                  hasDone: hasCopied,
+                  isFocused,
+                  isHovered,
+                })}
+              >
+                {hasCopied ? (
+                  <CheckIcon size={11} strokeWidth={2.5} />
+                ) : (
+                  <CopyIcon size={11} strokeWidth={2} />
+                )}
+              </Box>
             </Box>
+
+            {/* 切り詰めメタ情報行（保存文字数 / 元の文字数） */}
+            {truncated && !hasCopied && (
+              <Box sx={getTruncatedInfoRowSx(theme)}>
+                <ScissorsIcon size={9} strokeWidth={2} />
+                <Typography sx={getTruncatedInfoTextSx(theme)}>
+                  <Typography
+                    component='span'
+                    sx={{ fontWeight: 700, color: theme.palette.amber.text }}
+                  >
+                    {(charCount ?? 0).toLocaleString('en-US')}
+                  </Typography>
+                  {' / '}
+                  {(originalCharCount ?? 0).toLocaleString('en-US')}
+                </Typography>
+              </Box>
+            )}
           </Box>
         </Tooltip>
 

--- a/src/components/molecules/HistoryItemRow.tsx
+++ b/src/components/molecules/HistoryItemRow.tsx
@@ -201,12 +201,7 @@ export const HistoryItemRow = forwardRef<HTMLDivElement, HistoryItemRowProps>(
               <Box sx={getTruncatedInfoRowSx(theme)}>
                 <ScissorsIcon size={9} strokeWidth={2} />
                 <Typography sx={getTruncatedInfoTextSx(theme)}>
-                  <Typography
-                    component='span'
-                    sx={{ fontWeight: 700, color: theme.palette.amber.text }}
-                  >
-                    {(charCount ?? 0).toLocaleString('en-US')}
-                  </Typography>
+                  {(charCount ?? 0).toLocaleString('en-US')}
                   {' / '}
                   {(originalCharCount ?? 0).toLocaleString('en-US')}
                 </Typography>

--- a/src/components/molecules/commandFieldStyles.ts
+++ b/src/components/molecules/commandFieldStyles.ts
@@ -108,6 +108,29 @@ export function getCommandTextSx(
   } as const
 }
 
+/**
+ * クリップボード履歴の切り詰めメタ情報行（issue #196）のスタイル。
+ * v19 mockup の「案D — メタ情報行」に準拠し、テキスト本文の下に dashed の区切り線を
+ * 挟んで表示する。色は既存の警告用トークン（`theme.palette.amber.*`）を流用する。
+ */
+export function getTruncatedInfoRowSx(theme: Theme) {
+  return {
+    paddingTop: '5px',
+    borderTop: `0.5px dashed ${theme.palette.amber.border}`,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '5px',
+    color: alpha(theme.palette.amber.text, 0.82),
+  } as const
+}
+
+export function getTruncatedInfoTextSx(theme: Theme) {
+  return {
+    fontFamily: FONT_CODE,
+    fontSize: scaledPx(theme.custom.fontSize.hint),
+  } as const
+}
+
 /** 右端のアクションアイコン（コピー/実行/チェック）ラッパー用スタイル */
 export function getActionIconBoxSx(
   theme: Theme,

--- a/src/components/molecules/commandFieldStyles.ts
+++ b/src/components/molecules/commandFieldStyles.ts
@@ -124,10 +124,11 @@ export function getTruncatedInfoRowSx(theme: Theme) {
   } as const
 }
 
+/** ハサミアイコン（9px）に合わせ、numberHint（9.5px）を使用する */
 export function getTruncatedInfoTextSx(theme: Theme) {
   return {
     fontFamily: FONT_CODE,
-    fontSize: scaledPx(theme.custom.fontSize.hint),
+    fontSize: scaledPx(theme.custom.fontSize.numberHint),
   } as const
 }
 

--- a/src/components/organisms/clipboard-history/ClipboardHistorySheet.tsx
+++ b/src/components/organisms/clipboard-history/ClipboardHistorySheet.tsx
@@ -78,6 +78,9 @@ export function ClipboardHistorySheet({
                 firstCopiedAt={item.first_copied_at}
                 lastCopiedAt={item.copied_at}
                 heatColor={heatBarColor}
+                truncated={item.truncated}
+                charCount={item.char_count}
+                originalCharCount={item.original_char_count ?? undefined}
               />
             ))}
           </Box>

--- a/src/types/api/ClipboardHistory.ts
+++ b/src/types/api/ClipboardHistory.ts
@@ -14,6 +14,8 @@ export type ClipboardHistoryItem = {
   copied_at: string
   copy_count: number
   first_copied_at: string
+  truncated: boolean
+  original_char_count: number | null
 }
 
 // 一覧取得時の上限件数。設定の「Max history entries」上限（1000）に合わせる。


### PR DESCRIPTION
## 概要

Preferences → Clipboard History の「Maximum characters to save」を超えて切り詰め保存されたクリップボード履歴エントリを、一覧画面で識別できるようにする。

Claude Design プロジェクトで検討された4案のうち「案D — メタ情報行」が採用され `RightCheat Mockup v19.html` に統合済みのデザインに準拠して実装した。

## 変更内容

### バックエンド
- `src-tauri/src/db/schema.rs`: `migrate_v5()` を追加。`clipboard_history` に `truncated INTEGER NOT NULL DEFAULT 0` / `original_char_count INTEGER`（NULL可）を追加（スキーマバージョン 4 → 5）
- `src-tauri/src/db/repository.rs`: `insert_clipboard_history` に `original_char_count: Option<i64>` 引数を追加。新規保存時のみ `truncated`/`original_char_count` を記録し、move-to-top 更新時は既存値を保持する
- `src-tauri/src/api/clipboard_monitor.rs`: `save_clipboard_text` で計算済みの切り詰め判定から `original_char_count` を組み立てて渡す
- `src-tauri/src/api/clipboard_history.rs`: `ClipboardHistoryItem` に新フィールドを追加。`record_clipboard_history_recopy`（履歴内での再コピー）は常に `None` を渡す

### フロントエンド
- `src/components/molecules/HistoryItemRow.tsx`: テキスト本文の下に、切り詰められたエントリのみメタ情報行（ハサミアイコン + 「保存文字数 / 元の文字数」）を常時表示する。コピー成功のチェックマーク表示中は非表示
- `src/components/atoms/icons/index.tsx`: `ScissorsIcon` を追加
- `src/components/molecules/commandFieldStyles.ts`: メタ情報行用のスタイルヘルパーを追加（既存の `theme.palette.amber.*` トークンを流用、直書き禁止ルール準拠）
- `src/types/api/ClipboardHistory.ts`, `ClipboardHistorySheet.tsx`: 新フィールドの型定義・配線

## 表示仕様

- 常時表示（ホバー不要）。切り詰めが発生していないエントリには何も表示しない
- 表示する「保存文字数」は現在の `max_chars` 設定値ではなく、実際にDBへ保存されている `char_count`（そのエントリが保存された時点での切り詰め後文字数）を使用。設定変更後も過去のエントリの表示が不正確にならないための設計判断

Closes #196

## Test plan

- [x] `cargo test --verbose -- --test-threads=1` — 全テストパス（402 + 14件）
- [x] `cargo fmt --check` / `yarn lint` / `yarn tsc --noEmit` — 全てクリーン
- [x] CI（GitHub Actions）の SUCCESS 確認