### PR TITLE
refactor: クリップボード設定Stepperの連打時に保存処理が毎回実行されるのをdebounceする

### DIFF
--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -573,24 +573,47 @@ export default function Page() {
     }, CLIPBOARD_SETTINGS_SAVE_DEBOUNCE_MS)
   }
 
-  // unmount 時（ウィンドウを閉じる操作を含む）に保留中の変更を保存する。
-  // コンポーネントは既に破棄されているため、失敗してもロールバック・ダイアログ表示は行わず
+  // 保留中の debounce タイマーをクリアし、未保存の最新値があれば保存を試みる。
+  // 呼び出し元は既に画面が閉じる途中のため、失敗してもロールバック・ダイアログ表示は行わず
   // ベストエフォートで保存のみ試みる。
+  const flushPendingClipboardSettingsOnExit = () => {
+    if (clipboardSaveTimerRef.current) {
+      clearTimeout(clipboardSaveTimerRef.current)
+      clipboardSaveTimerRef.current = null
+    }
+    const pending = pendingClipboardSettingsRef.current
+    if (pending === null) return Promise.resolve()
+    pendingClipboardSettingsRef.current = null
+    return saveClipboardSettingsNow(pending).catch((err) => {
+      error(`[preferences] Error flushing clipboard settings on exit: ${err}`)
+    })
+  }
+
+  // React の unmount（画面遷移等）時の保険。
   useEffect(() => {
     return () => {
-      if (clipboardSaveTimerRef.current) {
-        clearTimeout(clipboardSaveTimerRef.current)
-        clipboardSaveTimerRef.current = null
-      }
-      const pending = pendingClipboardSettingsRef.current
-      if (pending === null) return
-      pendingClipboardSettingsRef.current = null
-      saveClipboardSettingsNow(pending).catch((err) => {
-        error(
-          `[preferences] Error flushing clipboard settings on unmount: ${err}`,
-        )
-      })
+      void flushPendingClipboardSettingsOnExit()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // ウィンドウを閉じる操作（Esc 経由の `close()` 呼び出し・タイトルバーの閉じるボタン）は
+  // どちらも Tauri の closeRequested イベントを経由するため、実際の保存漏れ対策としては
+  // こちらが本命となる。React の unmount はプロセスごとクローズされる場合には発火しない
+  // ことがあるため、上記の unmount cleanup だけでは信頼できない。
+  useEffect(() => {
+    let unlisten: (() => void) | undefined
+    ;(async () => {
+      unlisten = await getCurrentWindow().onCloseRequested(async (event) => {
+        event.preventDefault()
+        await flushPendingClipboardSettingsOnExit()
+        await getCurrentWindow().destroy()
+      })
+    })()
+    return () => {
+      unlisten?.()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // 取得完了前（clipboardSettings === null）は対応するコントロールが

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -59,6 +59,10 @@ import { open as openOsDialog } from '@tauri-apps/plugin-dialog'
 import { debug, error } from '@tauri-apps/plugin-log'
 import { relaunch } from '@tauri-apps/plugin-process'
 
+// Stepper 連打・キーリピート時に SET_CLIPBOARD_SETTINGS の IPC / ディスク保存が
+// 毎回実行されるのを防ぐための debounce 間隔。
+const CLIPBOARD_SETTINGS_SAVE_DEBOUNCE_MS = 300
+
 type PrefSectionKey = 'clipboard' | 'shortcut' | 'ui' | 'other'
 
 const PREF_SECTIONS: { key: PrefSectionKey; label: string }[] = [
@@ -115,6 +119,16 @@ export default function Page() {
   // セクションはスケルトン表示とし、フロントエンドにデフォルト値を持たない。
   const [clipboardSettings, setClipboardSettingsState] =
     useState<ClipboardSettings | null>(null)
+
+  // SET_CLIPBOARD_SETTINGS の debounce 保存用。UI (clipboardSettings) は即時更新し、
+  // バックエンドへの保存のみを CLIPBOARD_SETTINGS_SAVE_DEBOUNCE_MS だけ遅延させる。
+  const clipboardSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+  // debounce 待機中の未保存の最新値。
+  const pendingClipboardSettingsRef = useRef<ClipboardSettings | null>(null)
+  // 直近に保存が成功した値。保存失敗時のロールバック先として使う。
+  const lastSavedClipboardSettingsRef = useRef<ClipboardSettings | null>(null)
 
   // ── RcDialog state ──────────────────────────────────────────
   const [rcDialog, setRcDialog] = useState<{
@@ -293,6 +307,7 @@ export default function Page() {
           `[preferences] invoke '${ClipboardSettingsAPI.GET_CLIPBOARD_SETTINGS}' response=${JSON.stringify(settings)}`,
         )
         setClipboardSettingsState(settings)
+        lastSavedClipboardSettingsRef.current = settings
       } catch (err) {
         error(`[preferences] Error getting clipboard settings: ${err}`)
         await showRcError(
@@ -517,27 +532,66 @@ export default function Page() {
     }
   }
 
-  // 即時保存・即時反映（Saveボタンや確認ダイアログは設けない）。
-  // 失敗時は変更前の値に戻す。
-  const applyClipboardSettings = async (next: ClipboardSettings) => {
-    const prev = clipboardSettings
-    setClipboardSettingsState(next)
+  // 実際に SET_CLIPBOARD_SETTINGS を呼び出す。状態の更新は行わず、呼び出し元が
+  // 成功時・失敗時の後処理を担う。
+  const saveClipboardSettingsNow = (settings: ClipboardSettings) =>
+    invoke(ClipboardSettingsAPI.SET_CLIPBOARD_SETTINGS, { settings })
+
+  // debounce 待機後に呼ばれ、保留中の最新値を実際に保存する。
+  // 失敗時は直近の保存成功値へロールバックし、エラーダイアログを表示する。
+  const flushClipboardSettings = async () => {
+    clipboardSaveTimerRef.current = null
+    const next = pendingClipboardSettingsRef.current
+    if (next === null) return
+    pendingClipboardSettingsRef.current = null
     try {
-      await invoke(ClipboardSettingsAPI.SET_CLIPBOARD_SETTINGS, {
-        settings: next,
-      })
+      await saveClipboardSettingsNow(next)
       debug(
         `[preferences] invoke '${ClipboardSettingsAPI.SET_CLIPBOARD_SETTINGS}' succeeded: ${JSON.stringify(next)}`,
       )
+      lastSavedClipboardSettingsRef.current = next
     } catch (err) {
       error(`[preferences] Error setting clipboard settings: ${err}`)
       await showRcError(
         'Preferences',
         'Failed to save clipboard history settings',
       )
-      setClipboardSettingsState(prev)
+      setClipboardSettingsState(lastSavedClipboardSettingsRef.current)
     }
   }
+
+  // UI (clipboardSettings) は即時更新して体感の応答性を維持しつつ、バックエンドへの
+  // 保存は debounce する。連続変更時は保留中のタイマーを差し替え、最新値のみ保存する。
+  const applyClipboardSettings = (next: ClipboardSettings) => {
+    setClipboardSettingsState(next)
+    pendingClipboardSettingsRef.current = next
+    if (clipboardSaveTimerRef.current) {
+      clearTimeout(clipboardSaveTimerRef.current)
+    }
+    clipboardSaveTimerRef.current = setTimeout(() => {
+      void flushClipboardSettings()
+    }, CLIPBOARD_SETTINGS_SAVE_DEBOUNCE_MS)
+  }
+
+  // unmount 時（ウィンドウを閉じる操作を含む）に保留中の変更を保存する。
+  // コンポーネントは既に破棄されているため、失敗してもロールバック・ダイアログ表示は行わず
+  // ベストエフォートで保存のみ試みる。
+  useEffect(() => {
+    return () => {
+      if (clipboardSaveTimerRef.current) {
+        clearTimeout(clipboardSaveTimerRef.current)
+        clipboardSaveTimerRef.current = null
+      }
+      const pending = pendingClipboardSettingsRef.current
+      if (pending === null) return
+      pendingClipboardSettingsRef.current = null
+      saveClipboardSettingsNow(pending).catch((err) => {
+        error(
+          `[preferences] Error flushing clipboard settings on unmount: ${err}`,
+        )
+      })
+    }
+  }, [])
 
   // 取得完了前（clipboardSettings === null）は対応するコントロールが
   // スケルトン表示で操作不能なため、これらのハンドラは実際には呼ばれない。


### PR DESCRIPTION
## 概要

Closes #190

Preferences 画面の Clipboard History セクション（PR #189）で、`StepperInput`（＋/− ボタン連打・↑/↓ キーの自動リピート）による値変更のたびに、以下の保存処理がフルで実行されていた問題を解消する。

1. `invoke(SET_CLIPBOARD_SETTINGS)`（IPC）
2. `tauri-plugin-store` によるディスクへの同期保存
3. `clipboard_settings_changed` イベントの emit

`max_items` は 10〜1000 の範囲があり、連打・キーリピートで大きく値を動かすと数百回の保存が発生し得た。

## 変更内容

`src/app/preferences/page.tsx` のみ変更。

- `applyClipboardSettings` を UI 状態の即時更新と、バックエンド保存（debounce対象）に分離
  - `clipboardSaveTimerRef`（`useRef` + `setTimeout` の自前実装、外部ライブラリ不使用）で保留中のタイマーを差し替えながら、連続変更時は最新値のみ 300ms 後に1回だけ保存する
  - `pendingClipboardSettingsRef`: debounce 待機中の未保存の最新値
  - `lastSavedClipboardSettingsRef`: 直近の保存成功値。保存失敗時のロールバック先として使用（従来の「失敗時に変更前の値へ戻す」挙動を維持）
- debounce 経過後に呼ばれる `flushClipboardSettings` で実際の保存を実行し、失敗時は `showRcError` によるエラーダイアログ表示＋ロールバックを行う
- Switch（monitoring / clear on quit）を含む全フィールドを同じ debounce 経路に統一した（実装をシンプルに保つため。連打の実害が小さい点は issue 本文の指摘通り）

### ウィンドウクローズ時の flush（レビュー対応で追加）

初回実装では React の `useEffect` unmount cleanup のみで保存漏れ対策をしていたが、ネイティブにウィンドウが閉じられて JS 実行コンテキストごと破棄される場合、React の unmount cleanup が発火しない可能性が高いという指摘をコードレビューで受けた。

- Esc キー（`useWindowCloseShortcuts` の `onCancel` → `getCurrentWindow().close()`）・タイトルバーの閉じるボタンは、いずれも Tauri の `closeRequested` イベントを経由する
- `getCurrentWindow().onCloseRequested()` でこのイベントを一旦 `preventDefault()` し、保留中の debounce 分を `flushPendingClipboardSettingsOnExit()` で flush してから `destroy()` で確実にウィンドウを閉じるようにした
- 必要な権限（`core:window:allow-close` / `core:window:allow-destroy` / `core:event:allow-listen`）は `src-tauri/capabilities/default.json` に既に含まれているため追加変更なし
- React の unmount cleanup（`useEffect` の return）も保険として残している

## テスト

- `yarn lint`（ESLint + Prettier）: 通過
- `npx tsc --noEmit`: エラーなし
- `yarn build`: 成功
- debounce ロジック（連打時に最新値のみ1回保存される）を Node スクリプトで抽出・シミュレーションし、想定通りの挙動を確認
- ブラウザ（Tauri なし環境）で `/preferences` を表示し、新規の実行時エラーが発生しないことを確認

**未検証事項**: `onCloseRequested` によるウィンドウクローズ時の実際の flush 動作は、ネイティブの Tauri アプリ（`yarn tauri dev`）でウィンドウを直接操作する必要があり、本セッションで利用可能なブラウザ自動化ツールでは検証できなかった。実装は Tauri 公式ドキュメントの `onCloseRequested` の用法（`preventDefault()` → 非同期処理 → `destroy()`）に忠実に従っている。マージ前に実機での動作確認（Stepper操作直後にウィンドウを閉じ、再度開いて値が保存されているか）を推奨する。

フロントエンドのみの変更のため `src-tauri/` の修正はなし。